### PR TITLE
Allow to delete messages from your own private chat

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -469,7 +469,7 @@ Page {
                                     deleteMessageRemorseItem.execute(messageListItem, qsTr("Deleting message"), function() { tdLibWrapper.deleteMessages(chatInformation.id, [ display.id ]); } );
                                 }
                                 text: qsTr("Delete Message")
-                                visible: display.can_be_deleted_for_all_users
+                                visible: display.can_be_deleted_for_all_users || (display.can_be_deleted_only_for_self && display.chat_id === chatPage.myUserId)
                             }
                         }
 


### PR DESCRIPTION
They have `"can_be_deleted_for_all_users": false` and yet you can delete those because you are the only one who has access to your own private chat.