### PR TITLE
entity sort offset+length

### DIFF
--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -253,7 +253,7 @@ function enhanceMessageText(formattedText) {
         }
     }
 
-    messageInsertions.sort( function(a, b) { return b.offset - a.offset } );
+    messageInsertions.sort( function(a, b) { return (b.offset+b.removeLength) - (a.offset+a.removeLength) } );
 
     for (var z = 0; z < messageInsertions.length; z++) {
         messageText = messageText.substring(0, messageInsertions[z].offset) + messageInsertions[z].insertionString + messageText.substring(messageInsertions[z].offset + messageInsertions[z].removeLength);


### PR DESCRIPTION
For the following (slighly changed) mention entity 
```
"content": {
    "@type": "messageText",
    "text": {
        "@type": "formattedText",
        "entities": [
            {
                "@type": "textEntity",
                "length": 16,
                "offset": 5,
                "type": {
                    "@type": "textEntityTypeMention"
                }
            }
        ],
        "text": "[D] <@TestUserReplace> Just testing what this does."
    }
},
```
`enhanceMessageText` resulted in 

`&lt;<a href="user:@TestUserReplace">@TestUserReplace&gt;/a>> Just testing what this does.`

With this change, it becomes 
`[D] &lt;<a href="user:@TestUserReplace">@TestUserReplace</a>&gt; Just testing what this does.`

Disclaimer: I'm not totally sure it makes much more sense because I should have been going to bed instead of doing this.