### PR TITLE
add pkgconfig build requirements to rpm meta data

### DIFF
--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -23,6 +23,8 @@ BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(nemonotifications-qt5)
+BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  desktop-file-utils
 
 %description

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -23,6 +23,8 @@ PkgConfigBR:
   - Qt5Core
   - Qt5Qml
   - Qt5Quick
+  - nemonotifications-qt5
+  - ngf-qt5
 
 # Build dependencies without a pkgconfig setup can be listed here
 # PkgBR:


### PR DESCRIPTION
This makes it a bit easier to get up and running on a fresh SDK. 
The tdlib thing is still a bit annoying because one has to figure out how to build that (or how to strip it out of the released rpm – yay, me!) and it's not fun preparing for different architectures.

cheers!

Edit: ctrl+enter submits the PR form, that's embarrasing. Text is now finished, sorry.