### PR TITLE
Adjusted app icon size on the about page (again)

### DIFF
--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -51,7 +51,7 @@ Page {
 
                 fillMode: Image.PreserveAspectFit
                 asynchronous: true
-                width: (aboutPage.isPortrait ? aboutPage.width : aboutPage.height) / 2
+                width: Math.min(2 * Theme.itemSizeHuge, Math.min(aboutPage.width, aboutPage.height) / 2)
             }
 
             Label {


### PR DESCRIPTION
It was still too large on a 4:3 tablet screen in landscape, IMO.