### PR TITLE
Fix crash in ChatModel

### DIFF
--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -83,7 +83,7 @@ void ChatModel::initialize(const QVariantMap &chatInformation)
 
 void ChatModel::triggerLoadMoreHistory()
 {
-    if (!this->inIncrementalUpdate) {
+    if (!this->inIncrementalUpdate && !messages.isEmpty()) {
         qDebug() << "[ChatModel] Trigger loading older history...";
         this->inIncrementalUpdate = true;
         this->tdLibWrapper->getChatHistory(this->chatId, this->messages.first().toMap().value("id").toLongLong());


### PR DESCRIPTION
`QList::first()` panics if the list is empty:
```
Program terminated with signal SIGABRT, Aborted.
#0  __libc_do_syscall () at ../sysdeps/unix/sysv/linux/arm/libc-do-syscall.S:47
47		pop	{r7, pc}
[Current thread is 1 (Thread 0xec14f700 (LWP 15707))]
(gdb) bt
#0  __libc_do_syscall () at libc-do-syscall.S:47
#1  0xeeab0bda in __libc_signal_restore_set (set=0xffe64414) at internal-signals.h:84
#2  __GI_raise (sig=6) at raise.c:48
#3  0xeea9a7b2 in __GI_abort () at abort.c:79
#4  0xeedeb7a8 in qt_message_fatal (context=..., message=<synthetic pointer>...) at qlogging.cpp:1649
#5  QMessageLogger::fatal (this=0xffe64670, msg=0xeef9e3bc "ASSERT: \"%s\" in file %s, line %d") at qlogging.cpp:790
#6  0xeedf6d16 in qt_assert (assertion=<optimized out>, file=<optimized out>, line=<optimized out>) at qlogging.h:85
#7  0x08641554 in QList<QVariant>::first (this=0xffe6a334) at qlist.h:335
#8  0x0863e42a in ChatModel::triggerLoadMoreHistory (this=0xffe6a328) at chatmodel.cpp:89
#9  0x0865fe48 in ChatModel::qt_static_metacall (_o=0xffe6a328, _c=QMetaObject::InvokeMetaMethod, _id=17, _a=0xffe64878) at moc_chatmodel.cpp:186
#10 0x08660300 in ChatModel::qt_metacall (this=0xffe6a328, _c=QMetaObject::InvokeMetaMethod, _id=17, _a=0xffe64878) at moc_chatmodel.cpp:281
#11 0xef3af3d6 in QQmlObjectOrGadget::metacall (this=0xffe64ad0, type=QMetaObject::InvokeMetaMethod, index=<optimized out>, index=72, argv=0xffe64878) at qflagpointer_p.h:323
#12 0xef359850 in CallMethod (object=..., index=72, returnType=43, argCount=0, argTypes=0x0, engine=0x8b8ce88, callArgs=0xe9001970) at qv4qobjectwrapper.cpp:1156
#13 0xef35aa4c in CallPrecise (object=..., data=..., engine=0x8b8ce88, callArgs=0xe9001970) at qv4qobjectwrapper.cpp:1393
#14 0xef35afb6 in QV4::QObjectMethod::callInternal (this=<optimized out>, callData=0xe9001970) at qv4qobjectwrapper.cpp:1871
#15 0xef36b994 in QV4::Object::call (d=<optimized out>, this=<optimized out>) at qv4heap_p.h:90
#16 QV4::Runtime::callProperty (engine=0x8b8ce88, nameIndex=<optimized out>, callData=<optimized out>) at qv4runtime.cpp:998
#17 0xe47c6de8 in ?? ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb)
```