### PR TITLE
fix rpm changelog

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -66,7 +66,7 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/pages/PollResultsPage.qml \
     qml/pages/SettingsPage.qml \
     qml/pages/VideoPage.qml \
-    rpm/harbour-fernschreiber.changes.in \
+    rpm/harbour-fernschreiber.changes \
     rpm/harbour-fernschreiber.spec \
     rpm/harbour-fernschreiber.yaml \
     translations/*.ts \

--- a/rpm/harbour-fernschreiber.changes
+++ b/rpm/harbour-fernschreiber.changes
@@ -12,21 +12,7 @@
 # * date Author's Name <author's email> version-release
 # - Summary of changes
 
-* Sun Sep 20 2020 Sebastian J. Wolf <sebastian@ygriega.de> 0.1
-- Initial release
-
-* Wed Sep 30 2020 Sebastian J. Wolf <sebastian@ygriega.de> 0.2
-- Support sending images, videos and documents
-- Support receiving locations and venues - thanks to jgibbon
-- Performance improvements for chat list, new sorting algorithm and much more - thanks to monich
-- Performance improvements for chat, lazy loading for most UI elements
-- Cover page improvements - thanks to jgibbon
-- Fix handling of "<>" in messages
-- Differentiate text between other people and current user ("You have..." vs. "Somebody has...")
-- Support for the Jolla Tablet
-- New translations (Chinese, Hungarian, Polish, Spanish) - thanks to dashinfantry, edp17, atlochowski, GNUuser
-
-* Sun Oct 18 2020 Sebastian J. Wolf <sebastian@ygriega.de> 0.2
+* Sun Oct 18 2020 Sebastian J. Wolf <sebastian@ygriega.de> 0.3
 - Support for sending stickers
 - Search for emojis from message input field, use :<keyword> to start searching
 - New icon/logo - thanks to iamnomeutente
@@ -41,3 +27,17 @@
 - Fix: Don't display error message in case of repeated download of the same file
 - New translations (Finnish, Italian, Russian), thanks to jorm1s, iamnomeutente, arustg and monich
 - That was quite a lot - I hope I didn't forget anything. If I did, big sorry and please let me know!
+
+* Wed Sep 30 2020 Sebastian J. Wolf <sebastian@ygriega.de> 0.2
+- Support sending images, videos and documents
+- Support receiving locations and venues - thanks to jgibbon
+- Performance improvements for chat list, new sorting algorithm and much more - thanks to monich
+- Performance improvements for chat, lazy loading for most UI elements
+- Cover page improvements - thanks to jgibbon
+- Fix handling of "<>" in messages
+- Differentiate text between other people and current user ("You have..." vs. "Somebody has...")
+- Support for the Jolla Tablet
+- New translations (Chinese, Hungarian, Polish, Spanish) - thanks to dashinfantry, edp17, atlochowski, GNUuser
+
+* Sun Sep 20 2020 Sebastian J. Wolf <sebastian@ygriega.de> 0.1
+- Initial release


### PR DESCRIPTION
To include the changes in the rpm it
 - needs to be renamed
 - needs to have entries in descending order
Also, I've changed the second 0.2 → 0.3

If you think that's not important at all, let me tell you: 
You're probably completely right. 
(But perhaps it saves you a bit of copypasting when releasing on openrepos.)