### PR TITLE
Enable verbose output in TDLibReceiver if DEBUG is defined

### DIFF
--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -20,6 +20,12 @@
 
 #define LOG(x) qDebug() << "[TDLibReceiver]" << x
 
+#ifdef DEBUG
+#  define VERBOSE(x) LOG(x)
+#else
+#  define VERBOSE(x)
+#endif
+
 namespace {
     const QString ID("id");
     const QString LIST("list");
@@ -110,7 +116,7 @@ void TDLibReceiver::receiverLoop()
       const char *result = td_json_client_receive(this->tdLibClient, WAIT_TIMEOUT);
       if (result) {
           QJsonDocument receivedJsonDocument = QJsonDocument::fromJson(QByteArray(result));
-          // Too much information qDebug().noquote() << "[TDLibReceiver] Raw result: " << receivedJsonDocument.toJson(QJsonDocument::Indented);
+          VERBOSE("Raw result:" << receivedJsonDocument.toJson(QJsonDocument::Indented).constData());
           processReceivedDocument(receivedJsonDocument);
       }
     }


### PR DESCRIPTION
This should have no effect on release build but helps me with debugging.