### PR TITLE
Notifications

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -136,27 +136,27 @@ void NotificationManager::handleChatDiscovered(const QString &chatId, const QVar
     this->chatMap.insert(chatId, chatInformation);
 }
 
-void NotificationManager::handleNgfConnectionStatus(const bool &connected)
+void NotificationManager::handleNgfConnectionStatus(bool connected)
 {
     LOG("NGF Daemon connection status changed" << connected);
 }
 
-void NotificationManager::handleNgfEventFailed(const quint32 &eventId)
+void NotificationManager::handleNgfEventFailed(quint32 eventId)
 {
     LOG("NGF event failed, id:" << eventId);
 }
 
-void NotificationManager::handleNgfEventCompleted(const quint32 &eventId)
+void NotificationManager::handleNgfEventCompleted(quint32 eventId)
 {
     LOG("NGF event completed, id:" << eventId);
 }
 
-void NotificationManager::handleNgfEventPlaying(const quint32 &eventId)
+void NotificationManager::handleNgfEventPlaying(quint32 eventId)
 {
     LOG("NGF event playing, id:" << eventId);
 }
 
-void NotificationManager::handleNgfEventPaused(const quint32 &eventId)
+void NotificationManager::handleNgfEventPaused(quint32 eventId)
 {
     LOG("NGF event paused, id:" << eventId);
 }
@@ -232,7 +232,7 @@ QString NotificationManager::getNotificationText(const QVariantMap &notification
     return FernschreiberUtils::getMessageShortText(notificationContent, false);
 }
 
-void NotificationManager::controlLedNotification(const bool &enabled)
+void NotificationManager::controlLedNotification(bool enabled)
 {
     static const QString PATTERN("PatternCommunicationIM");
     static const QString ACTIVATE("req_led_pattern_activate");

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -22,6 +22,7 @@
 
 #include <QObject>
 #include <QDBusInterface>
+#include <nemonotifications-qt5/notification.h>
 #include <ngf-qt5/NgfClient>
 #include "tdlibwrapper.h"
 #include "appsettings.h"
@@ -29,18 +30,21 @@
 class NotificationManager : public QObject
 {
     Q_OBJECT
+    class ChatInfo;
+    class NotificationGroup;
+
 public:
+
     NotificationManager(TDLibWrapper *tdLibWrapper, AppSettings *appSettings);
     ~NotificationManager() override;
 
-signals:
-
 public slots:
 
-    void handleUpdateActiveNotifications(const QVariantList notificationGroups);
-    void handleUpdateNotificationGroup(const QVariantMap notificationGroupUpdate);
-    void handleUpdateNotification(const QVariantMap updatedNotification);
+    void handleUpdateActiveNotifications(const QVariantList &notificationGroups);
+    void handleUpdateNotificationGroup(const QVariantMap &notificationGroupUpdate);
+    void handleUpdateNotification(const QVariantMap &updatedNotification);
     void handleChatDiscovered(const QString &chatId, const QVariantMap &chatInformation);
+    void handleChatTitleUpdated(const QString &chatId, const QString &title);
     void handleNgfConnectionStatus(bool connected);
     void handleNgfEventFailed(quint32 eventId);
     void handleNgfEventCompleted(quint32 eventId);
@@ -49,18 +53,21 @@ public slots:
 
 private:
 
-    QVariantMap sendNotification(const QString &chatId, const QVariantMap &notificationInformation, const QVariantMap &activeNotifications);
-    void removeNotification(const QVariantMap &notificationInformation);
+    void publishNotification(const NotificationGroup *notificationGroup, bool needFeedback);
     QString getNotificationText(const QVariantMap &notificationContent);
     void controlLedNotification(bool enabled);
+    void updateNotificationGroup(int groupId, qlonglong chatId, int totalCount,
+        const QVariantList &addedNotifications,
+        const QVariantList &removedNotificationIds = QVariantList(),
+        AppSettings::NotificationFeedback feedback = AppSettings::NotificationFeedbackNone);
 
 private:
 
     TDLibWrapper *tdLibWrapper;
     AppSettings *appSettings;
     Ngf::Client *ngfClient;
-    QVariantMap chatMap;
-    QVariantMap notificationGroups;
+    QMap<qlonglong,ChatInfo*> chatMap;
+    QMap<int,NotificationGroup*> notificationGroups;
     QDBusInterface mceInterface;
     QString appIconFile;
 

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -41,18 +41,18 @@ public slots:
     void handleUpdateNotificationGroup(const QVariantMap notificationGroupUpdate);
     void handleUpdateNotification(const QVariantMap updatedNotification);
     void handleChatDiscovered(const QString &chatId, const QVariantMap &chatInformation);
-    void handleNgfConnectionStatus(const bool &connected);
-    void handleNgfEventFailed(const quint32 &eventId);
-    void handleNgfEventCompleted(const quint32 &eventId);
-    void handleNgfEventPlaying(const quint32 &eventId);
-    void handleNgfEventPaused(const quint32 &eventId);
+    void handleNgfConnectionStatus(bool connected);
+    void handleNgfEventFailed(quint32 eventId);
+    void handleNgfEventCompleted(quint32 eventId);
+    void handleNgfEventPlaying(quint32 eventId);
+    void handleNgfEventPaused(quint32 eventId);
 
 private:
 
     QVariantMap sendNotification(const QString &chatId, const QVariantMap &notificationInformation, const QVariantMap &activeNotifications);
     void removeNotification(const QVariantMap &notificationInformation);
     QString getNotificationText(const QVariantMap &notificationContent);
-    void controlLedNotification(const bool &enabled);
+    void controlLedNotification(bool enabled);
 
 private:
 

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -62,6 +62,7 @@ private:
     QVariantMap chatMap;
     QVariantMap notificationGroups;
     QDBusInterface mceInterface;
+    QString appIconFile;
 
 };
 


### PR DESCRIPTION
I noticed bzzzz when a group was being marked as read by another client (even though I had "Only new events" selected in the settings), and in the process of fixing that, made a bunch of other changes.

Summary:

1. Don't post unwanted feedback for removed notifications
2. Don't turn off PatternCommunicationIM pattern when some (but not all) notifications are removed
3. Don't keep empty notification groups in notificationGroups map
4. Pre-allocate commonly used QStrings
5. Don't pass primitive types by const references to NotificationManager
6. Use const objects when appropriate to make sure that they don't get unnecessarily detached (i.e. duplicated)

I tried to split unrelated changes into different commits.