### PR TITLE
CoverPage change for large numbers of messages

### DIFF
--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -93,6 +93,15 @@ function getMessageText(message, simple) {
     }
     return qsTr("Unsupported message: %1").arg(message.content['@type'].substring(7));
 }
+function getShortenedCount(count) {
+    if (count >= 1000000) {
+        return qsTr("%1M").arg((count / 1000000).toLocaleString(Qt.locale(), 'f', 0));
+    } else if (count >= 1000 ) {
+        return qsTr("%1K").arg((count / 1000).toLocaleString(Qt.locale(), 'f', 0));
+    } else {
+        return count;
+    }
+}
 
 function getDateTimeElapsed(timestamp) {
     return Format.formatDate(new Date(timestamp * 1000), Formatter.DurationElapsed);

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -41,16 +41,6 @@ Page {
     property variant chatGroupInformation;
     property int chatOnlineMemberCount: 0;
 
-    function getShortenedCount(count) {
-        if (count >= 1000000) {
-            return qsTr("%1M").arg((count / 1000000).toLocaleString(Qt.locale(), 'f', 0));
-        } else if (count >= 1000 ) {
-            return qsTr("%1K").arg((count / 1000).toLocaleString(Qt.locale(), 'f', 0));
-        } else {
-            return count;
-        }
-    }
-
     function updateChatPartnerStatusText() {
         if (chatPartnerInformation.status['@type'] === "userStatusEmpty" ) {
             chatStatusText.text = qsTr("was never online");
@@ -74,12 +64,12 @@ Page {
 
     function updateGroupStatusText() {
         if (chatOnlineMemberCount > 0) {
-            chatStatusText.text = qsTr("%1 members, %2 online").arg(getShortenedCount(chatGroupInformation.member_count)).arg(getShortenedCount(chatOnlineMemberCount));
+            chatStatusText.text = qsTr("%1 members, %2 online").arg(Functions.getShortenedCount(chatGroupInformation.member_count)).arg(Functions.getShortenedCount(chatOnlineMemberCount));
         } else {
             if (isChannel) {
-                chatStatusText.text = qsTr("%1 subscribers").arg(getShortenedCount(chatGroupInformation.member_count));
+                chatStatusText.text = qsTr("%1 subscribers").arg(Functions.getShortenedCount(chatGroupInformation.member_count));
             } else {
-                chatStatusText.text = qsTr("%1 members").arg(getShortenedCount(chatGroupInformation.member_count));
+                chatStatusText.text = qsTr("%1 members").arg(Functions.getShortenedCount(chatGroupInformation.member_count));
             }
         }
     }

--- a/qml/pages/CoverPage.qml
+++ b/qml/pages/CoverPage.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.5
 import Sailfish.Silica 1.0
 import WerkWolf.Fernschreiber 1.0
+import "../js/functions.js" as Functions
 
 CoverBackground {
 
@@ -118,7 +119,7 @@ CoverBackground {
                 id: unreadMessagesCountText
                 font.pixelSize: Theme.fontSizeHuge
                 color: Theme.primaryColor
-                text: coverPage.unreadMessages
+                text: Functions.getShortenedCount(coverPage.unreadMessages)
             }
             Text {
                 id: unreadMessagesText
@@ -147,13 +148,13 @@ CoverBackground {
                 id: unreadChatsCountText
                 font.pixelSize: Theme.fontSizeHuge
                 color: Theme.primaryColor
-                text: coverPage.unreadChats
+                text: Functions.getShortenedCount(coverPage.unreadChats)
             }
             Text {
                 id: unreadChatsText
                 font.pixelSize: Theme.fontSizeSmall
                 color: Theme.primaryColor
-                width: parent.width - unreadMessagesCountText.width - inText.width - ( 2 * Theme.paddingMedium )
+                width: parent.width - unreadChatsCountText.width - inText.width - ( 2 * Theme.paddingMedium )
                 wrapMode: Text.Wrap
                 anchors.verticalCenter: unreadChatsCountText.verticalCenter
             }


### PR DESCRIPTION
The CoverPage wasn't quite prepared for users residing in really spammy channels.

Changes:
 - As suggested, getShortenedCount was moved from ChatPage to functions.js and is now also used in the CoverPage
 - A small copy/paste error was fixed in the CoverPage

Before/after:
[<img src="https://i.imgur.com/YDn8WnW.png" width="250"/>](https://i.imgur.com/YDn8WnW.png)

As always, it's a pleasure to "work" with you,
cheers!

John