### PR TITLE
Made "Stickers as images" feature optional

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -497,7 +497,6 @@ Page {
                             onTriggered: {
                                 webPagePreviewLoader.active = ( typeof display.content.web_page !== "undefined" );
                                 imagePreviewLoader.active = ( display.content['@type'] === "messagePhoto" );
-                                stickerPreviewLoader.active = ( display.content['@type'] === "messageSticker" );
                                 videoPreviewLoader.active = (( display.content['@type'] === "messageVideo" ) || ( display.content['@type'] === "messageAnimation" ));
                                 audioPreviewLoader.active = (( display.content['@type'] === "messageVoiceNote" ) || ( display.content['@type'] === "messageAudio" ));
                                 documentPreviewLoader.active = ( display.content['@type'] === "messageDocument" );
@@ -560,6 +559,7 @@ Page {
                                     color: index > ( chatView.count - chatInformation.unread_count - 1 ) ? Theme.secondaryHighlightColor : Theme.secondaryColor
                                     radius: parent.width / 50
                                     opacity: index > ( chatView.count - chatInformation.unread_count - 1 ) ? 0.5 : 0.2
+                                    visible: appSettings.showStickersAsImages || display.content['@type'] !== "messageSticker"
                                 }
 
                                 Column {
@@ -740,18 +740,16 @@ Page {
                                     Component {
                                         id: stickerPreviewComponent
                                         StickerPreview {
-                                            id: messageStickerPreview
                                             stickerData: ( display.content['@type'] === "messageSticker" ) ?  display.content.sticker : ""
-                                            visible: display.content['@type'] === "messageSticker"
-                                            anchors.horizontalCenter: parent.horizontalCenter
                                         }
                                     }
 
                                     Loader {
                                         id: stickerPreviewLoader
-                                        active: false
+                                        active: display.content['@type'] === "messageSticker"
                                         asynchronous: true
-                                        width: parent.width
+                                        x: (chatPage.myUserId === display.sender_user_id) ? (parent.width - width) : 0
+                                        width: (appSettings.showStickersAsImages || !item) ? parent.width : item.width
                                         sourceComponent: stickerPreviewComponent
                                     }
 

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -33,7 +33,6 @@ Page {
         Column {
             id: column
             width: settingsPage.width
-            spacing: Theme.paddingLarge
 
             PageHeader {
                 title: qsTr("Settings")
@@ -53,8 +52,22 @@ Page {
                 }
             }
 
-            VerticalScrollDecorator {}
+            SectionHeader {
+                text: qsTr("Appearance")
+            }
+
+            TextSwitch {
+                checked: appSettings.showStickersAsImages
+                text: qsTr("Show stickers as images")
+                description: qsTr("Show background for stickers and align them centrally like images")
+                automaticCheck: false
+                onClicked: {
+                    appSettings.showStickersAsImages = !checked
+                }
+            }
+
         }
 
+        VerticalScrollDecorator {}
     }
 }

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -22,6 +22,7 @@
 
 namespace {
     const QString KEY_SEND_BY_ENTER("sendByEnter");
+    const QString KEY_SHOW_STICKERS_AS_IMAGES("showStickersAsImages");
 }
 
 AppSettings::AppSettings(QObject *parent) : QObject(parent), settings("harbour-fernschreiber", "settings")
@@ -39,5 +40,19 @@ void AppSettings::setSendByEnter(bool sendByEnter)
         LOG(KEY_SEND_BY_ENTER << sendByEnter);
         settings.setValue(KEY_SEND_BY_ENTER, sendByEnter);
         emit sendByEnterChanged();
+    }
+}
+
+bool AppSettings::showStickersAsImages() const
+{
+    return settings.value(KEY_SHOW_STICKERS_AS_IMAGES, true).toBool();
+}
+
+void AppSettings::setShowStickersAsImages(bool showAsImages)
+{
+    if (showStickersAsImages() != showAsImages) {
+        LOG(KEY_SHOW_STICKERS_AS_IMAGES << showAsImages);
+        settings.setValue(KEY_SHOW_STICKERS_AS_IMAGES, showAsImages);
+        emit showStickersAsImagesChanged();
     }
 }

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -24,6 +24,7 @@
 class AppSettings : public QObject {
     Q_OBJECT
     Q_PROPERTY(bool sendByEnter READ getSendByEnter WRITE setSendByEnter NOTIFY sendByEnterChanged)
+    Q_PROPERTY(bool showStickersAsImages READ showStickersAsImages WRITE setShowStickersAsImages NOTIFY showStickersAsImagesChanged)
 
 public:
     AppSettings(QObject *parent = Q_NULLPTR);
@@ -31,8 +32,12 @@ public:
     bool getSendByEnter() const;
     void setSendByEnter(bool sendByEnter);
 
+    bool showStickersAsImages() const;
+    void setShowStickersAsImages(bool showAsImages);
+
 signals:
     void sendByEnterChanged();
+    void showStickersAsImagesChanged();
 
 private:
     QSettings settings;


### PR DESCRIPTION
Since you're saying that optimization efforts have to be consistently applied to the entire files or else they are not being accepted, I did my best to stop myself from doing any optimization this time. Expressions `display.content['@type'] === "messageSticker"`and `chatPage.myUserId === display.sender_user_id` are being (consistently!) evaluated as many times as possible.