### PR TITLE
Fix the app icon size on the About page in landscape

### DIFF
--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -51,8 +51,7 @@ Page {
 
                 fillMode: Image.PreserveAspectFit
                 asynchronous: true
-                width: aboutPage.isPortrait ? ( 1/2 * parent.width ) : ( 1/2 * parent.height )
-
+                width: (aboutPage.isPortrait ? aboutPage.width : aboutPage.height) / 2
             }
 
             Label {


### PR DESCRIPTION
It's ridiculously large (because its parent is the Column rather than Page)