### PR TITLE
OBS build requires qt5-qttools-linguist

### DIFF
--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -27,6 +27,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(nemonotifications-qt5)
 BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  desktop-file-utils
+BuildRequires:  qt5-qttools-linguist
 
 %description
 Fernschreiber is a Telegram client for Sailfish OS


### PR DESCRIPTION
Otherwise translations will be missing. That's not the only thing that breaks OBS build though (most important reasons - dependency on tdlib and tdlibsecrets.h) so it doesn't really matter... It's up to you. Those who want to do reproducible unattended builds would have to modify .spec file anyway, this would just reduce the amount of changes they have to make.