### PR TITLE
clean up qml imports

### DIFF
--- a/qml/components/AppNotification.qml
+++ b/qml/components/AppNotification.qml
@@ -17,7 +17,6 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.6
-import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 
 Item {

--- a/qml/components/AppNotification.qml
+++ b/qml/components/AppNotification.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 

--- a/qml/components/AppNotificationItem.qml
+++ b/qml/components/AppNotificationItem.qml
@@ -17,7 +17,6 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.6
-import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 
 Item {

--- a/qml/components/AppNotificationItem.qml
+++ b/qml/components/AppNotificationItem.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 

--- a/qml/components/AudioPreview.qml
+++ b/qml/components/AudioPreview.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import "../js/functions.js" as Functions
 
 Item {

--- a/qml/components/AudioPreview.qml
+++ b/qml/components/AudioPreview.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtMultimedia 5.0
 import "../js/functions.js" as Functions

--- a/qml/components/BackgroundImage.qml
+++ b/qml/components/BackgroundImage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 
 Image {

--- a/qml/components/BackgroundProgressIndicator.qml
+++ b/qml/components/BackgroundProgressIndicator.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 
 Item {

--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.5
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 
 import "../js/twemoji.js" as Emoji

--- a/qml/components/DocumentPreview.qml
+++ b/qml/components/DocumentPreview.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 

--- a/qml/components/DocumentPreview.qml
+++ b/qml/components/DocumentPreview.qml
@@ -17,7 +17,6 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.6
-import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 
 Item {

--- a/qml/components/ImagePreview.qml
+++ b/qml/components/ImagePreview.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 

--- a/qml/components/ImagePreview.qml
+++ b/qml/components/ImagePreview.qml
@@ -17,7 +17,6 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.6
-import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 
 Item {

--- a/qml/components/InReplyToRow.qml
+++ b/qml/components/InReplyToRow.qml
@@ -18,7 +18,6 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji

--- a/qml/components/InReplyToRow.qml
+++ b/qml/components/InReplyToRow.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji

--- a/qml/components/InReplyToRow.qml
+++ b/qml/components/InReplyToRow.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtMultimedia 5.0
 import "../components"

--- a/qml/components/LocationPreview.qml
+++ b/qml/components/LocationPreview.qml
@@ -16,7 +16,7 @@
      You should have received a copy of the GNU General Public License
      along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
  */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 

--- a/qml/components/PhotoTextsListItem.qml
+++ b/qml/components/PhotoTextsListItem.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.5
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 ListItem {
 

--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -17,7 +17,7 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtGraphicalEffects 1.0
 

--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -19,7 +19,6 @@
 
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtGraphicalEffects 1.0
 
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji

--- a/qml/components/ProfileThumbnail.qml
+++ b/qml/components/ProfileThumbnail.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 

--- a/qml/components/StickerPicker.qml
+++ b/qml/components/StickerPicker.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import QtGraphicalEffects 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import Sailfish.Silica 1.0
 import "../components"
 import "../js/twemoji.js" as Emoji

--- a/qml/components/StickerPicker.qml
+++ b/qml/components/StickerPicker.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import QtMultimedia 5.0
 import Sailfish.Silica 1.0

--- a/qml/components/StickerPicker.qml
+++ b/qml/components/StickerPicker.qml
@@ -17,8 +17,6 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.6
-import QtGraphicalEffects 1.0
-import QtMultimedia 5.6
 import Sailfish.Silica 1.0
 import "../components"
 import "../js/twemoji.js" as Emoji

--- a/qml/components/StickerPreview.qml
+++ b/qml/components/StickerPreview.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 
 Item {

--- a/qml/components/VideoPreview.qml
+++ b/qml/components/VideoPreview.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import "../js/functions.js" as Functions
 
 Item {

--- a/qml/components/VideoPreview.qml
+++ b/qml/components/VideoPreview.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtMultimedia 5.0
 import "../js/functions.js" as Functions

--- a/qml/components/WebPagePreview.qml
+++ b/qml/components/WebPagePreview.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import Sailfish.Silica 1.0
 import "../components"

--- a/qml/harbour-fernschreiber.qml
+++ b/qml/harbour-fernschreiber.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import "pages"
 

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import "../components"
 import "../js/twemoji.js" as Emoji

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -17,8 +17,6 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.6
-import QtGraphicalEffects 1.0
-import QtMultimedia 5.6
 import Sailfish.Silica 1.0
 import Sailfish.Pickers 1.0
 import Nemo.Thumbnailer 1.0

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import QtMultimedia 5.0
 import Sailfish.Silica 1.0

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import QtGraphicalEffects 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import Sailfish.Silica 1.0
 import Sailfish.Pickers 1.0
 import Nemo.Thumbnailer 1.0

--- a/qml/pages/CoverPage.qml
+++ b/qml/pages/CoverPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import WerkWolf.Fernschreiber 1.0
 import "../components"

--- a/qml/pages/ImagePage.qml
+++ b/qml/pages/ImagePage.qml
@@ -18,7 +18,6 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 

--- a/qml/pages/ImagePage.qml
+++ b/qml/pages/ImagePage.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 

--- a/qml/pages/ImagePage.qml
+++ b/qml/pages/ImagePage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtMultimedia 5.0
 import "../components"

--- a/qml/pages/InitializationPage.qml
+++ b/qml/pages/InitializationPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import WerkWolf.Fernschreiber 1.0
 

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import QtGraphicalEffects 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import Sailfish.Silica 1.0
 import Nemo.Notifications 1.0
 import WerkWolf.Fernschreiber 1.0

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -17,8 +17,6 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.6
-import QtGraphicalEffects 1.0
-import QtMultimedia 5.6
 import Sailfish.Silica 1.0
 import Nemo.Notifications 1.0
 import WerkWolf.Fernschreiber 1.0

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.5
+import QtQuick 2.6
 import QtGraphicalEffects 1.0
 import QtMultimedia 5.0
 import Sailfish.Silica 1.0

--- a/qml/pages/PollCreationPage.qml
+++ b/qml/pages/PollCreationPage.qml
@@ -18,7 +18,6 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji

--- a/qml/pages/PollCreationPage.qml
+++ b/qml/pages/PollCreationPage.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji

--- a/qml/pages/PollResultsPage.qml
+++ b/qml/pages/PollResultsPage.qml
@@ -18,7 +18,6 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji

--- a/qml/pages/PollResultsPage.qml
+++ b/qml/pages/PollResultsPage.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import WerkWolf.Fernschreiber 1.0
 import "../js/functions.js" as Functions

--- a/qml/pages/VideoPage.qml
+++ b/qml/pages/VideoPage.qml
@@ -18,7 +18,7 @@
 */
 import QtQuick 2.6
 import Sailfish.Silica 1.0
-import QtMultimedia 5.0
+import QtMultimedia 5.6
 import "../components"
 import "../js/functions.js" as Functions
 

--- a/qml/pages/VideoPage.qml
+++ b/qml/pages/VideoPage.qml
@@ -16,7 +16,7 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.0
+import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtMultimedia 5.0
 import "../components"


### PR DESCRIPTION
This changes "old" imports from QtQuick (newest supported is 2.6) and QtMultimedia (newest 5.6).
Also removes QtMultimedia & QtGraphicalEffects from some qml files where I could not identify usage.