### PR TITLE
implement "mark all messages as read" MenuItem

### DIFF
--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -26,6 +26,14 @@ PhotoTextsListItem {
     openMenuOnPressAndHold: true//chat_id != overviewPage.ownUserId
     menu: ContextMenu {
         MenuItem {
+            visible: unread_count > 0
+            onClicked: {
+                tdLibWrapper.viewMessage(chat_id, display.last_message.id, true);
+            }
+            text: qsTr("Mark all messages as read")
+        }
+
+        MenuItem {
             visible: chat_id != listItem.ownUserId
             onClicked: {
                 var newNotificationSettings = display.notification_settings;

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -290,7 +290,7 @@ Page {
             chatPage.loading = false;
             if (chatView.height > chatView.contentHeight) {
                 console.log("[ChatPage] Chat content quite small...");
-                tdLibWrapper.viewMessage(chatInformation.id, chatModel.getMessage(chatView.count - 1).id);
+                tdLibWrapper.viewMessage(chatInformation.id, chatModel.getMessage(chatView.count - 1).id, false);
             }
         }
         onNewMessageReceived: {
@@ -498,7 +498,7 @@ Page {
 
                     function handleScrollPositionChanged() {
                         console.log("Current position: " + chatView.contentY);
-                        tdLibWrapper.viewMessage(chatInformation.id, chatView.itemAt(chatView.contentX, ( chatView.contentY + chatView.height - Theme.horizontalPageMargin )).myMessage.id);
+                        tdLibWrapper.viewMessage(chatInformation.id, chatView.itemAt(chatView.contentX, ( chatView.contentY + chatView.height - Theme.horizontalPageMargin )).myMessage.id, false);
                     }
 
                     onContentYChanged: {

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -258,13 +258,13 @@ void TDLibWrapper::getChatHistory(const QString &chatId, const qlonglong &fromMe
     this->sendRequest(requestObject);
 }
 
-void TDLibWrapper::viewMessage(const QString &chatId, const QString &messageId)
+void TDLibWrapper::viewMessage(const QString &chatId, const QString &messageId, const bool &force = false)
 {
     LOG("Mark message as viewed" << chatId << messageId);
     QVariantMap requestObject;
     requestObject.insert(_TYPE, "viewMessages");
     requestObject.insert("chat_id", chatId);
-    requestObject.insert("force_read", false);
+    requestObject.insert("force_read", force);
     QVariantList messageIds;
     messageIds.append(messageId);
     requestObject.insert("message_ids", messageIds);

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -115,7 +115,7 @@ public:
     Q_INVOKABLE void closeChat(const QString &chatId);
     Q_INVOKABLE void leaveChat(const QString &chatId);
     Q_INVOKABLE void getChatHistory(const QString &chatId, const qlonglong &fromMessageId = 0, const int &offset = 0, const int &limit = 50, const bool &onlyLocal = false);
-    Q_INVOKABLE void viewMessage(const QString &chatId, const QString &messageId);
+    Q_INVOKABLE void viewMessage(const QString &chatId, const QString &messageId, const bool &force);
     Q_INVOKABLE void sendTextMessage(const QString &chatId, const QString &message, const QString &replyToMessageId = "0");
     Q_INVOKABLE void sendPhotoMessage(const QString &chatId, const QString &filePath, const QString &message, const QString &replyToMessageId = "0");
     Q_INVOKABLE void sendVideoMessage(const QString &chatId, const QString &filePath, const QString &message, const QString &replyToMessageId = "0");

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation>Gruppeninfos</translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation>Nachrichten als gelesen markieren</translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -226,6 +226,10 @@
         <source>Group Info</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Mark all messages as read</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>


### PR DESCRIPTION
Contributes to #70 
Adds a simple forced "ViewMessage" entry for chats with unread messages.

Because the Title of #70 implies it: This doesn't mark anything as unread, though, and does not use toggleChatIsMarkedAsUnread at all.