### PR TITLE
Set initial scroll position for ChatPage

### DIFF
--- a/qml/components/ProfileThumbnail.qml
+++ b/qml/components/ProfileThumbnail.qml
@@ -106,7 +106,6 @@ Item {
                 height: parent.height - Theme.paddingSmall
                 anchors.centerIn: parent
                 source: profileThumbnail.photoData.local.path
-
                 fillMode: Image.PreserveAspectCrop
                 autoTransform: true
                 asynchronous: true


### PR DESCRIPTION
Fixes #1 (if I haven't missed something) and uses a simplified version of the solution discussed in that issue. `ListView.ApplyRange` does work better than `ListView.StrictlyEnforceRange` for `contentHeight` < `height` and doesn't (as far as I've seen) interfere with manual scrolling, so the proposed `Timer` wasn't necessary. It also works well with chats containing "variable height" messages like polls. (Those still jump when scrolling up manually, of course.)

A workaround for quickScroll guessing wrong (scrolling down) was also added.

I did not notice any of the crashes you mentioned, but since those were quite elusive, I obviously can't be sure they won't happen.

Also, a new bool `manuallyScrolledToBottom` property was added to the `SilicaListView` to keep scrolling down when new messages arrive. 
Those messages will, as of now, only be marked as read after a manual scroll action – if Fernschreiber isn't visible, this prevents automatically "reading" and missing messages. 

Possible enhancements:
 - Mark those as read if the app is running in the foreground to spare users the manual scrolling.
 - Perhaps marking messages as read could generally be done with a `Timer` (also when scrolling) to give users a chance to see what's happening. This would be another way to adress the "they effectively just blink" part from #23. The background color could also get a transition to be a bit more "fluid".

IMHO both of those would make sense. What do you think?