### PR TITLE
handle user registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const char TDLIB_API_HASH[] = "1234567890abcdef1234567890abcdef";
 
 You get the Telegram API ID and hash as soon as you've registered your own application on [https://my.telegram.org](https://my.telegram.org).
 
-Moreover, you need to have a compiled version of [TDLib](https://github.com/tdlib/td) in the sub-directory `tdlib`. This sub-directory must contain another sub-directory that fits to the target device architecture (e.g. armv7hl, i486). Within this directory, there needs to be a folder called `lib` that contains at least `libtdjson.so`. For armv7hl the relative path would consequently be `tdlib/armv7hl/lib`. Before compiling the project, be sure to set the target architecture in the project file `harbour-fernschreiber.pro` correctly using the variable `TARGET_ARCHITECTURE`. This can most certainly be automated. Pull requests welcome! ;)
+Moreover, you need to have a compiled version of [TDLib](https://github.com/tdlib/td) in the sub-directory `tdlib`. This sub-directory must contain another sub-directory that fits to the target device architecture (e.g. armv7hl, i486). Within this directory, there needs to be a folder called `lib` that contains at least `libtdjson.so`. For armv7hl the relative path would consequently be `tdlib/armv7hl/lib`.
 
 ## Credits
 This project uses

--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -57,8 +57,11 @@ TRANSLATIONS += translations/harbour-fernschreiber-de.ts \
                 translations/harbour-fernschreiber-pl.ts \
                 translations/harbour-fernschreiber-zh_CN.ts
 
-# Use armv7hl for most devices and i486 for emulator and Jolla Tablet. Can most certainly be automated... ;)
-TARGET_ARCHITECTURE = i486
+contains(QT_ARCH, arm) {
+    TARGET_ARCHITECTURE = armv7hl
+} else {
+    TARGET_ARCHITECTURE = i486
+}
 
 INCLUDEPATH += $$PWD/tdlib/include
 DEPENDPATH += $$PWD/tdlib/include

--- a/qml/pages/CoverPage.qml
+++ b/qml/pages/CoverPage.qml
@@ -65,7 +65,7 @@ CoverBackground {
     Component.onCompleted: {
         coverPage.authenticated = (tdLibWrapper.getAuthorizationState() === TelegramAPI.AuthorizationReady);
         coverPage.connectionState = tdLibWrapper.getConnectionState();
-        coverPage.unreadMessages = tdLibWrapper.getUnreadMessageInformation().unread_count;
+        coverPage.unreadMessages = tdLibWrapper.getUnreadMessageInformation().unread_count || 0;
         coverPage.unreadChats = tdLibWrapper.getUnreadChatInformation().unread_count;
         setUnreadInfoText();
     }

--- a/qml/pages/InitializationPage.qml
+++ b/qml/pages/InitializationPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.2
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import WerkWolf.Fernschreiber 1.0
 
@@ -27,6 +27,7 @@ Page {
 
     property bool loading: true
     property int authorizationState: TelegramAPI.Closed
+    property var authorizationStateData: null
 
     BusyLabel {
         text: qsTr("Loading...")
@@ -35,16 +36,33 @@ Page {
 
     Component.onCompleted: {
         initializationPage.authorizationState = tdLibWrapper.getAuthorizationState();
+        initializationPage.authorizationStateData = tdLibWrapper.getAuthorizationStateData();
         initializationPage.loading = false;
-        if (initializationPage.authorizationState === TelegramAPI.WaitCode) {
-            welcomeFlickable.visible = false;
+
+        switch (authorizationState) {
+        case TelegramAPI.WaitCode:
+            initializationPage.loading = false;
+            welcomeColumn.visible = false;
             enterPinColumn.visible = true;
             enterPasswordColumn.visible = false;
-        }
-        if (initializationPage.authorizationState === TelegramAPI.WaitPassword) {
-            welcomeFlickable.visible = false;
+            waitRegistrationColumn.visible = false;
+            break;
+        case TelegramAPI.WaitPassword:
+            initializationPage.loading = false;
+            welcomeColumn.visible = false;
             enterPinColumn.visible = false;
             enterPasswordColumn.visible = true;
+            waitRegistrationColumn.visible = false;
+            break;
+        case TelegramAPI.WaitRegistration:
+            initializationPage.loading = false;
+            welcomeColumn.visible = false;
+            enterPinColumn.visible = false;
+            enterPasswordColumn.visible = false;
+            waitRegistrationColumn.visible = true;
+            break;
+        default:
+            // Nothing ;)
         }
     }
 
@@ -56,11 +74,19 @@ Page {
                 initializationPage.loading = false;
                 enterPinColumn.visible = true;
                 enterPasswordColumn.visible = false;
+                waitRegistrationColumn.visible = false;
                 break;
             case TelegramAPI.WaitPassword:
                 initializationPage.loading = false;
                 enterPinColumn.visible = false;
                 enterPasswordColumn.visible = true;
+                waitRegistrationColumn.visible = false;
+                break;
+            case TelegramAPI.WaitRegistration:
+                initializationPage.loading = false;
+                enterPinColumn.visible = false;
+                enterPasswordColumn.visible = false;
+                waitRegistrationColumn.visible = true;
                 break;
             case TelegramAPI.AuthorizationReady:
                 initializationPage.loading = false;
@@ -70,214 +96,16 @@ Page {
             default:
                 // Nothing ;)
             }
+            initializationPage.authorizationStateData = authorizationStateData;
         }
     }
 
-    Column {
-        y: ( parent.height - ( errorInfoLabel.height + fernschreiberErrorImage.height + errorOkButton.height + ( 3 * Theme.paddingSmall ) ) ) / 2
-        width: parent.width
-        id: pinErrorColumn
-        spacing: Theme.paddingSmall
-
-        Behavior on opacity { NumberAnimation {} }
-        opacity: visible ? 1 : 0
-        visible: false
-
-        Image {
-            id: fernschreiberErrorImage
-            source: "../../images/fernschreiber.png"
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-
-            fillMode: Image.PreserveAspectFit
-            asynchronous: true
-            width: 1/2 * parent.width
-        }
-
-        InfoLabel {
-            id: errorInfoLabel
-            font.pixelSize: Theme.fontSizeLarge
-            text: ""
-        }
-
-        Button {
-            id: errorOkButton
-            text: qsTr("OK")
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-            onClicked: {
-                pinErrorColumn.visible = false;
-                welcomeFlickable.visible = true;
-            }
-        }
-    }
-
-    Column {
-        y: ( parent.height - ( fernschreiberPasswordImage.height + enterPasswordLabel.height + enterPasswordField.height + enterPasswordButton.height + ( 3 * Theme.paddingSmall ) ) ) / 2
-        width: parent.width
-        id: enterPasswordColumn
-        spacing: Theme.paddingSmall
-
-        Behavior on opacity { NumberAnimation {} }
-        opacity: visible ? true : false
-        visible: false
-
-        Image {
-            id: fernschreiberPasswordImage
-            source: "../../images/fernschreiber.png"
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-
-            fillMode: Image.PreserveAspectFit
-            asynchronous: true
-            width: 1/2 * parent.width
-        }
-
-        InfoLabel {
-            id: enterPasswordLabel
-            font.pixelSize: Theme.fontSizeLarge
-            text: qsTr("Please enter your password:")
-        }
-
-        PasswordField {
-            id: enterPasswordField
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-            font.pixelSize: Theme.fontSizeLarge
-            width: parent.width - 2 * Theme.horizontalPageMargin
-            horizontalAlignment: TextInput.AlignHCenter
-        }
-
-        Button {
-            id: enterPasswordButton
-            text: qsTr("OK")
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-            onClicked: {
-                initializationPage.loading = true;
-                enterPasswordColumn.visible = false;
-                tdLibWrapper.setAuthenticationPassword(enterPasswordField.text);
-            }
-        }
-    }
-
-    Column {
-        y: ( parent.height - ( fernschreiberPinImage.height + enterPinLabel.height + enterPinField.height + enterPinButton.height + ( 3 * Theme.paddingSmall ) ) ) / 2
-        width: parent.width
-        id: enterPinColumn
-        spacing: Theme.paddingSmall
-
-        Behavior on opacity { NumberAnimation {} }
-        opacity: visible ? true : false
-        visible: false
-
-        Image {
-            id: fernschreiberPinImage
-            source: "../../images/fernschreiber.png"
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-
-            fillMode: Image.PreserveAspectFit
-            asynchronous: true
-            width: 1/2 * parent.width
-        }
-
-        InfoLabel {
-            id: enterPinLabel
-            font.pixelSize: Theme.fontSizeLarge
-            text: qsTr("Please enter the code that you received:")
-        }
-
-        TextField {
-            id: enterPinField
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-            inputMethodHints: Qt.ImhDigitsOnly
-            font.pixelSize: Theme.fontSizeExtraLarge
-            width: parent.width - 4 * Theme.paddingLarge
-            horizontalAlignment: TextInput.AlignHCenter
-        }
-
-        Button {
-            id: enterPinButton
-            text: qsTr("OK")
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-            onClicked: {
-                initializationPage.loading = true;
-                enterPinColumn.visible = false;
-                tdLibWrapper.setAuthenticationCode(enterPinField.text);
-            }
-        }
-    }
-
-    Column {
-        y: ( parent.height - ( fernschreiberLinkingErrorImage.height + linkingErrorInfoLabel.height + errorOkButton.height + ( 3 * Theme.paddingSmall ) ) ) / 2
-        width: parent.width
-        id: linkingErrorColumn
-        spacing: Theme.paddingSmall
-
-        Behavior on opacity { NumberAnimation {} }
-        opacity: visible ? true : false
-        visible: false
-
-        Image {
-            id: fernschreiberLinkingErrorImage
-            source: "../../images/fernschreiber.png"
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-
-            fillMode: Image.PreserveAspectFit
-            asynchronous: true
-            width: 1/2 * parent.width
-        }
-
-        InfoLabel {
-            id: linkingErrorInfoLabel
-            font.pixelSize: Theme.fontSizeLarge
-            text: qsTr("Unable to authenticate you with the entered code.")
-        }
-
-        Button {
-            id: enterPinAgainButton
-            text: qsTr("Enter code again")
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-            onClicked: {
-                linkingErrorColumn.visible = false;
-                enterPinColumn.visible = true;
-            }
-        }
-
-        Button {
-            id: restartAuthenticationButton
-            text: qsTr("Restart authentication")
-            anchors {
-                horizontalCenter: parent.horizontalCenter
-            }
-            onClicked: {
-                linkingErrorColumn.visible = false;
-                welcomeFlickable.visible = true;
-            }
-        }
-    }
 
     SilicaFlickable {
         id: welcomeFlickable
-        contentHeight: welcomeColumn.height
-        Behavior on opacity { NumberAnimation {} }
+        contentHeight: contentItem.childrenRect.height
+        Behavior on contentHeight { NumberAnimation {} }
         anchors.fill: parent
-        opacity: visible ? 1 : 0
 
         Column {
             id: welcomeColumn
@@ -330,11 +158,339 @@ Page {
                 enabled: phoneNumberTextField.text.match(/\+[1-9][0-9]{4,}/g)
                 onClicked: {
                     initializationPage.loading = true;
-                    welcomeFlickable.visible = false;
+                    welcomeColumn.visible = false;
                     tdLibWrapper.setAuthenticationPhoneNumber(phoneNumberTextField.text);
                 }
             }
 
+        }
+
+        Column {
+            id: pinErrorColumn
+//            y: ( parent.height - ( errorInfoLabel.height + fernschreiberErrorImage.height + errorOkButton.height + ( 3 * Theme.paddingSmall ) ) ) / 2
+            width: parent.width
+            spacing: Theme.paddingSmall
+
+            Behavior on opacity { NumberAnimation {} }
+            opacity: visible ? 1 : 0
+            visible: false
+
+            Image {
+                id: fernschreiberErrorImage
+                source: "../../images/fernschreiber.png"
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+
+                fillMode: Image.PreserveAspectFit
+                asynchronous: true
+                width: 1/2 * parent.width
+            }
+
+            InfoLabel {
+                id: errorInfoLabel
+                font.pixelSize: Theme.fontSizeLarge
+                text: ""
+            }
+
+            Button {
+                id: errorOkButton
+                text: qsTr("OK")
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                onClicked: {
+                    pinErrorColumn.visible = false;
+                    welcomeColumn.visible = true;
+                }
+            }
+        }
+
+        Column {
+            id: enterPasswordColumn
+//            y: ( parent.height - ( fernschreiberPasswordImage.height + enterPasswordLabel.height + enterPasswordField.height + enterPasswordButton.height + ( 3 * Theme.paddingSmall ) ) ) / 2
+            width: parent.width
+            spacing: Theme.paddingSmall
+
+            Behavior on opacity { NumberAnimation {} }
+            opacity: visible ? 1.0 : 0.0
+            visible: false
+
+            Image {
+                id: fernschreiberPasswordImage
+                source: "../../images/fernschreiber.png"
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+
+                fillMode: Image.PreserveAspectFit
+                asynchronous: true
+                width: 1/2 * parent.width
+            }
+
+            InfoLabel {
+                id: enterPasswordLabel
+                font.pixelSize: Theme.fontSizeLarge
+                text: qsTr("Please enter your password:")
+            }
+
+            PasswordField {
+                id: enterPasswordField
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                font.pixelSize: Theme.fontSizeLarge
+                width: parent.width - 2 * Theme.horizontalPageMargin
+                horizontalAlignment: TextInput.AlignHCenter
+            }
+
+            Button {
+                id: enterPasswordButton
+                text: qsTr("OK")
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                onClicked: {
+                    initializationPage.loading = true;
+                    enterPasswordColumn.visible = false;
+                    tdLibWrapper.setAuthenticationPassword(enterPasswordField.text);
+                }
+            }
+        }
+
+        Column {
+            id: enterPinColumn
+            topPadding: Theme.paddingLarge
+            bottomPadding: Theme.paddingLarge
+            width: parent.width
+            spacing: Theme.paddingSmall
+
+            Behavior on opacity { NumberAnimation {} }
+            opacity: visible ? 1.0 : 0.0
+            visible: false
+
+
+            Image {
+                id: fernschreiberPinImage
+                source: "../../images/fernschreiber.png"
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+
+                fillMode: Image.PreserveAspectFit
+                asynchronous: true
+                width: 1/2 * parent.width
+            }
+
+            InfoLabel {
+                id: enterPinLabel
+                font.pixelSize: Theme.fontSizeLarge
+                text: qsTr("Please enter the code that you received:")
+            }
+
+            TextField {
+                id: enterPinField
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                inputMethodHints: Qt.ImhDigitsOnly
+                font.pixelSize: Theme.fontSizeExtraLarge
+                width: parent.width - 4 * Theme.paddingLarge
+                horizontalAlignment: TextInput.AlignHCenter
+            }
+
+            Button {
+                id: enterPinButton
+                text: qsTr("OK")
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                onClicked: {
+                    initializationPage.loading = true;
+                    enterPinColumn.visible = false;
+                    tdLibWrapper.setAuthenticationCode(enterPinField.text);
+                }
+            }
+        }
+
+        Column {
+            id: linkingErrorColumn
+            topPadding: Theme.paddingLarge
+            bottomPadding: Theme.paddingLarge
+            width: parent.width
+            spacing: Theme.paddingSmall
+
+            Behavior on opacity { NumberAnimation {} }
+            opacity: visible ? 1.0 : 0.0
+            visible: false
+
+            Image {
+                id: fernschreiberLinkingErrorImage
+                source: "../../images/fernschreiber.png"
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+
+                fillMode: Image.PreserveAspectFit
+                asynchronous: true
+                width: 1/2 * parent.width
+            }
+
+            InfoLabel {
+                id: linkingErrorInfoLabel
+                font.pixelSize: Theme.fontSizeLarge
+                text: qsTr("Unable to authenticate you with the entered code.")
+            }
+
+            Button {
+                id: enterPinAgainButton
+                text: qsTr("Enter code again")
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                onClicked: {
+                    linkingErrorColumn.visible = false;
+                    enterPinColumn.visible = true;
+                }
+            }
+
+            Button {
+                id: restartAuthenticationButton
+                text: qsTr("Restart authentication")
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                onClicked: {
+                    linkingErrorColumn.visible = false;
+                    welcomeColumn.visible = true;
+                }
+            }
+        }
+
+        Column {
+            id: waitRegistrationColumn
+            topPadding: Theme.paddingLarge
+            bottomPadding: Theme.paddingLarge
+            width: parent.width
+            spacing: Theme.paddingLarge
+
+            Behavior on opacity { NumberAnimation {} }
+            opacity: visible ? 1.0 : 0.0
+            visible: false
+
+            PageHeader {
+                title: qsTr("User Registration")
+            }
+            Image {
+                id: waitRegistrationImage
+                source: "../../images/fernschreiber.png"
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+
+                fillMode: Image.PreserveAspectFit
+                asynchronous: true
+                width:  1/2 * Screen.width
+            }
+
+            InfoLabel {
+                id: waitRegistrationInfoLabel
+                property bool acknowledged
+                font.pixelSize: Theme.fontSizeExtraSmall
+                textFormat: Text.StyledText
+                horizontalAlignment: Text.AlignLeft
+                linkColor: Theme.primaryColor
+                property var stateText: initializationPage.authorizationStateData.authorization_state && initializationPage.authorizationStateData.authorization_state.terms_of_service ?
+                                               initializationPage.authorizationStateData.authorization_state.terms_of_service.text :
+                                               null
+                visible: !!stateText && !acknowledged
+                text: {
+                    if(!stateText) {
+                        return '';
+                    }
+                    var entities = stateText.entities;
+                    if(entities && entities.length > 0 && entities[0]["type"]["@type"] === "textEntityTypeTextUrl") { //we just use the first entity for now.
+                        var offset = entities[0].offset;
+                        var length = entities[0].length;
+                        return (stateText.text.slice(0,entities[0].offset)
+                                + "<a href=\""+entities[0]["type"]["url"]+"\">"
+                                + stateText.text.slice(entities[0].offset, entities[0].offset + entities[0].length)
+                                + '</a>'
+                                + stateText.text.slice(entities[0].offset + entities[0].length)).replace(/\n/gm, "<br>");
+                    }
+                    return stateText.text.replace(/\n/gm, "<br>");
+
+
+                }
+                    //JSON.stringify(initializationPage.authorizationStateData, null, 2)//qsTr("Unable to authenticate you with the entered code.")
+            }
+
+            Button {
+                id: acknowledgeTOCButton
+                visible: waitRegistrationInfoLabel.visible
+                text: qsTr("OK")
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                onClicked: {
+                    waitRegistrationInfoLabel.acknowledged = true;
+                    userFirstNameTextField.focus = true
+                }
+            }
+            RegExpValidator {
+                id: filledValidator
+                regExp: /.+/
+            }
+            TextField {
+                id: userFirstNameTextField
+                visible: !waitRegistrationInfoLabel.visible
+                opacity: visible ? 1.0 : 0.0
+                Behavior on opacity { NumberAnimation {} }
+                placeholderText: qsTr("Enter your First Name")
+                labelVisible: false
+                width: parent.width
+                EnterKey.iconSource: !!text ? "image://theme/icon-m-enter-next" : "image://theme/icon-m-text-input"
+                EnterKey.onClicked: {
+                    validator = filledValidator
+                    if(acceptableInput) userLastNameTextField.focus = true;
+                }
+            }
+            TextField {
+                id: userLastNameTextField
+                visible: !waitRegistrationInfoLabel.visible
+                opacity: visible ? 1.0 : 0.0
+                Behavior on opacity { NumberAnimation {} }
+                placeholderText: qsTr("Enter your Last Name")
+                labelVisible: false
+                width: parent.width
+                EnterKey.iconSource: !!text ? "image://theme/icon-m-enter-accept" : "image://theme/icon-m-text-input"
+                EnterKey.onClicked: {
+                    validator = filledValidator
+                    if(acceptableInput) registerUserButton.onClicked(null);
+                }
+            }
+            Button {
+                id: registerUserButton
+                visible: !waitRegistrationInfoLabel.visible
+                opacity: visible ? 1.0 : 0.0
+                Behavior on opacity { NumberAnimation {} }
+                text: qsTr("Register User")
+                anchors {
+                    horizontalCenter: parent.horizontalCenter
+                }
+                onClicked: {
+                    userFirstNameTextField.validator = filledValidator
+                    userLastNameTextField.validator = filledValidator
+                    if(userFirstNameTextField.acceptableInput && userLastNameTextField.acceptableInput) {
+                        tdLibWrapper.registerUser(userFirstNameTextField.text, userLastNameTextField.text);
+                    } else if(!userFirstNameTextField.acceptableInput) {
+                        userFirstNameTextField.focus = true;
+                    } else {
+                        userLastNameTextField.focus = true;
+                    }
+
+                }
+            }
         }
     }
 

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -147,6 +147,12 @@ Page {
                 chatListCreatedTimer.start();
             }
         }
+        onChatsReceived: {
+            if(chats && chats.chat_ids && chats.chat_ids.length === 0) {
+                chatListCreatedTimer.stop();
+                chatListCreatedTimer.start();
+            }
+        }
     }
 
     Component.onCompleted: {
@@ -210,7 +216,6 @@ Page {
                     anchors.fill: parent
 
                     clip: true
-                    visible: count > 0
                     opacity: overviewPage.chatListCreated ? 1 : 0
                     Behavior on opacity { NumberAnimation {} }
 
@@ -417,6 +422,11 @@ Page {
                             horizontalAlignment: Qt.AlignHCenter
                         }
 
+                    }
+
+                    ViewPlaceholder {
+                        enabled: chatListView.count === 0
+                        text: qsTr("You don't have any chats yet.")
                     }
 
                     VerticalScrollDecorator {}

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -106,14 +106,9 @@ Page {
     function handleAuthorizationState() {
         switch (overviewPage.authorizationState) {
         case TelegramAPI.WaitPhoneNumber:
-            overviewPage.loading = false;
-            pageStack.push(Qt.resolvedUrl("../pages/InitializationPage.qml"));
-            break;
         case TelegramAPI.WaitCode:
-            overviewPage.loading = false;
-            pageStack.push(Qt.resolvedUrl("../pages/InitializationPage.qml"));
-            break;
         case TelegramAPI.WaitPassword:
+        case TelegramAPI.WaitRegistration:
             overviewPage.loading = false;
             pageStack.push(Qt.resolvedUrl("../pages/InitializationPage.qml"));
             break;

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -90,6 +90,7 @@ TDLibReceiver::TDLibReceiver(void *tdLibClient, QObject *parent) : QThread(paren
     handlers.insert("updateChatNotificationSettings", &TDLibReceiver::processUpdateChatNotificationSettings);
     handlers.insert("updateMessageContent", &TDLibReceiver::processUpdateMessageContent);
     handlers.insert("updateDeleteMessages", &TDLibReceiver::processUpdateDeleteMessages);
+    handlers.insert("chats", &TDLibReceiver::processChats);
 }
 
 void TDLibReceiver::setActive(const bool &active)
@@ -352,4 +353,9 @@ void TDLibReceiver::processUpdateDeleteMessages(const QVariantMap &receivedInfor
     QVariantList messageIds = receivedInformation.value("message_ids").toList();
     LOG("Some messages were deleted " << chatId);
     emit messagesDeleted(chatId, messageIds);
+}
+
+void TDLibReceiver::processChats(const QVariantMap &receivedInformation)
+{
+    emit chats(receivedInformation);
 }

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -148,7 +148,7 @@ void TDLibReceiver::processUpdateAuthorizationState(const QVariantMap &receivedI
 {
     QString authorizationState = receivedInformation.value("authorization_state").toMap().value("@type").toString();
     LOG("Authorization state changed: " << authorizationState);
-    emit authorizationStateChanged(authorizationState);
+    emit authorizationStateChanged(authorizationState, receivedInformation);
 }
 
 void TDLibReceiver::processUpdateConnectionState(const QVariantMap &receivedInformation)

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -37,7 +37,7 @@ public:
 
 signals:
     void versionDetected(const QString &version);
-    void authorizationStateChanged(const QString &authorizationState);
+    void authorizationStateChanged(const QString &authorizationState, const QVariantMap &authorizationStateData);
     void optionUpdated(const QString &optionName, const QVariant &optionValue);
     void connectionStateChanged(const QString &connectionState);
     void userUpdated(const QVariantMap &userInformation);

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -63,6 +63,7 @@ signals:
     void chatNotificationSettingsUpdated(const QString &chatId, const QVariantMap updatedChatNotificationSettings);
     void messageContentUpdated(const QString &chatId, const QString &messageId, const QVariantMap &newContent);
     void messagesDeleted(const QString &chatId, const QVariantList &messageIds);
+    void chats(const QVariantMap &chats);
 
 private:
     typedef void (TDLibReceiver::*Handler)(const QVariantMap &);
@@ -101,6 +102,7 @@ private:
     void processUpdateChatNotificationSettings(const QVariantMap &receivedInformation);
     void processUpdateMessageContent(const QVariantMap &receivedInformation);
     void processUpdateDeleteMessages(const QVariantMap &receivedInformation);
+    void processChats(const QVariantMap &receivedInformation);
 };
 
 #endif // TDLIBRECEIVER_H

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -46,7 +46,7 @@ TDLibWrapper::TDLibWrapper(QObject *parent) : QObject(parent), settings("harbour
     this->initializeOpenWith();
 
     connect(this->tdLibReceiver, SIGNAL(versionDetected(QString)), this, SLOT(handleVersionDetected(QString)));
-    connect(this->tdLibReceiver, SIGNAL(authorizationStateChanged(QString)), this, SLOT(handleAuthorizationStateChanged(QString)));
+    connect(this->tdLibReceiver, SIGNAL(authorizationStateChanged(QString, QVariantMap)), this, SLOT(handleAuthorizationStateChanged(QString, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(optionUpdated(QString, QVariant)), this, SLOT(handleOptionUpdated(QString, QVariant)));
     connect(this->tdLibReceiver, SIGNAL(connectionStateChanged(QString)), this, SLOT(handleConnectionStateChanged(QString)));
     connect(this->tdLibReceiver, SIGNAL(userUpdated(QVariantMap)), this, SLOT(handleUserUpdated(QVariantMap)));
@@ -107,6 +107,11 @@ TDLibWrapper::AuthorizationState TDLibWrapper::getAuthorizationState()
     return this->authorizationState;
 }
 
+QVariantMap TDLibWrapper::getAuthorizationStateData()
+{
+    return this->authorizationStateData;
+}
+
 TDLibWrapper::ConnectionState TDLibWrapper::getConnectionState()
 {
     return this->connectionState;
@@ -140,6 +145,16 @@ void TDLibWrapper::setAuthenticationPassword(const QString &authenticationPasswo
     QVariantMap requestObject;
     requestObject.insert("@type", "checkAuthenticationPassword");
     requestObject.insert("password", authenticationPassword);
+    this->sendRequest(requestObject);
+}
+
+void TDLibWrapper::registerUser(const QString &firstName, const QString &lastName)
+{
+    qDebug() << "[TDLibWrapper] Register User " << firstName << lastName;
+    QVariantMap requestObject;
+    requestObject.insert("@type", "registerUser");
+    requestObject.insert("first_name", firstName);
+    requestObject.insert("last_name", lastName);
     this->sendRequest(requestObject);
 }
 
@@ -487,7 +502,7 @@ void TDLibWrapper::handleVersionDetected(const QString &version)
     emit versionDetected(version);
 }
 
-void TDLibWrapper::handleAuthorizationStateChanged(const QString &authorizationState)
+void TDLibWrapper::handleAuthorizationStateChanged(const QString &authorizationState, const QVariantMap authorizationStateData)
 {
     if (authorizationState == "authorizationStateClosed") {
         this->authorizationState = AuthorizationState::Closed;
@@ -534,8 +549,8 @@ void TDLibWrapper::handleAuthorizationStateChanged(const QString &authorizationS
         this->setInitialParameters();
         this->authorizationState = AuthorizationState::WaitTdlibParameters;
     }
-
-    emit authorizationStateChanged(this->authorizationState);
+    this->authorizationStateData = authorizationStateData;
+    emit authorizationStateChanged(this->authorizationState, this->authorizationStateData);
 
 }
 

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -72,6 +72,7 @@ TDLibWrapper::TDLibWrapper(QObject *parent) : QObject(parent), settings("harbour
     connect(this->tdLibReceiver, SIGNAL(chatNotificationSettingsUpdated(QString, QVariantMap)), this, SLOT(handleChatNotificationSettingsUpdated(QString, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(messageContentUpdated(QString, QString, QVariantMap)), this, SLOT(handleMessageContentUpdated(QString, QString, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(messagesDeleted(QString, QVariantList)), this, SLOT(handleMessagesDeleted(QString, QVariantList)));
+    connect(this->tdLibReceiver, SIGNAL(chats(QVariantMap)), this, SLOT(handleChats(QVariantMap)));
 
     this->tdLibReceiver->start();
 
@@ -722,6 +723,11 @@ void TDLibWrapper::handleMessageContentUpdated(const QString &chatId, const QStr
 void TDLibWrapper::handleMessagesDeleted(const QString &chatId, const QVariantList &messageIds)
 {
     emit messagesDeleted(chatId, messageIds);
+}
+
+void TDLibWrapper::handleChats(const QVariantMap &chats)
+{
+    emit this->chatsReceived(chats);
 }
 
 void TDLibWrapper::setInitialParameters()

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -63,6 +63,7 @@ public:
 
     Q_INVOKABLE QString getVersion();
     Q_INVOKABLE TDLibWrapper::AuthorizationState getAuthorizationState();
+    Q_INVOKABLE QVariantMap getAuthorizationStateData();
     Q_INVOKABLE TDLibWrapper::ConnectionState getConnectionState();
     Q_INVOKABLE QVariantMap getUserInformation();
     Q_INVOKABLE QVariantMap getUserInformation(const QString &userId);
@@ -84,6 +85,7 @@ public:
     Q_INVOKABLE void setAuthenticationPhoneNumber(const QString &phoneNumber);
     Q_INVOKABLE void setAuthenticationCode(const QString &authenticationCode);
     Q_INVOKABLE void setAuthenticationPassword(const QString &authenticationPassword);
+    Q_INVOKABLE void registerUser(const QString &firstName, const QString &lastName);
     Q_INVOKABLE void getChats();
     Q_INVOKABLE void downloadFile(const QString &fileId);
     Q_INVOKABLE void openChat(const QString &chatId);
@@ -104,7 +106,7 @@ public:
 signals:
     void versionDetected(const QString &version);
     void ownUserIdFound(const QString &ownUserId);
-    void authorizationStateChanged(const TDLibWrapper::AuthorizationState &authorizationState);
+    void authorizationStateChanged(const TDLibWrapper::AuthorizationState &authorizationState, const QVariantMap &authorizationStateData);
     void optionUpdated(const QString &optionName, const QVariant &optionValue);
     void connectionStateChanged(const TDLibWrapper::ConnectionState &connectionState);
     void fileUpdated(const int fileId, const QVariantMap &fileInformation);
@@ -134,7 +136,7 @@ signals:
 
 public slots:
     void handleVersionDetected(const QString &version);
-    void handleAuthorizationStateChanged(const QString &authorizationState);
+    void handleAuthorizationStateChanged(const QString &authorizationState, const QVariantMap authorizationStateData);
     void handleOptionUpdated(const QString &optionName, const QVariant &optionValue);
     void handleConnectionStateChanged(const QString &connectionState);
     void handleUserUpdated(const QVariantMap &userInformation);
@@ -167,6 +169,7 @@ private:
     DBusInterface *dbusInterface;
     QString version;
     TDLibWrapper::AuthorizationState authorizationState;
+    QVariantMap authorizationStateData;
     TDLibWrapper::ConnectionState connectionState;
     QVariantMap options;
     QVariantMap userInformation;

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -133,6 +133,7 @@ signals:
     void chatNotificationSettingsUpdated(const QString &chatId, const QVariantMap chatNotificationSettings);
     void messageContentUpdated(const QString &chatId, const QString &messageId, const QVariantMap &newContent);
     void messagesDeleted(const QString &chatId, const QVariantList &messageIds);
+    void chatsReceived(const QVariantMap &chats);
 
 public slots:
     void handleVersionDetected(const QString &version);
@@ -162,6 +163,7 @@ public slots:
     void handleChatNotificationSettingsUpdated(const QString &chatId, const QVariantMap &chatNotificationSettings);
     void handleMessageContentUpdated(const QString &chatId, const QString &messageId, const QVariantMap &newContent);
     void handleMessagesDeleted(const QString &chatId, const QVariantList &messageIds);
+    void handleChats(const QVariantMap &chats);
 
 private:
     void *tdLibClient;

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -292,6 +292,22 @@
         <source>Please enter your password:</source>
         <translation>Bitte geben Sie Ihr Passwort ein:</translation>
     </message>
+    <message>
+        <source>Register User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your First Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your Last Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Registration</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -294,19 +294,19 @@
     </message>
     <message>
         <source>Register User</source>
-        <translation type="unfinished"></translation>
+        <translation>Registriere Benutzer</translation>
     </message>
     <message>
         <source>Enter your First Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitte geben Sie ihren Vornamen ein</translation>
     </message>
     <message>
         <source>Enter your Last Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Bitte geben Sie ihren Vornamen ein</translation>
     </message>
     <message>
         <source>User Registration</source>
-        <translation type="unfinished"></translation>
+        <translation>Benutzerregistrierung</translation>
     </message>
 </context>
 <context>
@@ -416,6 +416,10 @@
     <message>
         <source>Settings</source>
         <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <source>You don&apos;t have any chats yet.</source>
+        <translation>Sie haben noch keine Chats.</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -292,6 +292,22 @@
         <source>Please enter your password:</source>
         <translation>Por favor, introducir el código:</translation>
     </message>
+    <message>
+        <source>Register User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your First Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your Last Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Registration</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -417,6 +417,10 @@
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
+    <message>
+        <source>You don&apos;t have any chats yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -292,6 +292,22 @@
         <source>Please enter your password:</source>
         <translation>Kérlek add meg a jelszavad:</translation>
     </message>
+    <message>
+        <source>Register User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your First Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your Last Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Registration</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -417,6 +417,10 @@
         <source>Settings</source>
         <translation>Beállítások</translation>
     </message>
+    <message>
+        <source>You don&apos;t have any chats yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -417,6 +417,10 @@
         <source>Settings</source>
         <translation>Ustawienia</translation>
     </message>
+    <message>
+        <source>You don&apos;t have any chats yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -292,6 +292,22 @@
         <source>Please enter your password:</source>
         <translation>Wprowadź hasło:</translation>
     </message>
+    <message>
+        <source>Register User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your First Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your Last Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Registration</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -417,6 +417,10 @@
         <source>Settings</source>
         <translation>设置</translation>
     </message>
+    <message>
+        <source>You don&apos;t have any chats yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -292,6 +292,22 @@
         <source>Please enter your password:</source>
         <translation>请输入你的密码：</translation>
     </message>
+    <message>
+        <source>Register User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your First Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your Last Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Registration</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -292,6 +292,22 @@
         <source>Please enter your password:</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Register User</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your First Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your Last Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Registration</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -417,6 +417,10 @@
         <source>Settings</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>You don&apos;t have any chats yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>


### PR DESCRIPTION
First of all: 
Sorry, most parts from this one are a bit tricky to test. I've only been able to go through the sign up flow (once!), because I had a spare SIM laying around that never had anything to do with Telegram. Also, I apologize for including unrelated changes – those things bugged me a bit.

Relevant changes:
- WaitRegistration authorizationState is now handled. 
- If it is encountered, the user is asked to enter a first name and a last name. 
- If Telegram demands it, a server-supplied "terms of service" text with an "OK" Button is shown before that.
- When the authorization is done, there is a new check for an empty "chats", object. Previously, the other signals listened to were never emitted, so OverviewPage was stuck in Loading when there were no chats.
- If there are no Chats, a ViewPlaceholder is shown. Granted, there's not much else to do for the user after that.
- OverviewPage: All Columns now reside in the Flickable. Please check if the resulting layout changes are OK with you.

Unrelated changes (sorry):
- There was an error in CoverPage that annoyed me all the time, so I just put it in here, as well.
- After rebasing to your upstream, I found the architecture was changed to i486. Obviously I had to prevent an architecture ping pong from happening again. I did not have the chance to test the i486 build because I don't have TDlib for that yet. But it complains and fails, which is a good sign.

cheers,
John