### PR TITLE
Copy messages to clipboard

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -557,6 +557,12 @@ Page {
                             }
                             MenuItem {
                                 onClicked: {
+                                    Clipboard.text = messageText.text
+                                }
+                                text: qsTr("Copy Message to Clipboard")
+                            }
+                            MenuItem {
+                                onClicked: {
                                     deleteMessageRemorseItem.execute(messageListItem, qsTr("Deleting message"), function() { tdLibWrapper.deleteMessages(chatInformation.id, [ display.id ]); } );
                                 }
                                 text: qsTr("Delete Message")

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -278,6 +278,10 @@
         <translation>Nachricht bearbeiten</translation>
     </message>
     <message>
+        <source>Copy Message to Clipboard</source>
+        <translation>Nachricht in die Zwischenablage kopieren</translation>
+    </message>
+    <message>
         <source>edited</source>
         <translation>bearbeitet</translation>
     </message>


### PR DESCRIPTION
This PR adds an item to the message context menu allowing to copy the whole message to the clipboard.
This partially resolves #15 