### PR TITLE
Notification feedback control

### DIFF
--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -18,8 +18,8 @@
 */
 import QtQuick 2.0
 import Sailfish.Silica 1.0
+import WerkWolf.Fernschreiber 1.0
 import "../js/functions.js" as Functions
-
 
 Page {
     id: settingsPage
@@ -49,6 +49,57 @@ Page {
                 automaticCheck: false
                 onClicked: {
                     appSettings.sendByEnter = !checked
+                }
+            }
+
+            ComboBox {
+                id: feedbackComboBox
+                label: qsTr("Notification feedback")
+                description: qsTr("Non-graphical feedback adds vibration to visual notifications.")
+                menu: ContextMenu {
+                    id: feedbackMenu
+
+                    MenuItem {
+                        readonly property int value: AppSettings.NotificationFeedbackAll
+                        text: qsTr("All events")
+                        onClicked: {
+                            appSettings.notificationFeedback = value
+                        }
+                    }
+                    MenuItem {
+                        readonly property int value: AppSettings.NotificationFeedbackNew
+                        text: qsTr("Only new events")
+                        onClicked: {
+                            appSettings.notificationFeedback = value
+                        }
+                    }
+                    MenuItem {
+                        readonly property int value: AppSettings.NotificationFeedbackNone
+                        text: qsTr("None")
+                        onClicked: {
+                            appSettings.notificationFeedback = value
+                        }
+                    }
+                }
+
+                Component.onCompleted: updateFeedbackSelection()
+
+                function updateFeedbackSelection() {
+                    var menuItems = feedbackMenu.children
+                    var n = menuItems.length
+                    for (var i=0; i<n; i++) {
+                        if (menuItems[i].value === appSettings.notificationFeedback) {
+                            currentIndex = i
+                            return
+                        }
+                    }
+                }
+
+                Connections {
+                    target: appSettings
+                    onNotificationFeedbackChanged: {
+                        feedbackComboBox.updateFeedbackSelection()
+                    }
                 }
             }
 

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -23,6 +23,7 @@
 namespace {
     const QString KEY_SEND_BY_ENTER("sendByEnter");
     const QString KEY_SHOW_STICKERS_AS_IMAGES("showStickersAsImages");
+    const QString KEY_NOTIFICATION_FEEDBACK("notificationFeedback");
 }
 
 AppSettings::AppSettings(QObject *parent) : QObject(parent), settings("harbour-fernschreiber", "settings")
@@ -54,5 +55,19 @@ void AppSettings::setShowStickersAsImages(bool showAsImages)
         LOG(KEY_SHOW_STICKERS_AS_IMAGES << showAsImages);
         settings.setValue(KEY_SHOW_STICKERS_AS_IMAGES, showAsImages);
         emit showStickersAsImagesChanged();
+    }
+}
+
+AppSettings::NotificationFeedback AppSettings::notificationFeedback() const
+{
+    return (NotificationFeedback) settings.value(KEY_NOTIFICATION_FEEDBACK, (int) NotificationFeedbackAll).toInt();
+}
+
+void AppSettings::setNotificationFeedback(NotificationFeedback feedback)
+{
+    if (notificationFeedback() != feedback) {
+        LOG(KEY_NOTIFICATION_FEEDBACK << feedback);
+        settings.setValue(KEY_NOTIFICATION_FEEDBACK, (int) feedback);
+        emit notificationFeedbackChanged();
     }
 }

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -25,6 +25,15 @@ class AppSettings : public QObject {
     Q_OBJECT
     Q_PROPERTY(bool sendByEnter READ getSendByEnter WRITE setSendByEnter NOTIFY sendByEnterChanged)
     Q_PROPERTY(bool showStickersAsImages READ showStickersAsImages WRITE setShowStickersAsImages NOTIFY showStickersAsImagesChanged)
+    Q_PROPERTY(NotificationFeedback notificationFeedback READ notificationFeedback WRITE setNotificationFeedback NOTIFY notificationFeedbackChanged)
+
+public:
+    enum NotificationFeedback {
+        NotificationFeedbackNone,
+        NotificationFeedbackNew,
+        NotificationFeedbackAll
+    };
+    Q_ENUM(NotificationFeedback)
 
 public:
     AppSettings(QObject *parent = Q_NULLPTR);
@@ -35,9 +44,13 @@ public:
     bool showStickersAsImages() const;
     void setShowStickersAsImages(bool showAsImages);
 
+    NotificationFeedback notificationFeedback() const;
+    void setNotificationFeedback(NotificationFeedback feedback);
+
 signals:
     void sendByEnterChanged();
     void showStickersAsImagesChanged();
+    void notificationFeedbackChanged();
 
 private:
     QSettings settings;

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -47,10 +47,11 @@ int main(int argc, char *argv[])
 
     AppSettings *appSettings = new AppSettings(view.data());
     context->setContextProperty("appSettings", appSettings);
+    qmlRegisterUncreatableType<AppSettings>("WerkWolf.Fernschreiber", 1, 0, "AppSettings", QString());
 
     TDLibWrapper *tdLibWrapper = new TDLibWrapper(view.data());
     context->setContextProperty("tdLibWrapper", tdLibWrapper);
-    qmlRegisterType<TDLibWrapper>("WerkWolf.Fernschreiber", 1, 0, "TelegramAPI");
+    qmlRegisterUncreatableType<TDLibWrapper>("WerkWolf.Fernschreiber", 1, 0, "TelegramAPI", QString());
 
     DBusAdaptor *dBusAdaptor = tdLibWrapper->getDBusAdaptor();
     context->setContextProperty("dBusAdaptor", dBusAdaptor);
@@ -61,7 +62,7 @@ int main(int argc, char *argv[])
     ChatModel chatModel(tdLibWrapper);
     context->setContextProperty("chatModel", &chatModel);
 
-    NotificationManager notificationManager(tdLibWrapper);
+    NotificationManager notificationManager(tdLibWrapper, appSettings);
     context->setContextProperty("notificationManager", &notificationManager);
 
     ProcessLauncher processLauncher;

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -24,12 +24,13 @@
 #include <QDBusInterface>
 #include <ngf-qt5/NgfClient>
 #include "tdlibwrapper.h"
+#include "appsettings.h"
 
 class NotificationManager : public QObject
 {
     Q_OBJECT
 public:
-    NotificationManager(TDLibWrapper *tdLibWrapper);
+    NotificationManager(TDLibWrapper *tdLibWrapper, AppSettings *appSettings);
     ~NotificationManager() override;
 
 signals:
@@ -56,6 +57,7 @@ private:
 private:
 
     TDLibWrapper *tdLibWrapper;
+    AppSettings *appSettings;
     Ngf::Client *ngfClient;
     QVariantMap chatMap;
     QVariantMap notificationGroups;

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -21,7 +21,7 @@
 #define NOTIFICATIONMANAGER_H
 
 #include <QObject>
-#include <QMutex>
+#include <QDBusInterface>
 #include <ngf-qt5/NgfClient>
 #include "tdlibwrapper.h"
 
@@ -29,7 +29,7 @@ class NotificationManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit NotificationManager(TDLibWrapper *tdLibWrapper, QObject *parent = nullptr);
+    NotificationManager(TDLibWrapper *tdLibWrapper);
     ~NotificationManager() override;
 
 signals:
@@ -48,16 +48,18 @@ public slots:
 
 private:
 
-    TDLibWrapper *tdLibWrapper;
-    Ngf::Client *ngfClient;
-    QVariantMap chatMap;
-    QVariantMap notificationGroups;
-    QMutex chatListMutex;
-
     QVariantMap sendNotification(const QString &chatId, const QVariantMap &notificationInformation, const QVariantMap &activeNotifications);
     void removeNotification(const QVariantMap &notificationInformation);
     QString getNotificationText(const QVariantMap &notificationContent);
     void controlLedNotification(const bool &enabled);
+
+private:
+
+    TDLibWrapper *tdLibWrapper;
+    Ngf::Client *ngfClient;
+    QVariantMap chatMap;
+    QVariantMap notificationGroups;
+    QDBusInterface mceInterface;
 
 };
 


### PR DESCRIPTION
I find it pretty annoying to hear "bzzzz" every few seconds when a new message arrives to an active chat. Besides, running the vibra motor too often isn't good for battery life. This change introduces 3 options:

1. All events (default)
2. Only new events
3. No feedback at all

Notifications in the events view should still appear no matter what, it's only vibra and sounds that are controlled by this switch.