### PR TITLE
implement chat info page

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -34,13 +34,27 @@ SOURCES += src/harbour-fernschreiber.cpp \
 
 DISTFILES += qml/harbour-fernschreiber.qml \
     qml/components/AudioPreview.qml \
+    qml/components/ChatListViewItem.qml \
     qml/components/DocumentPreview.qml \
     qml/components/ImagePreview.qml \
     qml/components/InReplyToRow.qml \
     qml/components/LocationPreview.qml \
     qml/components/StickerPicker.qml \
+    qml/components/PhotoTextsListItem.qml \
     qml/components/WebPagePreview.qml \
+    qml/components/chatInformationPage/ChatInformationEditArea.qml \
+    qml/components/chatInformationPage/ChatInformationProfilePicture.qml \
+    qml/components/chatInformationPage/ChatInformationProfilePictureList.qml \
+    qml/components/chatInformationPage/ChatInformationTabItemBase.qml \
+    qml/components/chatInformationPage/ChatInformationTabItemDebug.qml \
+    qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml \
+    qml/components/chatInformationPage/ChatInformationTabItemSettings.qml \
+    qml/components/chatInformationPage/ChatInformationTabView.qml \
+    qml/components/chatInformationPage/ChatInformationTextItem.qml \
+    qml/components/chatInformationPage/EditGroupChatPermissionsColumn.qml \
+    qml/components/chatInformationPage/EditSuperGroupSlowModeColumn.qml \
     qml/js/functions.js \
+    qml/pages/ChatInformationPage.qml \
     qml/pages/ChatPage.qml \
     qml/pages/CoverPage.qml \
     qml/pages/InitializationPage.qml \

--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -1,0 +1,54 @@
+import QtQuick 2.5
+import Sailfish.Silica 1.0
+
+import "../js/twemoji.js" as Emoji
+import "../js/functions.js" as Functions
+
+PhotoTextsListItem {
+    id: listItem
+    pictureThumbnail {
+//        forceElementUpdate: overviewPage.chatListCreated
+        photoData: photo_small
+//                            replacementStringHint: primaryText.text
+    }
+    property int ownUserId
+
+    // chat title
+    primaryText.text: title ? Emoji.emojify(title, Theme.fontSizeMedium) + ( display.notification_settings.mute_for > 0 ? Emoji.emojify(" 🔇", Theme.fontSizeMedium) : "" ) : qsTr("Unknown")
+    // last user
+    prologSecondaryText.text: is_channel ? "" : ( last_message_sender_id ? ( last_message_sender_id !== ownUserId ? Emoji.emojify(Functions.getUserName(tdLibWrapper.getUserInformation(last_message_sender_id)), primaryText.font.pixelSize) : qsTr("You") ) : qsTr("Unknown") )
+    // last message
+    secondaryText.text: last_message_text ? Emoji.emojify(last_message_text, Theme.fontSizeExtraSmall) : qsTr("Unknown")
+    // message date
+    tertiaryText.text: last_message_date ? Functions.getDateTimeElapsed(last_message_date) : qsTr("Unknown")
+    unreadCount: unread_count
+
+    openMenuOnPressAndHold: true//chat_id != overviewPage.ownUserId
+    menu: ContextMenu {
+        MenuItem {
+            visible: chat_id != listItem.ownUserId
+            onClicked: {
+                var newNotificationSettings = display.notification_settings;
+                if (newNotificationSettings.mute_for > 0) {
+                    newNotificationSettings.mute_for = 0;
+                } else {
+                    newNotificationSettings.mute_for = 6666666;
+                }
+                tdLibWrapper.setChatNotificationSettings(chat_id, newNotificationSettings);
+            }
+            text: display.notification_settings.mute_for > 0 ? qsTr("Unmute Chat") : qsTr("Mute Chat")
+        }
+
+        MenuItem {
+            onClicked: {
+                if(pageStack.depth > 2) {
+                    pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
+                }
+
+                pageStack.push(Qt.resolvedUrl("../pages/ChatInformationPage.qml"), { "chatInformation" : display});
+            }
+            text: model.display.type['@type'] === "chatTypePrivate" ? qsTr("User Info") : qsTr("Group Info")
+        }
+    }
+
+}

--- a/qml/components/PhotoTextsListItem.qml
+++ b/qml/components/PhotoTextsListItem.qml
@@ -1,0 +1,153 @@
+import QtQuick 2.5
+import Sailfish.Silica 1.0
+ListItem {
+
+    id: chatListViewItem
+
+    property alias primaryText: primaryText //usually chat name
+    property alias prologSecondaryText: prologSecondaryText //usually last sender name
+    property alias secondaryText: secondaryText //usually last message
+    property alias tertiaryText: tertiaryText //usually last message date
+
+    property int unreadCount
+    property alias pictureThumbnail: pictureThumbnail
+
+    contentHeight: mainRow.height + separator.height + 2 * Theme.paddingMedium
+    contentWidth: parent.width
+
+
+
+    Column {
+        id: mainColumn
+        width: parent.width - ( 2 * Theme.horizontalPageMargin )
+        spacing: Theme.paddingSmall
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            verticalCenter: parent.verticalCenter
+        }
+
+        Row {
+            id: mainRow
+            width: parent.width
+            height: contentColumn.height
+            spacing: Theme.paddingMedium
+
+            Column {
+                id: pictureColumn
+                width: contentColumn.height - Theme.paddingSmall
+                height: contentColumn.height - Theme.paddingSmall
+                anchors.verticalCenter: parent.verticalCenter
+
+                Item {
+                    id: chatListPictureItem
+                    width: parent.width
+                    height: parent.width
+
+                    ProfileThumbnail {
+                        id: pictureThumbnail
+                        replacementStringHint: primaryText.text
+                        width: parent.width
+                        height: parent.width
+                    }
+
+                    Rectangle {
+                        id: chatUnreadMessagesCountBackground
+                        color: Theme.highlightBackgroundColor
+                        width: Theme.fontSizeLarge
+                        height: Theme.fontSizeLarge
+                        anchors.right: parent.right
+                        anchors.bottom: parent.bottom
+                        radius: parent.width / 2
+                        visible: chatListViewItem.unreadCount > 0
+                    }
+
+                    Text {
+                        id: chatUnreadMessagesCount
+                        font.pixelSize: Theme.fontSizeExtraSmall
+                        font.bold: true
+                        color: Theme.primaryColor
+                        anchors.centerIn: chatUnreadMessagesCountBackground
+                        visible: chatUnreadMessagesCountBackground.visible
+                        text: chatListViewItem.unreadCount > 99 ? "99+" : chatListViewItem.unreadCount
+                    }
+                }
+            }
+
+            Column {
+                id: contentColumn
+                width: parent.width * 5 / 6 - Theme.horizontalPageMargin
+                spacing: Theme.paddingSmall
+
+                Text {
+                    id: primaryText
+                    textFormat: Text.StyledText
+                    font.pixelSize: Theme.fontSizeMedium
+                    color: Theme.primaryColor
+                    elide: Text.ElideRight
+                    width: parent.width
+                    onTruncatedChanged: {
+                        // There is obviously a bug in QML in truncating text with images.
+                        // We simply remove Emojis then...
+                        if (truncated) {
+                            text = text.replace(/\<img [^>]+\/\>/g, "");
+                        }
+                    }
+                }
+
+                Row {
+                    id: additionalTextRow
+                    width: parent.width
+                    spacing: Theme.paddingSmall
+                    Text {
+                        id: prologSecondaryText
+                        font.pixelSize: Theme.fontSizeExtraSmall
+                        color: Theme.highlightColor
+                        textFormat: Text.StyledText
+                        onTruncatedChanged: {
+                            // There is obviously a bug in QML in truncating text with images.
+                            // We simply remove Emojis then...
+                            if (truncated) {
+                                text = text.replace(/\<img [^>]+\/\>/g, "");
+                            }
+                        }
+                    }
+                    Text {
+                        id: secondaryText
+                        font.pixelSize: Theme.fontSizeExtraSmall
+                        color: Theme.primaryColor
+                        width: parent.width - Theme.paddingMedium - prologSecondaryText.width
+                        elide: Text.ElideRight
+                        textFormat: Text.StyledText
+                        onTruncatedChanged: {
+                            // There is obviously a bug in QML in truncating text with images.
+                            // We simply remove Emojis then...
+                            if (truncated) {
+                                text = text.replace(/\<img [^>]+\/\>/g, "");
+                            }
+                        }
+                    }
+                }
+
+                Text {
+                    id: tertiaryText
+                    width: parent.width
+                    font.pixelSize: Theme.fontSizeTiny
+                    color: Theme.secondaryColor
+                }
+            }
+        }
+    }
+
+    Separator {
+        id: separator
+        anchors {
+            top: mainColumn.bottom
+            topMargin: Theme.paddingMedium
+        }
+
+        width: parent.width
+        color: Theme.primaryColor
+        horizontalAlignment: Qt.AlignHCenter
+    }
+
+}

--- a/qml/components/ProfileThumbnail.qml
+++ b/qml/components/ProfileThumbnail.qml
@@ -27,6 +27,8 @@ Item {
     property variant photoData;
     property string replacementStringHint: "X"
     property bool forceElementUpdate: false
+    property int radius: width / 2
+    property int imageStatus: -1
 
     function getReplacementString() {
         if (replacementStringHint.length > 2) {
@@ -109,6 +111,9 @@ Item {
                 autoTransform: true
                 asynchronous: true
                 visible: false
+                onStatusChanged: {
+                    profileThumbnail.imageStatus = status
+                }
             }
 
             Rectangle {
@@ -116,7 +121,7 @@ Item {
                 width: parent.width - Theme.paddingSmall
                 height: parent.height - Theme.paddingSmall
                 color: Theme.primaryColor
-                radius: parent.width / 2
+                radius: profileThumbnail.radius
                 anchors.centerIn: singleImage
                 visible: false
             }

--- a/qml/components/chatInformationPage/ChatInformationEditArea.qml
+++ b/qml/components/chatInformationPage/ChatInformationEditArea.qml
@@ -1,0 +1,102 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+Column {
+    id: editAreaColumn
+    visible: canEdit || text !== ""
+    property bool canEdit
+    property alias headerText: editAreaHeader.text
+    property string emptyPlaceholderText
+    property string text
+    property bool multiLine
+
+    property bool isEditing
+    property Item editItem: multiLine ? editAreaTextArea : editAreaTextField
+
+    signal saveButtonClicked(string textValue)
+    signal editButtonClicked()
+    signal textEdited(string textValue)
+    width: parent.width
+
+
+    SectionHeader {
+        id: editAreaHeader
+        font.pixelSize: Theme.fontSizeExtraSmall
+        height: parent.visible && text !== "" ? Theme.itemSizeExtraSmall : 0
+        x: 0
+    }
+    Row {
+        id: editAreaTextRow
+        width: parent.width
+
+        TextArea {
+            id: editAreaTextArea
+            visible: editAreaColumn.isEditing && editAreaColumn.multiLine
+            width: parent.width - editAreaButton.width
+            anchors.verticalCenter: parent.verticalCenter
+        }
+        TextField {
+            id: editAreaTextField
+            visible: editAreaColumn.isEditing && !editAreaColumn.multiLine
+            width: parent.width - editAreaButton.width
+            anchors.verticalCenter: parent.verticalCenter
+            EnterKey.onClicked: {
+                editAreaColumn.isEditing = false;
+                editAreaColumn.saveButtonClicked(editAreaColumn.editItem.text);
+            }
+            EnterKey.iconSource: editAreaButton.icon.source
+        }
+        ChatInformationTextItem {
+            id: editAreaTextItem
+            visible: !editAreaColumn.isEditing
+            anchors.verticalCenter: parent.verticalCenter
+            text: editAreaColumn.text || editAreaColumn.emptyPlaceholderText
+            width: parent.width - editAreaButton.width
+        }
+        IconButton {
+            id: editAreaButton
+            visible: editAreaColumn.canEdit
+            width: visible ? Theme.itemSizeSmall : 0
+            icon.source: editAreaColumn.isEditing ? "image://theme/icon-m-accept" : "image://theme/icon-m-edit"
+            anchors.verticalCenter: parent.verticalCenter
+            onClicked: {
+                if(editAreaColumn.isEditing) {
+                    editAreaColumn.isEditing = false;
+                    editAreaColumn.saveButtonClicked(editAreaColumn.editItem.text);
+                } else {
+                    editAreaColumn.isEditing = true;
+                    editAreaColumn.editItem.text = editAreaColumn.text;
+                    editAreaColumn.editItem.forceActiveFocus();
+                    editAreaColumn.editItem.cursorPosition = editAreaColumn.editItem.text.length;
+                    editAreaColumn.editButtonClicked();
+                }
+            }
+        }
+    }
+    Connections {
+        target: editItem
+        onTextChanged: {
+            if(editItem.focus) {
+                editAreaColumn.textEdited(editItem.text)
+            }
+        }
+    }
+}

--- a/qml/components/chatInformationPage/ChatInformationProfilePicture.qml
+++ b/qml/components/chatInformationPage/ChatInformationProfilePicture.qml
@@ -1,0 +1,44 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import "../"
+
+Item {
+    visible: imageContainer.tweenFactor > 0.8 && chatPictureDetail.imageStatus === Image.Ready
+    property bool isActive: imageContainer.tweenFactor === 1.0
+    opacity: isActive ? 1.0 : 0.0
+    Behavior on opacity { NumberAnimation {} }
+    ProfileThumbnail {
+        id: chatPictureDetail
+        anchors.fill: parent
+        photoData: (typeof chatInformation.photo !== "undefined") ? chatInformation.photo.big : ""
+        replacementStringHint: ""
+        radius: chatPictureThumbnail.radius
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: {
+            var preparedPhotoData = {sizes:[{width:640,height: 640,photo:chatPictureDetail.photoData}]};
+            pageStack.push(Qt.resolvedUrl("../../pages/ImagePage.qml"), { "photoData" : preparedPhotoData });
+        }
+    }
+}

--- a/qml/components/chatInformationPage/ChatInformationProfilePictureList.qml
+++ b/qml/components/chatInformationPage/ChatInformationProfilePictureList.qml
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import "../"
+
+Item {
+    visible: imageContainer.tweenFactor > 0.8 && bigProfilePictureList.count > 0
+    property bool isActive: imageContainer.tweenFactor === 1.0
+
+    opacity: isActive ? 1.0 : 0.0
+    Behavior on opacity { NumberAnimation {} }
+
+    SlideshowView {
+        id: bigProfilePictureList
+        property bool isActive: imageContainer.tweenFactor === 1.0
+        width: parent.width
+        height: parent.height
+        clip: true
+        itemWidth: width
+        itemHeight: height
+        interactive: parent.isActive
+        model: chatInformationPage.chatPartnerProfilePhotos
+        delegate: Item {
+            width: bigProfilePictureList.itemWidth
+            height: bigProfilePictureList.itemHeight
+            ProfileThumbnail {
+                id: chatPictureDetail
+                photoData: modelData.sizes[modelData.sizes.length - 1].photo
+                replacementStringHint: ""
+                radius: chatPictureThumbnail.radius
+                anchors.fill: parent
+            }
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    pageStack.push(Qt.resolvedUrl("../../pages/ImagePage.qml"), { "photoData" : modelData });
+                }
+            }
+        }
+    }
+
+    Text {
+        visible: bigProfilePictureList.count > 1
+        width: parent.width
+        anchors {
+            bottomMargin: Theme.paddingSmall
+            bottom: parent.bottom
+        }
+        horizontalAlignment: Text.AlignHCenter
+        property var baseString: new Array(bigProfilePictureList.count+1).join(" ○ ")
+        text: baseString.substring(0,bigProfilePictureList.currentIndex*3) + " ● " + baseString.substring((bigProfilePictureList.currentIndex+1)*3)
+        color: Theme.primaryColor
+        style: Text.Raised
+        styleColor: Theme.highlightDimmerColor
+    }
+}

--- a/qml/components/chatInformationPage/ChatInformationTabItemBase.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemBase.qml
@@ -1,0 +1,74 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import "../../pages"
+import "../"
+
+Item {
+    id: tabItem
+    property string title
+    property url image
+    property bool loading
+    //overrideable:
+    property alias loadingVisible: loadingColumn.loadingVisible
+    property string loadingText
+
+    property int tabIndex: tabItem.VisualItemModel.index
+    property bool active: tabItem.ListView.isCurrentItem
+
+    default property alias _data: contentItem.data
+
+
+    width: parent.width
+    height: tabView.maxHeight//Math.max(contentItem.height, loadingColumn.height)
+    opacity: active ? 1.0 : 0.0
+    Behavior on opacity { PropertyAnimation {duration: 300}}
+
+    Column {
+        id: loadingColumn
+        property bool loadingVisible: tabItem.loading
+        width: tabItem.width
+        height: loadingLabel.height + loadingBusyIndicator.height + Theme.paddingMedium
+        spacing: Theme.paddingMedium
+        topPadding: Theme.paddingLarge
+        anchors.top: parent.top
+        opacity: loadingVisible ? 1.0 : 0.0
+        Behavior on opacity { NumberAnimation {} }
+        visible: tabItem.loading
+
+        InfoLabel {
+            id: loadingLabel
+            text: tabItem.loadingText
+        }
+
+        BusyIndicator {
+            id: loadingBusyIndicator
+            anchors.horizontalCenter: parent.horizontalCenter
+            running: parent.loadingVisible
+            size: BusyIndicatorSize.Large
+        }
+    }
+    Item {
+        id: contentItem
+        width: parent.width
+        height: childrenRect.height
+    }
+
+}

--- a/qml/components/chatInformationPage/ChatInformationTabItemDebug.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemDebug.qml
@@ -1,0 +1,59 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import QtQml.Models 2.3
+
+import "../"
+import "../../pages"
+import "../../js/twemoji.js" as Emoji
+import "../../js/functions.js" as Functions
+
+ChatInformationTabItemBase {
+    id: tabBase
+    title: "debug"
+    image: "image://theme/icon-m-diagnostic"
+    SilicaFlickable {
+        height: tabBase.height
+        width: tabBase.width
+        contentHeight: contentColumn.height
+        Column {
+            id: contentColumn
+            width: tabBase.width - Theme.horizontalPageMargin * 2
+            x: Theme.horizontalPageMargin
+
+            ChatInformationTextItem {
+                headerText: "chatInformation"
+                text:chatInformationPage.chatInformation ?  JSON.stringify(chatInformationPage.chatInformation, null, 2) : ""
+                isLinkedLabel: true
+            }
+            ChatInformationTextItem {
+                headerText: "groupInformation"
+                text: chatInformationPage.groupInformation ? JSON.stringify(chatInformationPage.groupInformation, null, 2) : ""
+                isLinkedLabel: true
+            }
+
+            ChatInformationTextItem {
+                headerText: "groupFullInformation"
+                text: chatInformationPage.groupFullInformation ? JSON.stringify(chatInformationPage.groupFullInformation, null, 2) : ""
+                isLinkedLabel: true
+            }
+        }
+    }
+}

--- a/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
@@ -1,0 +1,231 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import QtQml.Models 2.3
+
+import "../"
+import "../../pages"
+import "../../js/twemoji.js" as Emoji
+import "../../js/functions.js" as Functions
+
+ChatInformationTabItemBase {
+    id: tabBase
+    title: chatInformationPage.isPrivateChat ? qsTr("Groups", "Button: groups in common (short)") : qsTr("Members", "Button: Group Members")
+    image: "image://theme/icon-m-people"
+    loadingText:  isPrivateChat ? qsTr("Loading common chats…", "chats you have in common with a user") : qsTr("Loading group members…")
+    loading: chatInformationPage.isSuperGroup || chatInformationPage.isPrivateChat
+    loadingVisible: loading && membersView.count === 0
+
+    property variant chatPartnerCommonGroupsIds: ([]);
+
+
+    SilicaListView {
+        id: membersView
+        model: isPrivateChat ? delegateModel : chatInformationPage.membersList
+        clip: true
+        height: tabBase.height
+        width: tabBase.width
+        opacity: tabBase.loading ? (count > 0 ? 0.5 : 0.0) : 1.0
+        Behavior on opacity { NumberAnimation {} }
+        function handleScrollIntoView(force){
+            if(!tabBase.loading && !dragging && !quickScrollAnimating ) {
+                if(!atYBeginning) {
+                    chatInformationPage.scrollDown()
+                } else {
+                    chatInformationPage.scrollUp(force);
+                }
+            }
+        }
+        onDraggingChanged: {
+            handleScrollIntoView()
+        }
+        onAtYBeginningChanged: {
+            handleScrollIntoView()
+        }
+        onAtYEndChanged: {
+            if(tabBase.active && !tabBase.loading && chatInformationPage.isSuperGroup && (groupInformation.member_count > membersView.count) && membersView.atYEnd) {
+                tabBase.loading = true;
+                fetchMoreMembersTimer.start()
+            }
+        }
+        onQuickScrollAnimatingChanged: {
+            handleScrollIntoView(true)
+        }
+
+        delegate: PhotoTextsListItem {
+            pictureThumbnail {
+                photoData: (typeof user.profile_photo !== "undefined") ? user.profile_photo.small : ""
+            }
+            width: parent.width
+
+            // chat title    isPrivateChat ? () :
+            primaryText.text: Emoji.emojify(Functions.getUserName(user), primaryText.font.pixelSize)
+            // last user
+            prologSecondaryText.text: "@"+(user.username !== "" ? user.username : user_id) + (user_id === chatInformationPage.myUserId ? " " + qsTr("You") : "")
+            secondaryText {
+                horizontalAlignment: Text.AlignRight
+                property string statusText: Functions.getChatMemberStatusText(model.status["@type"])
+                property string customText: model.status.custom_title ? Emoji.emojify(model.status.custom_title, secondaryText.font.pixelSize) : ""
+                text: (statusText !== "" && customText !== "") ? statusText + ", " + customText : statusText + customText
+            }
+            tertiaryText {
+                maximumLineCount: 1
+                text: user.type["@type"] === "userTypeBot" ? (Emoji.emojify("🤖 "+bot_info.description, tertiaryText.font.pixelSize)) : Functions.getChatPartnerStatusText(user.status["@type"], user.status.was_online);
+                elide: Text.ElideRight
+            }
+
+            onClicked: {
+                tdLibWrapper.createPrivateChat(user_id);
+            }
+        }
+        footer: Component {
+            Item {
+                property bool active: tabBase.active && chatInformationPage.isSuperGroup && (groupInformation.member_count > membersView.count)
+                width: tabBase.width
+                height: active ? Theme.itemSizeLarge : Theme.paddingMedium
+
+                BusyIndicator {
+                    id: loadMoreIndicator
+                    anchors.centerIn: parent
+                    size: BusyIndicatorSize.Small
+                    running: parent.active
+                }
+            }
+        }
+
+        VerticalScrollDecorator {}
+    }
+
+
+    DelegateModel {
+        id: delegateModel
+        model: chatListModel
+        groups: [
+            DelegateModelGroup {
+                name: "filterGroup"; includeByDefault: true
+            }
+        ]
+        filterOnGroup: "filterGroup"
+        function hasMatch(searchInArray) {
+            for (var i = 0; i < searchInArray.length; i++) {
+                if(searchInArray[i].toLowerCase().indexOf(chatInformationPage.searchString) > -1) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        function applyFilter(){
+            var numberOfEntries = chatListModel.rowCount();
+            var hasFilterString = !!chatInformationPage.searchString && chatInformationPage.searchString !== ""
+            for (var i = 0; i < numberOfEntries; i++){
+                var metadata = chatListModel.get(i);
+                if(tabBase.chatPartnerCommonGroupsIds.indexOf(metadata.chat_id) > -1) {
+                    items.addGroups(i, 1, "filterGroup");
+                } else {
+                    items.removeGroups(i, 1, "filterGroup");
+                }
+
+            }
+        }
+
+        delegate: ChatListViewItem {
+            ownUserId: chatInformationPage.myUserId
+
+            unreadCount: unread_count
+            onClicked: {
+                pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
+                pageStack.push(Qt.resolvedUrl("../../pages/ChatPage.qml"), { "chatInformation" : display });
+            }
+            Connections {
+                target: chatListModel
+                onChatChanged: {
+                    if (changedChatId === chat_id) {
+                        // Force update of some list item elements (currently only last message text seems to create problems). dataChanged() doesn't seem to trigger them all :(
+                        secondaryText.text = last_message_text ? Emoji.emojify(last_message_text, Theme.fontSizeExtraSmall) : qsTr("Unknown")
+                    }
+                }
+            }
+        }
+    }
+
+    Timer {
+        id: fetchMoreMembersTimer
+        interval: 600
+        property int fetchLimit: 50
+        onTriggered: {
+            if(isSuperGroup) {
+                tabBase.loading = true
+                tdLibWrapper.getSupergroupMembers(chatInformationPage.chatPartnerGroupId, fetchLimit, membersList.count);
+                fetchLimit = 200
+                interval = 400
+            }
+        }
+    }
+
+    Connections {
+        target: tdLibWrapper
+
+        onChatMembersReceived: {
+            if (isSuperGroup && chatInformationPage.chatPartnerGroupId === extra) {
+                if(members && members.length > 0) {
+                    for(var memberIndex in members) {
+                        var memberData = members[memberIndex];
+                        var userInfo = tdLibWrapper.getUserInformation(memberData.user_id) || {user:{}, bot_info:{}};
+                        memberData.user = userInfo;
+                        memberData.bot_info = memberData.bot_info || {};
+                        membersList.append(memberData);
+                    }
+                    groupInformation.member_count = totalMembers
+                    updateGroupStatusText();
+                    if(membersList.count < totalMembers) {
+//                        fetchMoreMembersTimer.start()
+                    }
+                }
+                // if we set it directly, the views start scrolling
+                loadedTimer.start();
+            }
+        }
+        onChatsReceived: {// common chats with user
+            if(isPrivateChat && chats["@extra"] === chatInformationPage.chatPartnerGroupId) {
+                tabBase.chatPartnerCommonGroupsIds = chats.chat_ids;
+                delegateModel.applyFilter();
+                // if we set it directly, the views start scrolling
+                loadedTimer.start();
+            }
+        }
+    }
+    Timer {
+        id: loadedTimer
+        interval: 50
+        onTriggered: {
+            tabBase.loading = false
+        }
+    }
+
+    Component.onCompleted: {
+        if(isPrivateChat) {
+            tdLibWrapper.getGroupsInCommon(chatInformationPage.chatPartnerGroupId, 200, 0); // we only use the first 200
+        } else if(isSuperGroup) {
+            fetchMoreMembersTimer.start();
+        }
+    }
+
+}

--- a/qml/components/chatInformationPage/ChatInformationTabItemSettings.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemSettings.qml
@@ -1,0 +1,70 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import QtQml.Models 2.3
+
+import "../"
+import "../../pages"
+import "../../js/twemoji.js" as Emoji
+import "../../js/functions.js" as Functions
+
+ChatInformationTabItemBase {
+    id: tabBase
+    title: qsTr("Settings", "Button: Chat Settings")
+    image: "image://theme/icon-m-developer-mode"
+
+    SilicaFlickable {
+        height: tabBase.height
+        width: tabBase.width
+        contentHeight: contentColumn.height
+        Column {
+            id: contentColumn
+            width: tabBase.width
+
+            //permissions
+
+            // if chatInformationPage.chatInformation.permissions.can_change_info
+            //  - upload/change chat photo/VIDEO (hahaha)
+            //  - description change
+            //  - toggleSupergroupIsAllHistoryAvailable
+            // if ?????? can_promote_members ???? can_restrict_members
+            // - setChatMemberStatus
+            // if creator (BasicGroup)
+            // - upgradeBasicGroupChatToSupergroupChat
+            // if creator (supergroup/channel)
+            // - canTransferOwnership?
+            //   - transferChatOwnership
+            Loader {
+                active: (chatInformationPage.isBasicGroup || chatInformationPage.isSuperGroup) && chatInformationPage.groupInformation &&  (chatInformationPage.groupInformation.status.can_restrict_members || chatInformationPage.groupInformation.status.can_change_info || chatInformationPage.groupInformation.status["@type"] === "chatMemberStatusCreator")
+                asynchronous: true
+                source: "./EditGroupChatPermissionsColumn.qml"
+                width: parent.width
+            }
+
+            Loader {
+                active: chatInformationPage.isSuperGroup && chatInformationPage.groupInformation &&  chatInformationPage.groupInformation.status.can_restrict_members || chatInformationPage.groupInformation.status["@type"] === "chatMemberStatusCreator"
+                asynchronous: true
+                source: "./EditSuperGroupSlowModeColumn.qml"
+                width: parent.width
+            }
+
+        }
+    }
+}

--- a/qml/components/chatInformationPage/ChatInformationTabView.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabView.qml
@@ -1,0 +1,169 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+import "./"
+import "../"
+import "../../pages"
+
+Item {
+    id: tabViewItem
+    property alias count: tabView.count
+    height: Screen.width
+    opacity: count > 0 ? 1.0 : 0.0
+    Behavior on height { PropertyAnimation {duration: 300}}
+    Behavior on opacity { PropertyAnimation {duration: 300}}
+
+    Item {
+        id: tabViewHeader
+        /*
+         * Tab view is prepared, but "disabled" for now
+         * to view shared media/links/…,
+         * we need message search with filters
+         */
+
+        // START: change this to enable
+        height: visible ? headerGrid.height : 0
+//        height: 0
+        clip: true
+        visible: tabView.count > 1
+        // END: change this to enable
+
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: parent.top
+        }
+
+        Grid {
+            id: headerGrid
+            width: parent.width
+            columns: tabView.count
+            Repeater {
+                model: tabView.count
+                delegate: BackgroundItem {
+                    id: headerItem
+                    property bool loaded: tabItem.image !== "" && tabItem.title !== ""
+                    width: loaded ? (headerGrid.width / tabView.count) : 0
+                    opacity: loaded ? 1.0 : 0.0
+
+                    Behavior on width { PropertyAnimation {duration: 300}}
+                    Behavior on opacity { PropertyAnimation {duration: 300}}
+                    height: Theme.itemSizeLarge
+                    property ChatInformationTabItemBase tabItem: tabView.model.get(index)
+                    property int itemIndex: index
+                    property bool itemIsActive: tabItem.active
+                    Icon {
+                        id: headerIcon
+                        source: headerItem.tabItem.image
+                        highlighted: headerItem.pressed || headerItem.itemIsActive
+                        anchors {
+                            top: parent.top
+                            horizontalCenter: parent.horizontalCenter
+                        }
+                    }
+                    Label {
+                        text: headerItem.tabItem.title// + headerItem.itemIsActive
+                        width: parent.width
+                        horizontalAlignment: Text.AlignHCenter
+                        anchors.top: headerIcon.bottom
+                        highlighted: headerItem.pressed || headerItem.itemIsActive
+                        font.pixelSize: Theme.fontSizeTiny
+                    }
+                    onClicked: {
+                        chatInformationPage.scrollDown()
+                        tabView.openTab(itemIndex)
+                    }
+                }
+            }
+        }
+    }
+
+    ListView {
+        id: tabView
+        orientation: ListView.Horizontal
+        clip: true
+        snapMode: ListView.SnapOneItem
+        highlightRangeMode: ListView.StrictlyEnforceRange
+        highlightFollowsCurrentItem: true
+        boundsBehavior: Flickable.StopAtBounds
+        currentIndex: 0
+        highlightMoveDuration: 500
+        property int maxHeight: tabViewItem.height - tabViewHeader.height
+
+
+        anchors {
+            top: tabViewHeader.bottom
+            left: parent.left
+            right: parent.right
+            bottom: parent.bottom
+        }
+
+        function openTab(index) {
+            currentIndex = index;
+        }
+        model: VisualItemModel {
+            id: tabModel
+        }
+    }
+    Component {
+        id: membersGroupComponent
+        ChatInformationTabItemMembersGroups{
+            width: tabView.width
+        }
+    }
+    Component {
+        id: settingsComponent
+        ChatInformationTabItemSettings {
+            width: tabView.width
+        }
+    }
+    Component {
+        id: debugComponent
+        ChatInformationTabItemDebug {
+            width: tabView.width
+        }
+    }
+    property var tabItems: {
+        var items = [];
+        if(!(isPrivateChat && chatPartnerGroupId === myUserId.toString())) {
+            items.push(membersGroupComponent);
+        }
+        if(!isPrivateChat && (groupInformation.status.can_restrict_members || groupInformation.status["@type"] === "chatMemberStatusCreator")) {
+            items.push(settingsComponent);
+        }
+//        items.push(debugComponent);
+
+        return items;
+    }
+    onTabItemsChanged: fillTabItems()
+
+    function fillTabItems() {
+        tabModel.clear()
+        for(var i in tabItems) {
+            tabModel.append(tabItems[i].createObject(tabModel));
+        }
+    }
+
+    Component.onCompleted: {
+        fillTabItems()
+    }
+
+}

--- a/qml/components/chatInformationPage/ChatInformationTextItem.qml
+++ b/qml/components/chatInformationPage/ChatInformationTextItem.qml
@@ -1,0 +1,74 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+import "../../js/twemoji.js" as Emoji
+import "../../js/functions.js" as Functions
+
+Column {
+    id: textItem
+    property alias headerText: headerItem.text
+    property string text
+    property bool isLinkedLabel // for telephone number
+    width: parent.width
+    visible: !!text
+    SectionHeader {
+        id: headerItem
+        visible: text !== "" && labelLoader.status === Loader.Ready && labelLoader.item.text !== ""
+        height: visible ? Theme.itemSizeSmall : 0
+        x: 0
+    }
+    Loader {
+        id: labelLoader
+        active: true
+        asynchronous: true
+        sourceComponent: textItem.isLinkedLabel ? linkedLabelComponent : labelComponent
+        width: textItem.width
+    }
+
+    Component {
+        id: labelComponent
+        Label {
+            wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+            font.pixelSize: Theme.fontSizeExtraSmall
+            textFormat: Text.StyledText
+            color: Theme.highlightColor
+            text: Emoji.emojify( Functions.replaceUrlsWithLinks(textItem.text).replace(/\n/g, "<br>"), Theme.fontSizeExtraSmall).replace(/\.\.\/js/g, "../../js")
+            linkColor: Theme.primaryColor
+            visible: text !== ""
+            onLinkActivated: {
+                Functions.handleLink(link);
+            }
+        }
+    }
+    Component {
+        id: linkedLabelComponent
+        LinkedLabel {
+            wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+            font.pixelSize: Theme.fontSizeExtraSmall
+            textFormat: Text.StyledText
+            plainText: textItem.text
+            visible: textItem.text !== ""
+            onLinkActivated: {
+                Functions.handleLink(link);
+            }
+        }
+    }
+}

--- a/qml/components/chatInformationPage/EditGroupChatPermissionsColumn.qml
+++ b/qml/components/chatInformationPage/EditGroupChatPermissionsColumn.qml
@@ -1,0 +1,148 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+
+Column {
+    id: chatPermissionsColumn
+
+    function setChatPermissions(textSwitchItem) {
+        if(textSwitchItem.busy) {return;}
+        var messageSubItems = ["can_send_media_messages", "can_send_polls", "can_send_other_messages", "can_add_web_page_previews"];
+        var permissionName = textSwitchItem.permissionName;
+        var permissionValue = !textSwitchItem.checked
+        textSwitchItem.busy = true;
+        var newPermissions = chatInformationPage.chatInformation.permissions;
+        if(permissionName in newPermissions) {
+            newPermissions[permissionName] = permissionValue;
+            // some permissions infer can_send_messages:
+            if(permissionName === "can_send_messages" && !permissionValue) {
+                for(var i in messageSubItems) {
+                    newPermissions[messageSubItems[i]] = false;
+                }
+            } else if(messageSubItems.indexOf(permissionName) > -1 && permissionValue) {
+                newPermissions.can_send_message = true;
+            }
+        }
+        tdLibWrapper.setChatPermissions(chatInformationPage.chatInformation.id, newPermissions);
+    }
+
+    Column {
+        visible: chatInformationPage.groupInformation.status.can_restrict_members || chatInformationPage.groupInformation.status["@type"] === "chatMemberStatusCreator"
+        width: parent.width
+
+        SectionHeader {
+            text: qsTr("Group Member Permissions", "what can normal group members do")
+        }
+        TextSwitch {
+            automaticCheck: false
+            property string permissionName: "can_send_messages"
+            text: qsTr("Send Messages", "member permission")
+            checked: chatInformationPage.chatInformation.permissions[permissionName]
+            onCheckedChanged: {busy = false;}
+            onClicked: {
+                chatPermissionsColumn.setChatPermissions(this)
+            }
+        }
+        TextSwitch {
+            automaticCheck: false
+            property string permissionName: "can_send_media_messages"
+            text: qsTr("Send Media Messages", "member permission")
+            onCheckedChanged: {busy = false;}
+            checked: chatInformationPage.chatInformation.permissions[permissionName]
+            onClicked: {
+                chatPermissionsColumn.setChatPermissions(this)
+            }
+        }
+
+        TextSwitch {
+            automaticCheck: false
+            property string permissionName: "can_send_other_messages"
+            text: qsTr("Send Other Messages", "member permission")
+            onCheckedChanged: {busy = false;}
+            checked: chatInformationPage.chatInformation.permissions[permissionName]
+            onClicked: {
+                chatPermissionsColumn.setChatPermissions(this)
+            }
+        }
+
+        TextSwitch {
+            automaticCheck: false
+            property string permissionName: "can_add_web_page_previews"
+            text: qsTr("Add Web Page Previews", "member permission")
+            onCheckedChanged: {busy = false;}
+            checked: chatInformationPage.chatInformation.permissions[permissionName]
+            onClicked: {
+                chatPermissionsColumn.setChatPermissions(this)
+            }
+        }
+
+        TextSwitch {
+            automaticCheck: false
+            property string permissionName: "can_change_info"
+            text: qsTr("Change Chat Info", "member permission")
+            onCheckedChanged: {busy = false;}
+            checked: chatInformationPage.chatInformation.permissions[permissionName]
+            onClicked: {
+                chatPermissionsColumn.setChatPermissions(this)
+            }
+        }
+
+        TextSwitch {
+            automaticCheck: false
+            property string permissionName: "can_invite_users"
+            text: qsTr("Invite Users", "member permission")
+            onCheckedChanged: {busy = false;}
+            checked: chatInformationPage.chatInformation.permissions[permissionName]
+            onClicked: {
+                chatPermissionsColumn.setChatPermissions(this)
+            }
+        }
+
+        TextSwitch {
+            automaticCheck: false
+            property string permissionName: "can_pin_messages"
+            text: qsTr("Pin Messages", "member permission")
+            onCheckedChanged: {busy = false;}
+            checked: chatInformationPage.chatInformation.permissions[permissionName]
+            onClicked: {
+                chatPermissionsColumn.setChatPermissions(this)
+            }
+        }
+    }
+
+    SectionHeader {
+        visible: historyAvailableSwitch.visible
+        text: qsTr("New Members", "what can new group members do")
+    }
+
+
+    TextSwitch {
+        id: historyAvailableSwitch
+        visible: chatInformationPage.isSuperGroup && chatInformationPage.groupInformation.status && chatInformationPage.groupInformation.status.can_change_info
+        automaticCheck: false
+        text: qsTr("New members can see older messages", "member permission")
+        onCheckedChanged: {busy = false;}
+        checked: chatInformationPage.groupFullInformation.is_all_history_available
+        onClicked: {
+            tdLibWrapper.toggleSupergroupIsAllHistoryAvailable(chatInformationPage.chatPartnerGroupId, !checked);
+        }
+    }
+}

--- a/qml/components/chatInformationPage/EditSuperGroupSlowModeColumn.qml
+++ b/qml/components/chatInformationPage/EditSuperGroupSlowModeColumn.qml
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+
+Column {
+    SectionHeader {
+        text: qsTr("Slow Mode")
+    }
+
+    Slider {
+        width: parent.width + Theme.horizontalPageMargin * 2
+        x: -Theme.horizontalPageMargin
+        property var presetValues: [0, 10, 30, 60, 300, 900, 3600]
+        property int realValue: chatInformationPage.groupFullInformation.slow_mode_delay
+        property int realValueIndex: presetValues.indexOf(realValue) > -1 ? presetValues.indexOf(realValue) : 0
+        value: realValueIndex
+        minimumValue: 0
+        maximumValue: presetValues.length - 1
+        stepSize: 1
+        valueText: value === 0 ? qsTr("Off") : Format.formatDuration(presetValues[value], presetValues[value] < 3600 ? Formatter.DurationShort : Formatter.DurationLong);
+        onPressedChanged: {
+            if(!pressed && value !== realValueIndex) {
+                tdLibWrapper.setChatSlowModeDelay(chatInformationPage.chatInformation.id, presetValues[value]);
+            }
+        }
+    }
+    Label {
+        text: qsTr("Set how long every chat member has to wait between Messages")
+        width: parent.width - Theme.horizontalPageMargin * 2
+        x: Theme.horizontalPageMargin
+        font.pixelSize: Theme.fontSizeSmall
+        color: Theme.secondaryHighlightColor
+    }
+}

--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -94,8 +94,46 @@ function getMessageText(message, simple, myself) {
     if (message.content['@type'] === 'messageChatDeleteMember') {
         return myself ? qsTr("left this chat", "myself") : qsTr("left this chat");
     }
+    if (message.content['@type'] === 'messageChatChangeTitle') {
+        return myself ? qsTr("changed the chat title to %1", "myself").arg(message.content.title) : qsTr("changed the chat title to %1").arg(message.content.title);
+    }
     return qsTr("Unsupported message: %1").arg(message.content['@type'].substring(7));
 }
+
+function getChatPartnerStatusText(statusType, was_online) {
+    switch(statusType) {
+    case "userStatusEmpty":
+        return qsTr("was never online");
+    case "userStatusLastMonth":
+        return qsTr("offline, last online: last month");
+    case "userStatusLastWeek":
+        return qsTr("offline, last online: last week");
+    case "userStatusOffline":
+        return qsTr("offline, last online: %1").arg(getDateTimeElapsed(was_online));
+    case "userStatusOnline":
+        return qsTr("online");
+    case "userStatusRecently":
+        return qsTr("offline, was recently online");
+    }
+}
+function getChatMemberStatusText(statusType) {
+//    chatMemberStatusAdministrator, chatMemberStatusBanned, chatMemberStatusCreator, chatMemberStatusLeft, chatMemberStatusMember, and chatMemberStatusRestricted.
+    switch(statusType) {
+    case "chatMemberStatusAdministrator":
+        return qsTr("Admin", "channel user role");
+    case "chatMemberStatusBanned":
+        return qsTr("Banned", "channel user role");
+    case "chatMemberStatusCreator":
+        return qsTr("Creator", "channel user role");
+    case "chatMemberStatusRestricted":
+        return qsTr("Restricted", "channel user role");
+    case "chatMemberStatusLeft":
+    case "chatMemberStatusMember":
+        return ""
+    }
+    return statusType || "";
+}
+
 function getShortenedCount(count) {
     if (count >= 1000000) {
         return qsTr("%1M").arg((count / 1000000).toLocaleString(Qt.locale(), 'f', 0));
@@ -225,4 +263,7 @@ function getVideoHeight(videoWidth, videoData) {
     } else {
         return 1;
     }
+}
+function replaceUrlsWithLinks(string) {
+    return string.replace(/((\w+):\/\/[\w?=&.\/-;#~%-]+(?![\w\s?&.\/;#~%"=-]*>))/g, "<a href=\"$1\">$1</a>");
 }

--- a/qml/pages/ChatInformationPage.qml
+++ b/qml/pages/ChatInformationPage.qml
@@ -1,0 +1,463 @@
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import "../components"
+import "../components/chatInformationPage"
+import "../js/twemoji.js" as Emoji
+import "../js/functions.js" as Functions
+
+Page {
+    id: chatInformationPage
+
+    allowedOrientations: Orientation.All
+    property string searchString
+
+    property int chatOnlineMemberCount: 0;
+    property int myUserId: tdLibWrapper.getUserInformation().id;
+
+    property bool isPrivateChat: false
+    property bool isBasicGroup: false
+    property bool isSuperGroup: false
+    property bool isChannel: false
+
+    property string chatPartnerGroupId
+
+    property bool userIsMember: (isPrivateChat && chatInformation["@type"]) || // should be optimized
+                                (isBasicGroup || isSuperGroup) && (
+                                    (groupInformation.status["@type"] === "chatMemberStatusMember")
+                                    || (groupInformation.status["@type"] === "chatMemberStatusAdministrator")
+                                    || (groupInformation.status["@type"] === "chatMemberStatusRestricted" && groupInformation.status.is_member)
+                                    || (groupInformation.status["@type"] === "chatMemberStatusCreator" && groupInformation.status.is_member)
+                                    )
+
+    property variant chatInformation:({});
+    property variant privateChatUserInformation:({});
+    property variant chatPartnerFullInformation:({});
+    property variant chatPartnerProfilePhotos:([]);
+    property variant groupInformation: ({});
+    property variant groupFullInformation: ({});
+
+    property alias membersList: membersList
+
+    function initializePage() {
+        console.log("[ChatInformationPage] Initializing chat info page...");
+        membersList.clear();
+        var chatType = chatInformation.type["@type"];
+        switch(chatType) {
+        case "chatTypePrivate":
+            isPrivateChat = true;
+            chatInformationPage.chatPartnerGroupId = chatInformation.type.user_id.toString();
+            if(!privateChatUserInformation.id) {
+                privateChatUserInformation = tdLibWrapper.getUserInformation(chatInformationPage.chatPartnerGroupId);
+            }
+            tdLibWrapper.getUserFullInfo(chatInformationPage.chatPartnerGroupId);
+            tdLibWrapper.getUserProfilePhotos(chatInformationPage.chatPartnerGroupId, 100, 0);
+            break;
+        case "chatTypeBasicGroup":
+            isBasicGroup = true;
+            chatInformationPage.chatPartnerGroupId = chatInformation.type.basic_group_id.toString();
+            if(!groupInformation.id) {
+                groupInformation = tdLibWrapper.getBasicGroup(chatInformationPage.chatPartnerGroupId);
+            }
+            tdLibWrapper.getGroupFullInfo(chatInformationPage.chatPartnerGroupId, false);
+            break;
+        case "chatTypeSupergroup":
+            isSuperGroup = true;
+            chatInformationPage.chatPartnerGroupId = chatInformation.type.supergroup_id.toString();
+            if(!groupInformation.id) {
+                groupInformation = tdLibWrapper.getSuperGroup(chatInformationPage.chatPartnerGroupId);
+            }
+
+            tdLibWrapper.getGroupFullInfo(chatInformationPage.chatPartnerGroupId, true);
+            isChannel = groupInformation.is_channel;
+            break;
+        }
+        if(!isPrivateChat) {
+            updateGroupStatusText();
+        }
+    }
+    function scrollUp(force) {
+        if(force) {
+            // animation does not always work while quick scrolling
+            scrollUpTimer.start()
+        } else {
+            scrollUpAnimation.start()
+        }
+    }
+    function scrollDown(force) {
+        if(force) {
+            scrollDownTimer.start()
+        } else {
+            scrollDownAnimation.start()
+        }
+    }
+    function handleBasicGroupFullInfo(groupFullInfo) {
+        groupFullInformation = groupFullInfo;
+        membersList.clear();
+        if(groupFullInfo.members && groupFullInfo.members.length > 0) {
+            for(var memberIndex in groupFullInfo.members) {
+                var memberData = groupFullInfo.members[memberIndex];
+                var userInfo = tdLibWrapper.getUserInformation(memberData.user_id) || {user:{}, bot_info:{}};
+                memberData.user = userInfo;
+                memberData.bot_info = memberData.bot_info || {};
+                membersList.append(memberData);
+            }
+            groupInformation.member_count = groupFullInfo.members.length
+            updateGroupStatusText();
+        }
+    }
+
+    Connections {
+        target: tdLibWrapper
+
+        onChatOnlineMemberCountUpdated: {
+            if ((isSuperGroup || isBasicGroup) && chatInformation.id.toString() === chatId) {
+                chatOnlineMemberCount = onlineMemberCount;
+                updateGroupStatusText();
+            }
+        }
+        onSupergroupFullInfoReceived: {
+            if(isSuperGroup && chatInformationPage.chatPartnerGroupId === groupId) {
+                groupFullInformation = groupFullInfo;
+            }
+        }
+        onSupergroupFullInfoUpdated: {
+            if(isSuperGroup && chatInformationPage.chatPartnerGroupId === groupId) {
+                groupFullInformation = groupFullInfo;
+            }
+        }
+        onBasicGroupFullInfoReceived: {
+            if(isBasicGroup && chatInformationPage.chatPartnerGroupId === groupId) {
+                handleBasicGroupFullInfo(groupFullInfo)
+            }
+        }
+
+        onBasicGroupFullInfoUpdated: {
+            if(isBasicGroup && chatInformationPage.chatPartnerGroupId === groupId) {
+                handleBasicGroupFullInfo(groupFullInfo)
+            }
+        }
+        onUserFullInfoReceived: {
+            if(isPrivateChat && userFullInfo["@extra"] === chatInformationPage.chatPartnerGroupId) {
+                chatPartnerFullInformation = userFullInfo;
+            }
+        }
+        onUserFullInfoUpdated: {
+            if(isPrivateChat && userId === chatInformationPage.chatPartnerGroupId) {
+                chatPartnerFullInformation = userFullInfo;
+            }
+        }
+
+        onUserProfilePhotosReceived: {
+            if(isPrivateChat && extra === chatInformationPage.chatPartnerGroupId) {
+                chatPartnerProfilePhotos = photos;
+            }
+        }
+        onChatPermissionsUpdated: {
+            if (chatInformation.id.toString() === chatId) {
+                // set whole object to trigger change
+                var newInformation = chatInformation;
+                newInformation.permissions = permissions
+                chatInformation = newInformation
+            }
+        }
+        onChatTitleUpdated: {
+            if (chatInformation.id.toString() === chatId) {
+                // set whole object to trigger change
+                var newInformation = chatInformation;
+                newInformation.title = title
+                chatInformation = newInformation
+            }
+        }
+    }
+    Component.onCompleted: initializePage();
+
+    ListModel {
+        id: membersList
+    }
+
+    AppNotification {
+        id: infoNotification
+    }
+    SilicaFlickable {
+        id: pageFlickable
+        anchors.fill: parent
+
+        PullDownMenu {
+            MenuItem {
+                visible: (isBasicGroup || isSuperGroup) && userIsMember
+                text: qsTr("Leave Group")
+                onClicked: {
+                    // ensure it's done even if the page is closed:
+                    var remorse = Remorse.popupAction(appWindow, qsTr("Leaving chat"), (function(chatid) {
+                        return function() {
+                            tdLibWrapper.leaveChat(chatid);
+                            // this does not care about the response (ideally type "ok" without further reference) for now
+                            pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ));
+                        };
+                    }(chatInformation.id.toString())))
+                }
+            }
+            MenuItem {
+                visible: userIsMember
+                onClicked: {
+                    var newNotificationSettings = chatInformation.notification_settings;
+                    if (newNotificationSettings.mute_for > 0) {
+                        newNotificationSettings.mute_for = 0;
+                    } else {
+                        newNotificationSettings.mute_for = 6666666;
+                    }
+                    tdLibWrapper.setChatNotificationSettings(chat_id, newNotificationSettings);
+                }
+                text: chatInformation.notification_settings.mute_for > 0 ? qsTr("Unmute Chat") : qsTr("Mute Chat")
+            }
+            // MenuItem { //TODO Implement
+            //     visible: !userIsMember
+            //     onClicked: {
+            //         tdLibWrapper.joinChat(chat_id);
+            //     }
+            //     text: qsTr("Join Chat")
+            // }
+        }
+        // header
+        PageHeader {
+            id: headerItem
+            z: 5
+            Item {
+                id: imageContainer
+                property bool hasImage: typeof chatInformation.photo !== "undefined"
+                property int minDimension: chatInformationPage.isLandscape ? Theme.itemSizeSmall : Theme.itemSizeMedium
+                property int maxDimension: Screen.width / 2
+                property int minX: Theme.horizontalPageMargin
+                property int maxX: (chatInformationPage.width - maxDimension)/2
+                property int minY: (parent.height - minDimension)/2
+                property int maxY: parent.height
+                property double tweenFactor: {
+                    if(!hasImage) {
+                        return 0
+                    }
+                    return 1 - Math.max(0, Math.min(1, contentFlickable.contentY / maxDimension))
+                }
+
+                function getEased(min,max,factor) {
+                    return min + (max-min)*factor
+                }
+                width: getEased(minDimension,maxDimension, tweenFactor)
+                height: width
+                x: getEased(minX,maxX, tweenFactor)
+                y: getEased(minY,maxY, tweenFactor)
+
+                ProfileThumbnail {
+                    id: chatPictureThumbnail
+                    photoData: imageContainer.hasImage ? chatInformation.photo.small : ""
+                    replacementStringHint: headerItem.title
+                    width: parent.width
+                    height: width
+                    radius: imageContainer.minDimension / 2
+                    opacity: profilePictureLoader.status !== Loader.Ready || profilePictureLoader.item.opacity < 1 ? 1.0 : 0.0
+                }
+                Loader {
+                    id: profilePictureLoader
+                    active: imageContainer.hasImage
+                    asynchronous: true
+                    anchors.fill: chatPictureThumbnail
+                    source: chatInformationPage.isPrivateChat
+                            ? "../components/chatInformationPage/ChatInformationProfilePictureList.qml"
+                            : "../components/chatInformationPage/ChatInformationProfilePicture.qml"
+                }
+            }
+            leftMargin: imageContainer.minDimension + Theme.horizontalPageMargin + Theme.paddingMedium
+            title: chatInformation.title !== "" ? Emoji.emojify(chatInformation.title, Theme.fontSizeLarge) : qsTr("Unknown")
+            description: chatInformationPage.isPrivateChat ? ("@"+(chatInformationPage.privateChatUserInformation.username || chatInformationPage.chatPartnerGroupId)) : ""
+        }
+
+        SilicaFlickable {
+            id: contentFlickable
+            contentHeight: groupInfoItem.height + tabViewLoader.height
+            clip: true
+            interactive: true//groupInfoItem.height > pageFlickable.height * 0.5
+
+            anchors {
+                top: headerItem.bottom
+                bottom: parent.bottom
+                left: parent.left
+                right: parent.right
+            }
+            NumberAnimation {
+                id: scrollDownAnimation
+                target: contentFlickable
+                to: groupInfoItem.height
+                property: "contentY"
+                duration: 500
+                easing.type: Easing.InOutCubic
+            }
+            NumberAnimation {
+                id: scrollUpAnimation
+                target: contentFlickable
+                to: 0
+                property: "contentY"
+                duration: 500
+                easing.type: Easing.InOutCubic
+                property Timer scrollUpTimer: Timer {
+                    id: scrollUpTimer
+                    interval: 50
+                    onTriggered: {
+                        contentFlickable.scrollToTop()
+                    }
+                }
+                property Timer scrollDownTimer: Timer {
+                    id: scrollDownTimer
+                    interval: 50
+                    onTriggered: {
+                        contentFlickable.scrollToBottom()
+                    }
+                }
+            }
+
+            Column {
+                id: groupInfoItem
+                bottomPadding: Theme.paddingLarge
+                topPadding: Theme.paddingLarge
+                anchors {
+                    top: parent.top
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                }
+
+                Item { //large image placeholder
+                    width: parent.width
+                    height: imageContainer.hasImage ? imageContainer.maxDimension : 0
+                }
+
+                ChatInformationEditArea {
+                    visible: canEdit
+                    canEdit: !chatInformationPage.isPrivateChat && chatInformationPage.groupInformation.status && (chatInformationPage.groupInformation.status.can_change_info  || chatInformationPage.groupInformation.status["@type"] === "chatMemberStatusCreator")
+                    headerText: qsTr("Chat Title", "group title header")
+                    text: chatInformation.title
+
+                    onSaveButtonClicked: {
+                        if(!editItem.errorHighlight) {
+                            tdLibWrapper.setChatTitle(chatInformationPage.chatInformation.id, textValue);
+                        } else {
+                            isEditing = true
+                        }
+                    }
+
+                    onTextEdited: {
+                        if(textValue.length > 0 && textValue.length < 129) {
+                            editItem.errorHighlight = false
+                            editItem.label = ""
+                            editItem.placeholderText = ""
+                        } else {
+                            editItem.label = qsTr("Enter 1-128 characters")
+                            editItem.placeholderText = editItem.label
+                            editItem.errorHighlight = true
+                        }
+                    }
+                }
+                ChatInformationEditArea {
+                    canEdit: (chatInformationPage.isPrivateChat && chatInformationPage.privateChatUserInformation.id === chatInformationPage.myUserId) || ((chatInformationPage.isBasicGroup || chatInformationPage.isSuperGroup) && chatInformationPage.groupInformation && (chatInformationPage.groupInformation.status.can_change_info || chatInformationPage.groupInformation.status["@type"] === "chatMemberStatusCreator"))
+                    emptyPlaceholderText: qsTr("There is no information text available, yet.")
+                    headerText: qsTr("Info", "group or user infotext header")
+                    multiLine: true
+                    text: (chatInformationPage.isPrivateChat ? chatInformationPage.chatPartnerFullInformation.bio : chatInformationPage.groupFullInformation.description) || ""
+                    onSaveButtonClicked: {
+                        if(chatInformationPage.isPrivateChat) { // own bio
+                            tdLibWrapper.setBio(textValue);
+                        } else { // group info
+                            tdLibWrapper.setChatDescription(chatInformationPage.chatInformation.id, textValue);
+                        }
+                    }
+                }
+
+                ChatInformationTextItem {
+                    headerText: qsTr("Phone Number", "user phone number header")
+                    text: (chatInformationPage.isPrivateChat && chatInformationPage.privateChatUserInformation.phone_number ? "+"+chatInformationPage.privateChatUserInformation.phone_number : "") || ""
+                    isLinkedLabel: true
+                }
+
+                SectionHeader {
+                    font.pixelSize: Theme.fontSizeExtraSmall
+                    visible: !!inviteLinkItem.text
+                    height: visible ? Theme.itemSizeExtraSmall : 0
+                    text: qsTr("Invite Link", "header")
+                    x: 0
+                }
+
+                Row {
+                    width: parent.width
+                    visible: !!inviteLinkItem.text
+                    ChatInformationTextItem {
+                        id: inviteLinkItem
+                        text: !isPrivateChat ? groupFullInformation.invite_link : ""
+                        width: parent.width - inviteLinkButton.width
+                    }
+                    IconButton {
+                        id: inviteLinkButton
+                        icon.source: "image://theme/icon-m-clipboard"
+                        anchors.verticalCenter: inviteLinkItem.verticalCenter
+                        onClicked: {
+                            inviteLinkField.selectAll();
+                            inviteLinkField.copy();
+                            inviteLinkField.select(0,0);
+                            infoNotification.show(qsTr("The Invite Link has been copied to the clipboard."));
+                        }
+                        TextField {
+                            id: inviteLinkField
+                            width: 0
+                            height: 0
+                            text: groupFullInformation.invite_link ? groupFullInformation.invite_link : ""
+                            visible: false
+                            readOnly: true
+                            opacity: 0
+                        }
+                    }
+                }
+
+                Item {
+                    width: parent.width
+                    height: Theme.paddingLarge
+                }
+
+                Separator {
+                    width: parent.width
+                    color: Theme.primaryColor
+                    horizontalAlignment: Qt.AlignHCenter
+                    opacity: (tabViewLoader.status === Loader.Ready && tabViewLoader.item.count > 0) ? 1.0 : 0.0
+
+                    Behavior on opacity { PropertyAnimation {duration: 500}}
+                }
+            }
+
+            Loader {
+                id: tabViewLoader
+                asynchronous: true
+                active: true
+                anchors {
+                    left: parent.left
+                    right: parent.right
+                    top: groupInfoItem.bottom
+                }
+                sourceComponent: Component {
+                    ChatInformationTabView {
+                        id: tabView
+                        height: tabView.count > 0 ? chatInformationPage.height - headerItem.height : 0
+                    }
+                }
+            }
+        }
+    }
+    function updateGroupStatusText() {
+        if (chatOnlineMemberCount > 0) {
+            headerItem.description = qsTr("%1 members, %2 online").arg(Functions.getShortenedCount(groupInformation.member_count)).arg(Functions.getShortenedCount(chatOnlineMemberCount));
+        } else {
+            if (isChannel) {
+                headerItem.description = qsTr("%1 subscribers").arg(Functions.getShortenedCount(groupInformation.member_count));
+            } else {
+                headerItem.description = qsTr("%1 members").arg(Functions.getShortenedCount(groupInformation.member_count));
+            }
+        }
+    }
+
+}

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -152,6 +152,16 @@ Page {
                 chatListCreatedTimer.restart();
             }
         }
+        onChatReceived: {
+            if(chat["@extra"] === "openDirectly") {
+                console.log("ON CHAT RECEIVED", JSON.stringify(chat, null, 2));
+                if (status !== PageStatus.Active) {
+                    pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
+                }
+                // if we get a new chat (no messages?), we can not use the provided data
+                pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : tdLibWrapper.getChat(chat.id) });
+            }
+        }
     }
 
     Component.onCompleted: {
@@ -219,31 +229,12 @@ Page {
                     Behavior on opacity { NumberAnimation {} }
 
                     model: chatListModel
-                    delegate: ListItem {
-
-                        id: chatListViewItem
-
-                        contentHeight: chatListRow.height + chatListSeparator.height + 2 * Theme.paddingMedium
-                        contentWidth: parent.width
+                    delegate: ChatListViewItem {
+                        pictureThumbnail.forceElementUpdate: overviewPage.chatListCreated
+                        ownUserId: overviewPage.ownUserId
 
                         onClicked: {
-                            pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : display });
-                        }
-
-                        showMenuOnPressAndHold: chat_id != overviewPage.ownUserId
-                        menu: ContextMenu {
-                            MenuItem {
-                                onClicked: {
-                                    var newNotificationSettings = display.notification_settings;
-                                    if (newNotificationSettings.mute_for > 0) {
-                                        newNotificationSettings.mute_for = 0;
-                                    } else {
-                                        newNotificationSettings.mute_for = 6666666;
-                                    }
-                                    tdLibWrapper.setChatNotificationSettings(chat_id, newNotificationSettings);
-                                }
-                                text: display.notification_settings.mute_for > 0 ? qsTr("Unmute Chat") : qsTr("Mute Chat")
-                            }
+                           pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : display });
                         }
 
                         Connections {
@@ -251,151 +242,10 @@ Page {
                             onChatChanged: {
                                 if (overviewPage.chatListCreated && changedChatId === chat_id) {
                                     // Force update of some list item elements (currently only last message text seems to create problems). dataChanged() doesn't seem to trigger them all :(
-                                    chatListLastMessageText.text = last_message_text ? Emoji.emojify(last_message_text, Theme.fontSizeExtraSmall) : qsTr("Unknown")
+                                    secondaryText.text = last_message_text ? Emoji.emojify(last_message_text, Theme.fontSizeExtraSmall) : qsTr("Unknown")
                                 }
                             }
                         }
-
-                        Column {
-                            id: chatListColumn
-                            width: parent.width - ( 2 * Theme.horizontalPageMargin )
-                            spacing: Theme.paddingSmall
-                            anchors {
-                                horizontalCenter: parent.horizontalCenter
-                                verticalCenter: parent.verticalCenter
-                            }
-
-                            Row {
-                                id: chatListRow
-                                width: parent.width
-                                height: chatListContentColumn.height
-                                spacing: Theme.paddingMedium
-
-                                Column {
-                                    id: chatListPictureColumn
-                                    width: chatListContentColumn.height - Theme.paddingSmall
-                                    height: chatListContentColumn.height - Theme.paddingSmall
-                                    anchors.verticalCenter: parent.verticalCenter
-
-                                    Item {
-                                        id: chatListPictureItem
-                                        width: parent.width
-                                        height: parent.width
-
-                                        ProfileThumbnail {
-                                            id: chatListPictureThumbnail
-                                            photoData: photo_small
-                                            replacementStringHint: chatListNameText.text
-                                            width: parent.width
-                                            height: parent.width
-                                            forceElementUpdate: overviewPage.chatListCreated
-                                        }
-
-                                        Rectangle {
-                                            id: chatUnreadMessagesCountBackground
-                                            color: Theme.highlightBackgroundColor
-                                            width: Theme.fontSizeLarge
-                                            height: Theme.fontSizeLarge
-                                            anchors.right: parent.right
-                                            anchors.bottom: parent.bottom
-                                            radius: parent.width / 2
-                                            visible: unread_count > 0
-                                        }
-
-                                        Text {
-                                            id: chatUnreadMessagesCount
-                                            font.pixelSize: Theme.fontSizeExtraSmall
-                                            font.bold: true
-                                            color: Theme.primaryColor
-                                            anchors.centerIn: chatUnreadMessagesCountBackground
-                                            visible: chatUnreadMessagesCountBackground.visible
-                                            text: unread_count > 99 ? "99+" : unread_count
-                                        }
-                                    }
-                                }
-
-                                Column {
-                                    id: chatListContentColumn
-                                    width: parent.width * 5 / 6 - Theme.horizontalPageMargin
-                                    spacing: Theme.paddingSmall
-
-                                    Text {
-                                        id: chatListNameText
-                                        text: title ? Emoji.emojify(title, Theme.fontSizeMedium) + ( display.notification_settings.mute_for > 0 ? Emoji.emojify(" 🔇", Theme.fontSizeMedium) : "" ) : qsTr("Unknown")
-                                        textFormat: Text.StyledText
-                                        font.pixelSize: Theme.fontSizeMedium
-                                        color: Theme.primaryColor
-                                        elide: Text.ElideRight
-                                        width: parent.width
-                                        onTruncatedChanged: {
-                                            // There is obviously a bug in QML in truncating text with images.
-                                            // We simply remove Emojis then...
-                                            if (truncated) {
-                                                text = text.replace(/\<img [^>]+\/\>/g, "");
-                                            }
-                                        }
-                                    }
-
-                                    Row {
-                                        id: chatListLastMessageRow
-                                        width: parent.width
-                                        spacing: Theme.paddingSmall
-                                        Text {
-                                            id: chatListLastUserText
-                                            text: is_channel ? "" : ( last_message_sender_id ? ( last_message_sender_id !== overviewPage.ownUserId ? Emoji.emojify(Functions.getUserName(tdLibWrapper.getUserInformation(last_message_sender_id)), font.pixelSize) : qsTr("You") ) : qsTr("Unknown") )
-                                            font.pixelSize: Theme.fontSizeExtraSmall
-                                            color: Theme.highlightColor
-                                            textFormat: Text.StyledText
-                                            onTruncatedChanged: {
-                                                // There is obviously a bug in QML in truncating text with images.
-                                                // We simply remove Emojis then...
-                                                if (truncated) {
-                                                    text = text.replace(/\<img [^>]+\/\>/g, "");
-                                                }
-                                            }
-                                        }
-                                        Text {
-                                            id: chatListLastMessageText
-                                            text: last_message_text ? Emoji.emojify(last_message_text, Theme.fontSizeExtraSmall) : qsTr("Unknown")
-                                            font.pixelSize: Theme.fontSizeExtraSmall
-                                            color: Theme.primaryColor
-                                            width: parent.width - Theme.paddingMedium - chatListLastUserText.width
-                                            elide: Text.ElideRight
-                                            textFormat: Text.StyledText
-                                            onTruncatedChanged: {
-                                                // There is obviously a bug in QML in truncating text with images.
-                                                // We simply remove Emojis then...
-                                                if (truncated) {
-                                                    text = text.replace(/\<img [^>]+\/\>/g, "");
-                                                }
-                                            }
-                                        }
-                                    }
-
-                                    Text {
-                                        id: messageContactTimeElapsedText
-                                        text: last_message_date ? Functions.getDateTimeElapsed(last_message_date) : qsTr("Unknown")
-                                        font.pixelSize: Theme.fontSizeTiny
-                                        color: Theme.secondaryColor
-                                    }
-                                }
-                            }
-
-                        }
-
-                        Separator {
-                            id: chatListSeparator
-
-                            anchors {
-                                top: chatListColumn.bottom
-                                topMargin: Theme.paddingMedium
-                            }
-
-                            width: parent.width
-                            color: Theme.primaryColor
-                            horizontalAlignment: Qt.AlignHCenter
-                        }
-
                     }
 
                     ViewPlaceholder {

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -352,6 +352,21 @@ void ChatListModel::redrawModel()
     layoutChanged();
 }
 
+QVariantMap ChatListModel::get(int row)
+{
+
+    QHash<int,QByteArray> names = roleNames();
+    QHashIterator<int, QByteArray> i(names);
+    QVariantMap res;
+    QModelIndex idx = index(row, 0);
+    while (i.hasNext()) {
+        i.next();
+        QVariant data = idx.data(i.key());
+        res[i.value()] = data;
+    }
+    return res;
+}
+
 int ChatListModel::updateChatOrder(int chatIndex)
 {
     ChatData *chat = chatList.at(chatIndex);

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -37,6 +37,7 @@ public:
     virtual QVariant data(const QModelIndex &index, int role) const override;
 
     Q_INVOKABLE void redrawModel();
+    Q_INVOKABLE QVariantMap get(int row);
 
     bool showAllChats() const;
     void setShowAllChats(bool showAll);

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -42,7 +42,7 @@ public:
     Q_INVOKABLE QVariantMap getMessage(const int &index);
 
 signals:
-    void messagesReceived(const int &modelIndex, const int &lastReadSentIndex);
+    void messagesReceived(const int &modelIndex, const int &lastReadSentIndex, const int &totalCount);
     void messagesIncrementalUpdate(const int &modelIndex, const int &lastReadSentIndex);
     void newMessageReceived(const QVariantMap &message);
     void unreadCountUpdated(const int &unreadCount, const QString &lastReadInboxMessageId);
@@ -52,7 +52,7 @@ signals:
     void messagesDeleted();
 
 public slots:
-    void handleMessagesReceived(const QVariantList &messages);
+    void handleMessagesReceived(const QVariantList &messages, const int &totalCount);
     void handleNewMessageReceived(const QString &chatId, const QVariantMap &message);
     void handleChatReadInboxUpdated(const QString &chatId, const QString &lastReadInboxMessageId, const int &unreadCount);
     void handleChatReadOutboxUpdated(const QString &chatId, const QString &lastReadOutboxMessageId);

--- a/src/fernschreiberutils.cpp
+++ b/src/fernschreiberutils.cpp
@@ -51,5 +51,8 @@ QString FernschreiberUtils::getMessageShortText(const QVariantMap &messageConten
     if (contentType == "messageChatDeleteMember") {
         return myself ? tr("left this chat", "myself") : tr("left this chat");
     }
+    if (contentType == "messageChatChangeTitle") {
+        return myself ? tr("changed the chat title", "myself") : tr("changed the chat title");
+    }
     return tr("Unsupported message: %1").arg(contentType.mid(7));
 }

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -41,6 +41,7 @@ namespace {
     const QString LAST_READ_OUTBOX_MESSAGE_ID("last_read_outbox_message_id");
 
     const QString TYPE("@type");
+    const QString EXTRA("@extra");
     const QString TYPE_CHAT_POSITION("chatPosition");
     const QString TYPE_CHAT_LIST_MAIN("chatListMain");
 }
@@ -99,11 +100,22 @@ TDLibReceiver::TDLibReceiver(void *tdLibClient, QObject *parent) : QThread(paren
     handlers.insert("updateMessageContent", &TDLibReceiver::processUpdateMessageContent);
     handlers.insert("updateDeleteMessages", &TDLibReceiver::processUpdateDeleteMessages);
     handlers.insert("chats", &TDLibReceiver::processChats);
+    handlers.insert("chat", &TDLibReceiver::processChat);
     handlers.insert("updateRecentStickers", &TDLibReceiver::processUpdateRecentStickers);
     handlers.insert("stickers", &TDLibReceiver::processStickers);
     handlers.insert("updateInstalledStickerSets", &TDLibReceiver::processUpdateInstalledStickerSets);
     handlers.insert("stickerSets", &TDLibReceiver::processStickerSets);
     handlers.insert("stickerSet", &TDLibReceiver::processStickerSet);
+    handlers.insert("chatMembers", &TDLibReceiver::processChatMembers);
+    handlers.insert("userFullInfo", &TDLibReceiver::processUserFullInfo);
+    handlers.insert("updateUserFullInfo", &TDLibReceiver::processUpdateUserFullInfo);
+    handlers.insert("basicGroupFullInfo", &TDLibReceiver::processBasicGroupFullInfo);
+    handlers.insert("updateBasicGroupFullInfo", &TDLibReceiver::processUpdateBasicGroupFullInfo);
+    handlers.insert("supergroupFullInfo", &TDLibReceiver::processSupergroupFullInfo);
+    handlers.insert("updateSupergroupFullInfo", &TDLibReceiver::processUpdateSupergroupFullInfo);
+    handlers.insert("userProfilePhotos", &TDLibReceiver::processUserProfilePhotos);
+    handlers.insert("updateChatPermissions", &TDLibReceiver::processUpdateChatPermissions);
+    handlers.insert("updateChatTitle", &TDLibReceiver::processUpdateChatTitle);
 }
 
 void TDLibReceiver::setActive(const bool &active)
@@ -302,7 +314,7 @@ void TDLibReceiver::processChatOnlineMemberCountUpdated(const QVariantMap &recei
 void TDLibReceiver::processMessages(const QVariantMap &receivedInformation)
 {
     LOG("Received new messages, amount: " << receivedInformation.value("total_count").toString());
-    emit messagesReceived(receivedInformation.value("messages").toList());
+    emit messagesReceived(receivedInformation.value("messages").toList(), receivedInformation.value("total_count").toInt());
 }
 
 void TDLibReceiver::processUpdateNewMessage(const QVariantMap &receivedInformation)
@@ -375,6 +387,11 @@ void TDLibReceiver::processChats(const QVariantMap &receivedInformation)
     emit chats(receivedInformation);
 }
 
+void TDLibReceiver::processChat(const QVariantMap &receivedInformation)
+{
+    emit chat(receivedInformation);
+}
+
 void TDLibReceiver::processUpdateRecentStickers(const QVariantMap &receivedInformation)
 {
     LOG("Recent stickers updated");
@@ -403,4 +420,77 @@ void TDLibReceiver::processStickerSet(const QVariantMap &receivedInformation)
 {
     LOG("Received a sticker set...");
     emit stickerSet(receivedInformation);
+}
+void TDLibReceiver::processChatMembers(const QVariantMap &receivedInformation)
+{
+    LOG("Received super group members");
+    const QString extra = receivedInformation.value(EXTRA).toString();
+    emit chatMembers(extra, receivedInformation.value("members").toList(), receivedInformation.value("total_count").toInt());
+}
+
+void TDLibReceiver::processUserFullInfo(const QVariantMap &receivedInformation)
+{
+
+    LOG("Received UserFullInfo");
+
+    emit userFullInfo(receivedInformation);
+}
+
+void TDLibReceiver::processUpdateUserFullInfo(const QVariantMap &receivedInformation)
+{
+
+    LOG("Received UserFullInfoUpdate");
+
+    emit userFullInfoUpdated(receivedInformation.value("user_id").toString(), receivedInformation.value("user_full_info").toMap());
+}
+
+void TDLibReceiver::processBasicGroupFullInfo(const QVariantMap &receivedInformation)
+{
+
+    LOG("Received BasicGroupFullInfo");
+    const QString groupId = receivedInformation.value(EXTRA).toString();
+
+    emit basicGroupFullInfo(groupId, receivedInformation);
+}
+void TDLibReceiver::processUpdateBasicGroupFullInfo(const QVariantMap &receivedInformation)
+{
+    LOG("Received BasicGroupFullInfoUpdate");
+    const QString groupId = receivedInformation.value("basic_group_id").toString();
+
+    emit basicGroupFullInfoUpdated(groupId, receivedInformation.value("basic_group_full_info").toMap());
+}
+
+void TDLibReceiver::processSupergroupFullInfo(const QVariantMap &receivedInformation)
+{
+    LOG("Received SuperGroupFullInfoUpdate");
+    const QString groupId = receivedInformation.value(EXTRA).toString();
+
+    emit supergroupFullInfo(groupId, receivedInformation);
+}
+
+void TDLibReceiver::processUpdateSupergroupFullInfo(const QVariantMap &receivedInformation)
+{
+
+    LOG("Received SuperGroupFullInfoUpdate");
+    const QString groupId = receivedInformation.value("supergroup_id").toString();
+
+    emit supergroupFullInfoUpdated(groupId, receivedInformation.value("supergroup_full_info").toMap());
+}
+
+void TDLibReceiver::processUserProfilePhotos(const QVariantMap &receivedInformation)
+{
+    const QString extra = receivedInformation.value(EXTRA).toString();
+    emit userProfilePhotos(extra, receivedInformation.value("photos").toList(), receivedInformation.value("total_count").toInt());
+}
+
+void TDLibReceiver::processUpdateChatPermissions(const QVariantMap &receivedInformation)
+{
+    emit chatPermissionsUpdated(receivedInformation.value("chat_id").toString(), receivedInformation.value("permissions").toMap());
+}
+
+void TDLibReceiver::processUpdateChatTitle(const QVariantMap &receivedInformation)
+{
+
+    LOG("Received UpdateChatTitle");
+    emit chatTitleUpdated(receivedInformation.value("chat_id").toString(), receivedInformation.value("title").toString());
 }

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -53,7 +53,7 @@ signals:
     void basicGroupUpdated(qlonglong groupId, const QVariantMap &groupInformation);
     void superGroupUpdated(qlonglong groupId, const QVariantMap &groupInformation);
     void chatOnlineMemberCountUpdated(const QString &chatId, const int &onlineMemberCount);
-    void messagesReceived(const QVariantList &messages);
+    void messagesReceived(const QVariantList &messages, const int &totalCount);
     void newMessageReceived(const QString &chatId, const QVariantMap &message);
     void messageInformation(const QString &messageId, const QVariantMap &message);
     void messageSendSucceeded(const QString &messageId, const QString &oldMessageId, const QVariantMap &message);
@@ -64,12 +64,22 @@ signals:
     void messageContentUpdated(const QString &chatId, const QString &messageId, const QVariantMap &newContent);
     void messagesDeleted(const QString &chatId, const QVariantList &messageIds);
     void chats(const QVariantMap &chats);
+    void chat(const QVariantMap &chats);
     void recentStickersUpdated(const QVariantList &stickerIds);
     void stickers(const QVariantList &stickers);
     void installedStickerSetsUpdated(const QVariantList &stickerSetIds);
     void stickerSets(const QVariantList &stickerSets);
     void stickerSet(const QVariantMap &stickerSet);
-
+    void chatMembers(const QString &extra, const QVariantList &members, const int &totalMembers);
+    void userFullInfo(const QVariantMap &userFullInfo);
+    void userFullInfoUpdated(const QString &userId,const QVariantMap &userFullInfo);
+    void basicGroupFullInfo(const QString &groupId, const QVariantMap &groupFullInfo);
+    void basicGroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
+    void supergroupFullInfo(const QString &groupId, const QVariantMap &groupFullInfo);
+    void supergroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
+    void userProfilePhotos(const QString &extra, const QVariantList &photos, const int &totalPhotos);
+    void chatPermissionsUpdated(const QString &chatId, const QVariantMap &chatPermissions);
+    void chatTitleUpdated(const QString &chatId, const QString &title);
 private:
     typedef void (TDLibReceiver::*Handler)(const QVariantMap &);
 
@@ -108,11 +118,22 @@ private:
     void processUpdateMessageContent(const QVariantMap &receivedInformation);
     void processUpdateDeleteMessages(const QVariantMap &receivedInformation);
     void processChats(const QVariantMap &receivedInformation);
+    void processChat(const QVariantMap &receivedInformation);
     void processUpdateRecentStickers(const QVariantMap &receivedInformation);
     void processStickers(const QVariantMap &receivedInformation);
     void processUpdateInstalledStickerSets(const QVariantMap &receivedInformation);
     void processStickerSets(const QVariantMap &receivedInformation);
     void processStickerSet(const QVariantMap &receivedInformation);
+    void processChatMembers(const QVariantMap &receivedInformation);
+    void processUserFullInfo(const QVariantMap &receivedInformation);
+    void processUpdateUserFullInfo(const QVariantMap &receivedInformation);
+    void processBasicGroupFullInfo(const QVariantMap &receivedInformation);
+    void processUpdateBasicGroupFullInfo(const QVariantMap &receivedInformation);
+    void processSupergroupFullInfo(const QVariantMap &receivedInformation);
+    void processUpdateSupergroupFullInfo(const QVariantMap &receivedInformation);
+    void processUserProfilePhotos(const QVariantMap &receivedInformation);
+    void processUpdateChatPermissions(const QVariantMap &receivedInformation);
+    void processUpdateChatTitle(const QVariantMap &receivedInformation);
 };
 
 #endif // TDLIBRECEIVER_H

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -113,6 +113,7 @@ public:
     Q_INVOKABLE void downloadFile(const QString &fileId);
     Q_INVOKABLE void openChat(const QString &chatId);
     Q_INVOKABLE void closeChat(const QString &chatId);
+    Q_INVOKABLE void leaveChat(const QString &chatId);
     Q_INVOKABLE void getChatHistory(const QString &chatId, const qlonglong &fromMessageId = 0, const int &offset = 0, const int &limit = 50, const bool &onlyLocal = false);
     Q_INVOKABLE void viewMessage(const QString &chatId, const QString &messageId);
     Q_INVOKABLE void sendTextMessage(const QString &chatId, const QString &message, const QString &replyToMessageId = "0");
@@ -129,6 +130,18 @@ public:
     Q_INVOKABLE void getRecentStickers();
     Q_INVOKABLE void getInstalledStickerSets();
     Q_INVOKABLE void getStickerSet(const QString &setId);
+    Q_INVOKABLE void getSupergroupMembers(const QString &groupId, const int &limit, const int &offset);
+    Q_INVOKABLE void getGroupFullInfo(const QString &groupId, const bool &isSuperGroup);
+    Q_INVOKABLE void getUserFullInfo(const QString &userId);
+    Q_INVOKABLE void createPrivateChat(const QString &userId);
+    Q_INVOKABLE void getGroupsInCommon(const QString &userId, const int &limit, const int &offset);
+    Q_INVOKABLE void getUserProfilePhotos(const QString &userId, const int &limit, const int &offset);
+    Q_INVOKABLE void setChatPermissions(const QString &chatId, const QVariantMap &chatPermissions);
+    Q_INVOKABLE void setChatSlowModeDelay(const QString &chatId, const int &delay);
+    Q_INVOKABLE void setChatDescription(const QString &chatId, const QString &description);
+    Q_INVOKABLE void setChatTitle(const QString &chatId, const QString &title);
+    Q_INVOKABLE void setBio(const QString &bio);
+    Q_INVOKABLE void toggleSupergroupIsAllHistoryAvailable(const QString &groupId, const bool &isAllHistoryAvailable);
 
     // Others (candidates for extraction ;))
     Q_INVOKABLE void searchEmoji(const QString &queryString);
@@ -155,7 +168,7 @@ signals:
     void basicGroupUpdated(qlonglong groupId);
     void superGroupUpdated(qlonglong groupId);
     void chatOnlineMemberCountUpdated(const QString &chatId, const int &onlineMemberCount);
-    void messagesReceived(const QVariantList &messages);
+    void messagesReceived(const QVariantList &messages, const int &totalCount);
     void newMessageReceived(const QString &chatId, const QVariantMap &message);
     void copyToDownloadsSuccessful(const QString &fileName, const QString &filePath);
     void copyToDownloadsError(const QString &fileName, const QString &filePath);
@@ -168,12 +181,23 @@ signals:
     void messageContentUpdated(const QString &chatId, const QString &messageId, const QVariantMap &newContent);
     void messagesDeleted(const QString &chatId, const QVariantList &messageIds);
     void chatsReceived(const QVariantMap &chats);
+    void chatReceived(const QVariantMap &chat);
     void recentStickersUpdated(const QVariantList &stickerIds);
     void stickersReceived(const QVariantList &stickers);
     void installedStickerSetsUpdated(const QVariantList &stickerSetIds);
     void stickerSetsReceived(const QVariantList &stickerSets);
     void stickerSetReceived(const QVariantMap &stickerSet);
     void emojiSearchSuccessful(const QVariantList &result);
+    void chatMembersReceived(const QString &extra, const QVariantList &members, const int &totalMembers);
+    void userFullInfoReceived(const QVariantMap &userFullInfo);
+    void userFullInfoUpdated(const QString &userId, const QVariantMap &userFullInfo);
+    void basicGroupFullInfoReceived(const QString &groupId, const QVariantMap &groupFullInfo);
+    void supergroupFullInfoReceived(const QString &groupId, const QVariantMap &groupFullInfo);
+    void basicGroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
+    void supergroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
+    void userProfilePhotosReceived(const QString &extra, const QVariantList &photos, const int &totalPhotos);
+    void chatPermissionsUpdated(const QString &chatId, const QVariantMap &permissions);
+    void chatTitleUpdated(const QString &chatId, const QString &title);
 
 public slots:
     void handleVersionDetected(const QString &version);
@@ -193,7 +217,7 @@ public slots:
     void handleBasicGroupUpdated(qlonglong groupId, const QVariantMap &groupInformation);
     void handleSuperGroupUpdated(qlonglong groupId, const QVariantMap &groupInformation);
     void handleChatOnlineMemberCountUpdated(const QString &chatId, const int &onlineMemberCount);
-    void handleMessagesReceived(const QVariantList &messages);
+    void handleMessagesReceived(const QVariantList &messages, const int &totalCount);
     void handleNewMessageReceived(const QString &chatId, const QVariantMap &message);
     void handleMessageInformation(const QString &messageId, const QVariantMap &message);
     void handleMessageSendSucceeded(const QString &messageId, const QString &oldMessageId, const QVariantMap &message);
@@ -204,12 +228,23 @@ public slots:
     void handleMessageContentUpdated(const QString &chatId, const QString &messageId, const QVariantMap &newContent);
     void handleMessagesDeleted(const QString &chatId, const QVariantList &messageIds);
     void handleChats(const QVariantMap &chats);
+    void handleChat(const QVariantMap &chat);
     void handleRecentStickersUpdated(const QVariantList &stickerIds);
     void handleStickers(const QVariantList &stickers);
     void handleInstalledStickerSetsUpdated(const QVariantList &stickerSetIds);
     void handleStickerSets(const QVariantList &stickerSets);
     void handleStickerSet(const QVariantMap &stickerSet);
     void handleEmojiSearchCompleted(const QString &queryString, const QVariantList &resultList);
+    void handleChatMembers(const QString &extra, const QVariantList &members, const int &totalMembers);
+    void handleUserFullInfo(const QVariantMap &userFullInfo);
+    void handleUserFullInfoUpdated(const QString &userId, const QVariantMap &userFullInfo);
+    void handleBasicGroupFullInfo(const QString &groupId, const QVariantMap &groupFullInfo);
+    void handleBasicGroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
+    void handleSupergroupFullInfo(const QString &groupId, const QVariantMap &groupFullInfo);
+    void handleSupergroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
+    void handleUserProfilePhotos(const QString &extra, const QVariantList &photos, const int &totalPhotos);
+    void handleChatPermissionsUpdated(const QString &chatId, const QVariantMap permissions);
+    void handleChatTitleUpdated(const QString &chatId, const QString title);
 
 private:
     void setInitialParameters();

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation>Stummschaltung des Chats aufheben</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation>Chat stummschalten</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation>Der Einladungslink wurde in die Zwischenablage kopiert.</translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation>%1 Mitglieder, %2 online</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation>%1 Abonnenten</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation>%1 Mitglieder</translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation>Gruppe verlassen</translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation>Verlasse Gruppe</translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation>Telefonnummer</translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation>Einladungslink</translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation>Es gibt noch keinen Informationstext.</translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation>Chattitel</translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation>Geben Sie 1-126 Zeichen ein</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>You</source>
+        <translation>Sie</translation>
+    </message>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation>Lade gemeinsame Chats…</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation>Gruppen</translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation>Mitglieder</translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation>Lade Gruppenmitglieder…</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation>Einstellungen</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation>Sie</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation>Stummschaltung des Chats aufheben</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation>Chat stummschalten</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation>Benutzerinfos</translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation>Gruppeninfos</translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>Ihre Nachricht</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>war niemals online</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>offline, zuletzt online im letzten Monat</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>offline, zuletzt online in der letzten Woche</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>offline, zuletzt online: %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>online</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>offline, war neulich online</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation>Weitergeleitete Nachricht</translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation>Dieser Chat ist leer.</translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>Dokument öffnen</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation>Berechtigungen der Gruppenmitglieder</translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation>Nachrichten senden</translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation>Medien senden</translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation>Andere Nachrichten senden</translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation>Webseiten-Vorschau hinzufügen</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation>Chatinformation ändern</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation>Benutzer einladen</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation>Nachrichten anpinnen</translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation>Neue Mitglieder</translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation>Neue Mitglieder können ältere Nachrichten sehen</translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation>Langsamer Modus</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>Aus</translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation>Legen Sie fest, wie lange jedes Mitglied zwischen zwei Nachrichten warten muss</translation>
     </message>
 </context>
 <context>
@@ -340,6 +520,15 @@
     <message>
         <source>sent a venue</source>
         <translation>hat einen Ort geschickt</translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation>haben den Chattitel geändert</translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <translation>hat den Chattitel geändert</translation>
     </message>
 </context>
 <context>
@@ -468,20 +657,8 @@
         <translation>Unbekannt</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>Sie</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>Lade Chatliste...</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>Stummschaltung des Chats aufheben</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>Chat stummschalten</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation>haben diesen Chat verlassen</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation>war niemals online</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation>offline, zuletzt online im letzten Monat</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation>offline, zuletzt online in der letzten Woche</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation>offline, zuletzt online: %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation>online</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation>offline, war neulich online</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation>haben den Chattitel zu %1 geändert</translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation>hat den Chattitel zu %1 geändert</translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">habilitar notificación</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">deshabilitar notificación</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished">%1 miembros, %2 en línea</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 suscriptores</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 miembros</translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished">Ajustes</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">habilitar notificación</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">deshabilitar notificación</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>Escribir mensaje</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>nunca estuvo en línea</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>sin línea, hace en línea: hace 1 mes</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>sin línea, hace en línea: hace 1 semana</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>sin línea, hace en línea: %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>en línea</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>sin línea, estuvo en línea</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation>Mensaje reenviado</translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>Abrir Documento</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -340,6 +520,15 @@
     <message>
         <source>sent a venue</source>
         <translation>envió un lugar</translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -468,20 +657,8 @@
         <translation>desconocido</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>Usted</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>cargando lista de charla...</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>Habilitar notificación</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>Deshabilitar notificación</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation>dejé esta charla</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished">nunca estuvo en línea</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished">sin línea, hace en línea: hace 1 mes</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished">sin línea, hace en línea: hace 1 semana</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished">sin línea, hace en línea: %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished">en línea</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished">sin línea, estuvo en línea</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Poista keskustelun vaimennus</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Vaimenna keskustelu</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Tuntematon</translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished">%1 jäsentä, %2 paikalla</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 tilaajaa</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 jäsentä</translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Tuntematon</translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Sinä</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished">Asetukset</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Tuntematon</translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Sinä</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Poista keskustelun vaimennus</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Vaimenna keskustelu</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>Viestisi</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>Ei ole ollut koskaan paikalla</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>Poissa. Nähty viimeksi: viime kuussa</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>Poissa. Nähty viimeksi: viime viikolla</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>Poissa. Nähty viimeksi: %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>paikalla</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>poissa, oli hetki sitten paikalla</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>Avaa dokumentti</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -340,6 +520,15 @@
     <message>
         <source>Unsupported message: %1</source>
         <translation>Viestityyppiä ei tueta: %1</translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -468,20 +657,8 @@
         <translation>Tuntematon</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>Sinä</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>Ladataan keskustelulistaa...</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>Poista keskustelun vaimennus</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>Vaimenna keskustelu</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation>poistuit keskustelusta</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished">Ei ole ollut koskaan paikalla</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished">Poissa. Nähty viimeksi: viime kuussa</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished">Poissa. Nähty viimeksi: viime viikolla</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished">Poissa. Nähty viimeksi: %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished">paikalla</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished">poissa, oli hetki sitten paikalla</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Csevegés némítás feloldása</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Csevegés némítása</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Ismeretlen</translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished">%1 tag, %2 online</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 feliratkozott</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 tag</translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Ismeretlen</translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Te</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished">Beállítások</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Ismeretlen</translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Te</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Csevegés némítás feloldása</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Csevegés némítása</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>Üzeneted</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>soha nem volt online</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>offline, utoljára online: múlt hónapban</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>offline, utoljára online: múlt héten</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>offline, utoljára online: %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>online</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>offline, nemrégen volt online</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>Dokumentum megyitása</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -339,6 +519,15 @@
     </message>
     <message>
         <source>sent a venue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -468,20 +657,8 @@
         <translation>Ismeretlen</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>Te</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>Csevegés lista betöltése...</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>Csevegés némítás feloldása</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>Csevegés némítása</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation type="unfinished">kilépett a csevegésből</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished">soha nem volt online</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished">offline, utoljára online: múlt hónapban</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished">offline, utoljára online: múlt héten</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished">offline, utoljára online: %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished">online</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished">offline, nemrégen volt online</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Riattiva suoni chat</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Silenzia chat</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished">%1 membri, %2 online</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 abbonati</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 membri</translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Tu</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished">Impostazioni</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Tu</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Riattiva suoni chat</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Silenzia chat</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>Tuo messaggio</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>mai online</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>offline, ultimo accesso il mese scorso</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>offline, ultimo accesso la settimana scorsa</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>offline, ultimo accesso: %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>online</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>offline, online di recente</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation>Messaggio inoltrato</translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>Apri documento</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -340,6 +520,15 @@
     <message>
         <source>sent a venue</source>
         <translation>ha inviato la posizione</translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -468,20 +657,8 @@
         <translation>Sconosciuto</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>Tu</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>Carica lista chat...</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>Riattiva suoni chat</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>Silenzia chat</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation>hanno lasciato questa chat</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished">mai online</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished">offline, ultimo accesso il mese scorso</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished">offline, ultimo accesso la settimana scorsa</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished">offline, ultimo accesso: %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished">online</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished">offline, online di recente</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Wyłącz wyciszenie czatu</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Wycisz czat</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznany</translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished">$1 członków, %2 online </translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 subskrybentów</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 czlonków</translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznany</translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Ty</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished">Ustawienia</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznany</translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Ty</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Wyłącz wyciszenie czatu</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Wycisz czat</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>Twoja wiadomość</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>nigdy nie był online</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>offline, ostatnio online: w zeszłym miesiącu</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>offline, ostatnio online: w zeszłym tygodniu</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>offline, ostatnio online: %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>online</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>offline, był niedawno online</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>Otwórz dokument</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -339,6 +519,15 @@
     </message>
     <message>
         <source>sent a venue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -468,20 +657,8 @@
         <translation>Nieznany</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>Ty</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>Ładowanie listy czatu...</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>Wyłącz wyciszenie czatu</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>Wycisz czat</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation type="unfinished">opuścił ten czat</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished">nigdy nie był online</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished">offline, ostatnio online: w zeszłym miesiącu</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished">offline, ostatnio online: w zeszłym tygodniu</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished">offline, ostatnio online: %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished">online</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished">offline, był niedawno online</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Включить уведомления</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Выключить уведомления</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished">%1 участников, %2 онлайн</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 подписчиков</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 участников</translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Вы</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished">Настройки</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">Вы</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">Включить уведомления</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">Выключить уведомления</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>Ваше сообщение</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>никогда не был(а) онлайн</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>офлайн, был(а) онлайн: в прошлом месяце</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>офлайн, был(а) онлайн: на прошлой неделе</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>офлайн, был(а) онлайн: %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>онлайн</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>офлайн, недавно был(а) онлайн</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation>Пересланное сообщение</translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>Открыть документ</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -340,6 +520,15 @@
     <message>
         <source>sent a venue</source>
         <translation>отправил(а) место встречи</translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -468,20 +657,8 @@
         <translation>Неизвестный</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>Вы</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>Загрузка чатов...</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>Включить уведомления</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>Выключить уведомления</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation>покинул(а) чат</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished">никогда не был(а) онлайн</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished">офлайн, был(а) онлайн: в прошлом месяце</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished">офлайн, был(а) онлайн: на прошлой неделе</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished">офлайн, был(а) онлайн: %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished">онлайн</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished">офлайн, недавно был(а) онлайн</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">取消对话静音</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">对话静音</translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished">%1 位成员, %2 在线</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 位订阅者</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 位成员</translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">你</translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished">设置</translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished">你</translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished">取消对话静音</translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished">对话静音</translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -96,30 +228,6 @@
     <message>
         <source>Your message</source>
         <translation>你的消息</translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation>完全离线</translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation>离线，上次在线时间：上月</translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation>离线，上次在线时间：上周</translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation>离线，上次在线时间： %1</translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation>在线</translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
-        <translation>离线，最近在线</translation>
     </message>
     <message>
         <source>%1 members, %2 online</source>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -230,6 +342,74 @@
     <message>
         <source>Open Document</source>
         <translation>打开文档</translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -340,6 +520,15 @@
     <message>
         <source>sent a venue</source>
         <translation type="unfinished">发送地点</translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -468,20 +657,8 @@
         <translation>未知</translation>
     </message>
     <message>
-        <source>You</source>
-        <translation>你</translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
         <translation>正在加载对话列表……</translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation>取消静音对话</translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
-        <translation>静音对话</translation>
     </message>
     <message>
         <source>Settings</source>
@@ -717,6 +894,59 @@
         <source>left this chat</source>
         <comment>myself</comment>
         <translation>离开此对话</translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished">完全离线</translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished">离线，上次在线时间：上月</translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished">离线，上次在线时间：上周</translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished">离线，上次在线时间： %1</translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished">在线</translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished">离线，最近在线</translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -88,6 +88,138 @@
     </message>
 </context>
 <context>
+    <name>ChatInformationPage</name>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The Invite Link has been copied to the clipboard.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members, %2 online</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leave Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Leaving chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Info</source>
+        <comment>group or user infotext header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Phone Number</source>
+        <comment>user phone number header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Link</source>
+        <comment>header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>There is no information text available, yet.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Chat Title</source>
+        <comment>group title header</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter 1-128 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemMembersGroups</name>
+    <message>
+        <source>Loading common chats…</source>
+        <comment>chats you have in common with a user</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Groups</source>
+        <comment>Button: groups in common (short)</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Members</source>
+        <comment>Button: Group Members</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Loading group members…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatInformationTabItemSettings</name>
+    <message>
+        <source>Settings</source>
+        <comment>Button: Chat Settings</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ChatListViewItem</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>You</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>User Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
@@ -95,30 +227,6 @@
     </message>
     <message>
         <source>Your message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>was never online</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>offline, last online: last month</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>offline, last online: last week</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>offline, last online: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>online</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>offline, was recently online</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -177,6 +285,10 @@
         <source>Forwarded Message</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>CoverPage</name>
@@ -229,6 +341,74 @@
     </message>
     <message>
         <source>Open Document</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditGroupChatPermissionsColumn</name>
+    <message>
+        <source>Group Member Permissions</source>
+        <comment>what can normal group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Media Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Other Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New Members</source>
+        <comment>what can new group members do</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New members can see older messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditSuperGroupSlowModeColumn</name>
+    <message>
+        <source>Slow Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Set how long every chat member has to wait between Messages</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -339,6 +519,15 @@
     </message>
     <message>
         <source>sent a venue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -468,19 +657,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>You</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Loading chat list...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unmute Chat</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Mute Chat</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -716,6 +893,59 @@
     <message>
         <source>left this chat</source>
         <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>was never online</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>offline, last online: last month</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>offline, last online: last week</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>offline, last online: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>online</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>offline, was recently online</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Admin</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Banned</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Creator</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restricted</source>
+        <comment>channel user role</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
+        <comment>myself</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>changed the chat title to %1</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This PR implements a Chat Info page. Fixes #27.
It does change/add rather a lot – as I already mentioned: sorry for that. 
Missing stuff just kept piling on, but I tried to limit myself at some point so there's still quite a lot missing.
One Example: The tab view was originally planned for displaying media content alongside the members/groups list, but that would've taken even more effort, including searches in c++ which I wasn't quite comfortable implementing by myself. So I used it for group settings for now. 
I think it could make sense to move those settings into a dedicated page when/if media tabs are added at some point.

Also, I'm almost sure some bugs crept in, please be sure to tell me if something surfaces.

## Added Features
 - PullDownMenu: Has "leave chat" and "mute/unmute" MenuItems
 - Profile picture area: If scrolled up (and a picture is available), the info page shows the big version of the profile picture. It can be clicked to go to the ImagePage. If the chat type is PrivateChat and there are multiple images, they are shown in a "Carousell".
 - Chat title: If the user is a group member with the corresponding permissions, the chat title is also (otherwise it's only in the PageHeader) shown in the content area, together with a button to change the text.
 - Chat info text/user bio: If it's the user's own page or is a group member with the corresponding permissions, a button to change the text is shown.
 - If available, the phone number is shown as a link.
 - If available, the invite link is shown as a link with a button to copy it.
 - Tab view: On the bottom of the page, a tabbed view for further stuff is added. For groups, the members are displayed in a list. For users, a list of common groups is shown. If the current user has certain permissions, a second tab item is shown to set group chat permissions, chat history visibility and slow mode (is that even supported in the ChatPage?). I also "left in" (commented out) a debug pane to quickly take a look at some values.

## Changed Things
 - The ListItems from the OverviewPage are now in a separate qml file to enable re-use.
 - ProfileThumbnail has minor changes to enable non-changing radius for different dimensions.
 - functions.js updateChatPartnerStatusText was moved here. Also, support for messageChatChangeTitle was added.
 - ChatListModel: To easily filter the lists from qml, a get(int row) method (like in listModel) was added.
 - ChatModel: messagesReceived signal was changed to include the total count. beginResetModel/endResetModel was added to initialize() to propagate changes to qml (visible with empty/new chats)
 - TDLibReceiver: messagesReceived signal was changed to include the total count. Also, a whole bunch of td-methods/signals were added.
 - TDLibWrapper: messagesReceived signal was changed to include the total count. Obviously loads of methods/signals were added here, as well.