### PR TITLE
Reduce ChatPage.qml jit compile time

### DIFF
--- a/qml/components/AudioPreview.qml
+++ b/qml/components/AudioPreview.qml
@@ -24,15 +24,18 @@ import "../js/functions.js" as Functions
 Item {
     id: audioMessageComponent
 
-    property variant audioData;
+    property ListItem messageListItem
+    property variant rawMessage: messageListItem.myMessage
+
+    property variant audioData: ( rawMessage.content['@type'] === "messageVoiceNote" ) ?  rawMessage.content.voice_note : ( ( rawMessage.content['@type'] === "messageAudio" ) ? rawMessage.content.audio : "");
     property string audioUrl;
     property int previewFileId;
     property int audioFileId;
-    property bool onScreen;
+    property bool onScreen: messageListItem.page.status === PageStatus.Active
     property string audioType : "voiceNote";
 
     width: parent.width
-    height: parent.height
+    height: width / 2
 
     function getTimeString(rawSeconds) {
         var minutes = Math.floor( rawSeconds / 60 );

--- a/qml/components/DocumentPreview.qml
+++ b/qml/components/DocumentPreview.qml
@@ -26,7 +26,10 @@ Item {
     width: parent.width
     height: Theme.itemSizeLarge
 
-    property variant documentData;
+    property ListItem messageListItem
+    property variant rawMessage: messageListItem.myMessage
+
+    property variant documentData: rawMessage.content.document
     property bool openRequested: false;
 
     Component.onCompleted: {

--- a/qml/components/ImagePreview.qml
+++ b/qml/components/ImagePreview.qml
@@ -24,8 +24,13 @@ Item {
 
     id: imagePreviewItem
 
-    property variant photoData;
+    property ListItem messageListItem
+    property variant rawMessage: messageListItem.myMessage
+    property variant photoData: rawMessage.content.photo;
     property variant pictureFileInformation;
+
+    width: parent.width
+    height: width * 2 / 3
 
     Component.onCompleted: {
         updatePicture();

--- a/qml/components/LocationPreview.qml
+++ b/qml/components/LocationPreview.qml
@@ -23,9 +23,16 @@ import Sailfish.Silica 1.0
 Item {
 
     id: imagePreviewItem
-    property variant locationData;
-    property int chatId;
+
+    property ListItem messageListItem
+    property variant rawMessage: messageListItem.myMessage
+
+    property variant locationData : ( rawMessage.content['@type'] === "messageLocation" ) ?  rawMessage.content.location : ( ( rawMessage.content['@type'] === "messageVenue" ) ? rawMessage.content.venue.location : "" )
+
+    property string chatId: messageListItem.page.chatInformation.id
     property variant pictureFileInformation;
+    width: parent.width
+    height: width / 2
 
     Component.onCompleted: {
         updatePicture();

--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -27,13 +27,16 @@ import "../js/twemoji.js" as Emoji
 Item {
     id: pollMessageComponent
 
-    property string chatId
-    property var message:({})
-    property bool isOwnMessage
 
-    property string messageId: message.id
-    property bool canEdit: message.can_be_edited
-    property var pollData: message.content.poll
+    property ListItem messageListItem
+    property variant rawMessage: messageListItem.myMessage
+    property string chatId: messageListItem.page.chatInformation.id
+
+    property bool isOwnMessage: messageListItem.isOwnMessage
+
+    property string messageId: rawMessage.id
+    property bool canEdit: rawMessage.can_be_edited
+    property var pollData: rawMessage.content.poll
     property var chosenPollData:({})
     property var chosenIndexes: []
     property bool hasAnswered: {
@@ -43,7 +46,7 @@ Item {
     }
     property bool canAnswer: !hasAnswered && !pollData.is_closed
     property bool isQuiz: pollData.type['@type'] === "pollTypeQuiz"
-    property Item messageItem
+    width: parent.width
     height: pollColumn.height
     opacity: 0
     Behavior on opacity { FadeAnimation {} }
@@ -286,9 +289,9 @@ Item {
 
     Component.onCompleted: {
         opacity = 1;
-        if(messageItem && messageItem.menu ) { // workaround to add menu entries
-            closePollMenuItemComponent.createObject(messageItem.menu._contentColumn);
-            resetAnswerMenuItemComponent.createObject(messageItem.menu._contentColumn);
+        if(messageListItem && messageListItem.menu ) { // workaround to add menu entries
+            closePollMenuItemComponent.createObject(messageListItem.menu._contentColumn);
+            resetAnswerMenuItemComponent.createObject(messageListItem.menu._contentColumn);
         }
     }
 }

--- a/qml/components/StickerPreview.qml
+++ b/qml/components/StickerPreview.qml
@@ -20,7 +20,11 @@ import QtQuick 2.5
 import Sailfish.Silica 1.0
 
 Item {
-    property variant stickerData;
+
+    property ListItem messageListItem
+    property variant rawMessage: messageListItem.myMessage
+
+    property variant stickerData: rawMessage.content.sticker;
     property int usedFileId;
 
     width: stickerData.width

--- a/qml/components/VideoPreview.qml
+++ b/qml/components/VideoPreview.qml
@@ -24,17 +24,20 @@ import "../js/functions.js" as Functions
 Item {
     id: videoMessageComponent
 
-    property variant videoData;
+    property ListItem messageListItem
+    property variant rawMessage: messageListItem.myMessage
+
+    property variant videoData:  ( rawMessage.content['@type'] === "messageVideo" ) ?  rawMessage.content.video : ( ( rawMessage.content['@type'] === "messageAnimation" ) ? rawMessage.content.animation : "")
     property string videoUrl;
     property int previewFileId;
     property int videoFileId;
     property bool fullscreen : false;
-    property bool onScreen;
+    property bool onScreen: messageListItem.page.status === PageStatus.Active;
     property string videoType : "video";
     property bool playRequested: false;
 
     width: parent.width
-    height: parent.height
+    height: Functions.getVideoHeight(width, videoData)
 
     Timer {
         id: screensaverTimer

--- a/qml/harbour-fernschreiber.qml
+++ b/qml/harbour-fernschreiber.qml
@@ -28,10 +28,6 @@ ApplicationWindow
     cover: Qt.resolvedUrl("pages/CoverPage.qml")
     allowedOrientations: defaultAllowedOrientations
 
-    RemorseItem {
-        id: deleteMessageRemorseItem
-    }
-
     Connections {
         target: dBusAdaptor
         onPleaseOpenMessage: {

--- a/qml/harbour-fernschreiber.qml
+++ b/qml/harbour-fernschreiber.qml
@@ -28,6 +28,10 @@ ApplicationWindow
     cover: Qt.resolvedUrl("pages/CoverPage.qml")
     allowedOrientations: defaultAllowedOrientations
 
+    RemorseItem {
+        id: deleteMessageRemorseItem
+    }
+
     Connections {
         target: dBusAdaptor
         onPleaseOpenMessage: {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1002,7 +1002,7 @@ Page {
                                 attachmentOptionsRow.visible = false;
                                 console.log("Selected document: " + picker.selectedContentProperties.filePath );
                                 attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
-                                attachmentPreviewRow.isDocument = true;
+                                attachmentPreviewRow.isPicture = true;
                                 attachmentPreviewRow.visible = true;
                                 controlSendButton();
                             })
@@ -1027,7 +1027,7 @@ Page {
                         id: documentAttachmentButton
                         icon.source: "image://theme/icon-m-document"
                         onClicked: {
-                            var picker = pageStack.push("Sailfish.Pickers.DocumentPicker");
+                            var picker = pageStack.push("Sailfish.Pickers.DocumentPickerPage");
                             picker.selectedContentPropertiesChanged.connect(function(){
                                 attachmentOptionsRow.visible = false;
                                 console.log("Selected document: " + picker.selectedContentProperties.filePath );

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -282,10 +282,6 @@
         <translation>bearbeitet</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Lösche Nachricht</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Nachricht löschen</translation>
     </message>
@@ -300,6 +296,10 @@
     <message>
         <source>This chat is empty.</source>
         <translation>Dieser Chat ist leer.</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation>Nachricht gelöscht</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -282,10 +282,6 @@
         <translation>editado</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Borrando mensaje</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Borrar</translation>
     </message>
@@ -300,6 +296,10 @@
     <message>
         <source>This chat is empty.</source>
         <translation>Esta charla está vacía.</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -282,10 +282,6 @@
         <translation>muokattu</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Poistetaan viestiä</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Poista viesti</translation>
     </message>
@@ -300,6 +296,10 @@
     <message>
         <source>This chat is empty.</source>
         <translation>Tämä keskustelu on tyhjä.</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -282,10 +282,6 @@
         <translation>Szerkesztett</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Üzenet törlése</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Üzenet törlése</translation>
     </message>
@@ -299,6 +295,10 @@
     </message>
     <message>
         <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -278,10 +278,6 @@
         <translation>modificato</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Cancellazione del messaggio</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Cancella messaggio</translation>
     </message>
@@ -300,6 +296,10 @@
     <message>
         <source>Uploading...</source>
         <translation>Carica...</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -282,10 +282,6 @@
         <translation>edytowana</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Usuwanie wiadomości</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Usuń wiadomość</translation>
     </message>
@@ -299,6 +295,10 @@
     </message>
     <message>
         <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -282,10 +282,6 @@
         <translation>изменено</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Удаление сообщения</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Удалить</translation>
     </message>
@@ -299,6 +295,10 @@
     </message>
     <message>
         <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -282,10 +282,6 @@
         <translation>redigerade</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>Tar bort meddelande</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>Ta bort meddelandet</translation>
     </message>
@@ -300,6 +296,10 @@
     <message>
         <source>This chat is empty.</source>
         <translation>Denna chatt är tom.</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -282,10 +282,6 @@
         <translation>已编辑</translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation>正在删除消息</translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation>删除消息</translation>
     </message>
@@ -299,6 +295,10 @@
     </message>
     <message>
         <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -282,10 +282,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Deleting message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Delete Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -299,6 +295,10 @@
     </message>
     <message>
         <source>This chat is empty.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
First of all: Take all measurements I mention with a grain of salt – all of them are rough and not necessarily measured more than a few times. All times were measured on an Xperia X run via SDK.

Visiting a chat page can take a long time, especially before the qml is cached by the engine.
When opening it for the first time after application launch, it sometimes takes >1000ms from onClicked (OverviewPage) to Component.OnCompleted (Chatpage).
Subsequent activations take roughly 470-480ms.

With these changes, I was able to reduce these times to ~450ms for the first, ~100ms for subsequent activations of the ChatPage on my test device.

There are some run-time optimizations possible (some of which I possibly created with this), I did not focus on those at all.

Things changed:
- The components for displaying extra content to a message are (mostly) gone and replaced by a single Loader. This Loader does not use sourceComponent to trade the initial compilation boost for a neglegible bit of runtime penalty.
- Connections were consolidated
- I was surprised how costly the inclusion of the RemorseItem was (compiling ~75ms, initializing up to ~20ms for every delegate). So I traded a bit for a compromise. deleteMessageRemorseItem is now defined on the appWindow level, where it gets a bit mitigated by the animations at application start. Also, only one deletion at a time is now possible. We can easily revert this change, but I thought it worthwhile despite its drawbacks.
- profileThumbnailComponent is now defined directly as sourceComponent, removing the need for its id. Probably didn't do anything.
- InReplyToRow had width: parent.width, so I removed horizontalCenter. Also probably didn't change compilation time at all.
- Another compromise I was willing to take – your opinion may differ: The PickerPages took ages (~200ms) to just parse/compile inside those Components, so I replaced them with the "string notation" of pageStack.push. Drawback: The first time a picker gets activated, you'll see how slow it is. Subsequent activations aren't that bad – also for the other pickers.