### PR TITLE
Fix two issues in PollPreview

### DIFF
--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -102,10 +102,11 @@ Item {
             id: canAnswerDelegate
             TextSwitch {
                 id: optionDelegate
+                // TextSwitch changes the html base path:
+                property url emojiBase: "../js/emoji/"
                 width: pollMessageComponent.width
                 automaticCheck: false
-                // emojify does not work here :/
-                text: modelData.text
+                text: Emoji.emojify(modelData.text, Theme.fontSizeMedium, emojiBase)
                 checked: pollMessageComponent.chosenIndexes.indexOf(index) > -1
                 onClicked: {
                     pollMessageComponent.handleChoose(index);
@@ -263,6 +264,7 @@ Item {
     Component {
         id: closePollMenuItemComponent
         MenuItem {
+            visible: !pollData.is_closed && pollMessageComponent.canEdit
             text: qsTr("Close Poll")
             onClicked: {
                 tdLibWrapper.stopPoll(pollMessageComponent.chatId, pollMessageComponent.messageId);
@@ -272,6 +274,7 @@ Item {
     Component {
         id: resetAnswerMenuItemComponent
         MenuItem {
+            visible: !pollData.is_closed && !pollMessageComponent.isQuiz && pollMessageComponent.hasAnswered
             text: qsTr("Reset Answer")
             onClicked: {
                 pollMessageComponent.resetChosen()
@@ -282,12 +285,8 @@ Item {
     Component.onCompleted: {
         opacity = 1;
         if(messageItem && messageItem.menu ) { // workaround to add menu entries
-            if(!pollData.is_closed && pollMessageComponent.canEdit) {
-                closePollMenuItemComponent.createObject(messageItem.menu._contentColumn);
-            }
-            if(!pollData.is_closed && !pollMessageComponent.isQuiz && pollMessageComponent.hasAnswered) {
-                resetAnswerMenuItemComponent.createObject(messageItem.menu._contentColumn);
-            }
+            closePollMenuItemComponent.createObject(messageItem.menu._contentColumn);
+            resetAnswerMenuItemComponent.createObject(messageItem.menu._contentColumn);
         }
     }
 }


### PR DESCRIPTION
 - The new emoji basePath workaround also works for TextSwitch content.
 - Checking which context menu entries get added for the poll preview didn't quite work nicely "OnCompleted".