### PR TITLE
Remove clipboard workaround

### DIFF
--- a/qml/pages/ChatInformationPage.qml
+++ b/qml/pages/ChatInformationPage.qml
@@ -400,19 +400,8 @@ Page {
                         icon.source: "image://theme/icon-m-clipboard"
                         anchors.verticalCenter: inviteLinkItem.verticalCenter
                         onClicked: {
-                            inviteLinkField.selectAll();
-                            inviteLinkField.copy();
-                            inviteLinkField.select(0,0);
+                            Clipboard.text = groupFullInformation.invite_link
                             infoNotification.show(qsTr("The Invite Link has been copied to the clipboard."));
-                        }
-                        TextField {
-                            id: inviteLinkField
-                            width: 0
-                            height: 0
-                            text: groupFullInformation.invite_link ? groupFullInformation.invite_link : ""
-                            visible: false
-                            readOnly: true
-                            opacity: 0
                         }
                     }
                 }


### PR DESCRIPTION
Turns out, I somehow forgot about the Clipboard type while implementing the info page. 
Thanks @chstem