### PR TITLE
Moved app settings to a separate object

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -19,6 +19,7 @@ PKGCONFIG += nemonotifications-qt5 ngf-qt5
 QT += core dbus
 
 SOURCES += src/harbour-fernschreiber.cpp \
+    src/appsettings.cpp \
     src/chatlistmodel.cpp \
     src/chatmodel.cpp \
     src/dbusadaptor.cpp \
@@ -102,6 +103,7 @@ INSTALLS += telegram 86.png 108.png 128.png 172.png 256.png \
             fernschreiber.desktop gui images
 
 HEADERS += \
+    src/appsettings.h \
     src/chatlistmodel.h \
     src/chatmodel.h \
     src/dbusadaptor.h \

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1078,20 +1078,15 @@ Page {
                             }
                         }
                         EnterKey.onClicked: {
-                            if (tdLibWrapper.getSendByEnter()) {
+                            if (appSettings.sendByEnter) {
                                 sendMessage();
                                 newMessageTextField.text = "";
                                 newMessageTextField.focus = false;
                             }
                         }
 
-                        EnterKey.enabled: tdLibWrapper.getSendByEnter() ? text.length > 0 : true;
-
-                        Component.onCompleted: {
-                            if (tdLibWrapper.getSendByEnter()) {
-                                EnterKey.iconSource = "image://theme/icon-m-chat";
-                            }
-                        }
+                        EnterKey.enabled: !appSettings.sendByEnter || text.length
+                        EnterKey.iconSource: appSettings.sendByEnter ? "image://theme/icon-m-chat" : "image://theme/icon-m-enter"
 
                         onTextChanged: {
                             controlSendButton();

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -44,11 +44,12 @@ Page {
             }
 
             TextSwitch {
-                checked: tdLibWrapper.getSendByEnter()
+                checked: appSettings.sendByEnter
                 text: qsTr("Send message by enter")
                 description: qsTr("Send your message by pressing the enter key")
-                onCheckedChanged: {
-                    tdLibWrapper.setSendByEnter(checked);
+                automaticCheck: false
+                onClicked: {
+                    appSettings.sendByEnter = !checked
                 }
             }
 

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -1,0 +1,43 @@
+/*
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "appsettings.h"
+#include <QDebug>
+
+#define LOG(x) qDebug() << "[AppSettings]" << x
+
+namespace {
+    const QString KEY_SEND_BY_ENTER("sendByEnter");
+}
+
+AppSettings::AppSettings(QObject *parent) : QObject(parent), settings("harbour-fernschreiber", "settings")
+{
+}
+
+bool AppSettings::getSendByEnter() const
+{
+    return settings.value(KEY_SEND_BY_ENTER, false).toBool();
+}
+
+void AppSettings::setSendByEnter(bool sendByEnter)
+{
+    if (getSendByEnter() != sendByEnter) {
+        LOG(KEY_SEND_BY_ENTER << sendByEnter);
+        settings.setValue(KEY_SEND_BY_ENTER, sendByEnter);
+        emit sendByEnterChanged();
+    }
+}

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -1,0 +1,41 @@
+/*
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef APPSETTINGS_H
+#define APPSETTINGS_H
+
+#include <QObject>
+#include <QSettings>
+
+class AppSettings : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool sendByEnter READ getSendByEnter WRITE setSendByEnter NOTIFY sendByEnterChanged)
+
+public:
+    AppSettings(QObject *parent = Q_NULLPTR);
+
+    bool getSendByEnter() const;
+    void setSendByEnter(bool sendByEnter);
+
+signals:
+    void sendByEnterChanged();
+
+private:
+    QSettings settings;
+};
+
+#endif // APPSETTINGS_H

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -29,6 +29,7 @@
 #include <QQmlEngine>
 #include <QGuiApplication>
 
+#include "appsettings.h"
 #include "tdlibwrapper.h"
 #include "chatlistmodel.h"
 #include "chatmodel.h"
@@ -42,6 +43,9 @@ int main(int argc, char *argv[])
     QScopedPointer<QQuickView> view(SailfishApp::createView());
 
     QQmlContext *context = view.data()->rootContext();
+
+    AppSettings *appSettings = new AppSettings(view.data());
+    context->setContextProperty("appSettings", appSettings);
 
     TDLibWrapper *tdLibWrapper = new TDLibWrapper(view.data());
     context->setContextProperty("tdLibWrapper", tdLibWrapper);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -25,7 +25,8 @@
 #include <QLocale>
 #include <QProcess>
 #include <QSysInfo>
-#include <QSettings>
+#include <QDebug>
+#include <QJsonDocument>
 #include <QStandardPaths>
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -43,7 +44,7 @@ namespace {
     const QString _TYPE("@type");
 }
 
-TDLibWrapper::TDLibWrapper(QObject *parent) : QObject(parent), settings("harbour-fernschreiber", "settings")
+TDLibWrapper::TDLibWrapper(QObject *parent) : QObject(parent)
 {
     LOG("Initializing TD Lib...");
     this->tdLibClient = td_json_client_create();
@@ -527,16 +528,6 @@ void TDLibWrapper::controlScreenSaver(const bool &enabled)
         qDebug() << "Disabling screensaver";
         dbusInterface.call("req_display_blanking_pause");
     }
-}
-
-void TDLibWrapper::setSendByEnter(const bool &sendByEnter)
-{
-    settings.setValue("sendByEnter", sendByEnter);
-}
-
-bool TDLibWrapper::getSendByEnter()
-{
-    return settings.value("sendByEnter", false).toBool();
 }
 
 DBusAdaptor *TDLibWrapper::getDBusAdaptor()

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -20,11 +20,6 @@
 #define TDLIBWRAPPER_H
 
 #include <QCoreApplication>
-#include <QObject>
-#include <QDebug>
-#include <QJsonDocument>
-#include <QStandardPaths>
-#include <QSettings>
 #include <td/telegram/td_json_client.h>
 #include "tdlibreceiver.h"
 #include "dbusadaptor.h"
@@ -104,8 +99,6 @@ public:
     Q_INVOKABLE void copyFileToDownloads(const QString &filePath);
     Q_INVOKABLE void openFileOnDevice(const QString &filePath);
     Q_INVOKABLE void controlScreenSaver(const bool &enabled);
-    Q_INVOKABLE void setSendByEnter(const bool &sendByEnter);
-    Q_INVOKABLE bool getSendByEnter();
 
     DBusAdaptor *getDBusAdaptor();
 
@@ -231,7 +224,6 @@ private:
     QVariantMap unreadChatInformation;
     QHash<qlonglong,Group*> basicGroups;
     QHash<qlonglong,Group*> superGroups;
-    QSettings settings;
 };
 
 #endif // TDLIBWRAPPER_H


### PR DESCRIPTION
As more settings seem to be coming (https://github.com/Wunderfitz/harbour-fernschreiber/pull/54, https://github.com/Wunderfitz/harbour-fernschreiber/issues/23) I think it's a good idea to separate them into a separate object. `TDLibWrapper` is already pretty big and is going to grow even bigger.

This object exposes settings (well, currently just one) as properties as opposed to invokable getters/setters. Properties are good for bindings, automatic re-evaluation of expressions, their values get cached by QML runtime and they generally fit nicely into QML philosophy.

This change doesn't affect any functionality yet, it's just a groundwork for the upcoming changes.