### PR TITLE
replace variant with var

### DIFF
--- a/qml/components/AudioPreview.qml
+++ b/qml/components/AudioPreview.qml
@@ -25,9 +25,9 @@ Item {
     id: audioMessageComponent
 
     property ListItem messageListItem
-    property variant rawMessage: messageListItem.myMessage
+    property var rawMessage: messageListItem.myMessage
 
-    property variant audioData: ( rawMessage.content['@type'] === "messageVoiceNote" ) ?  rawMessage.content.voice_note : ( ( rawMessage.content['@type'] === "messageAudio" ) ? rawMessage.content.audio : "");
+    property var audioData: ( rawMessage.content['@type'] === "messageVoiceNote" ) ?  rawMessage.content.voice_note : ( ( rawMessage.content['@type'] === "messageAudio" ) ? rawMessage.content.audio : "");
     property string audioUrl;
     property int previewFileId;
     property int audioFileId;

--- a/qml/components/DocumentPreview.qml
+++ b/qml/components/DocumentPreview.qml
@@ -26,9 +26,9 @@ Item {
     height: Theme.itemSizeLarge
 
     property ListItem messageListItem
-    property variant rawMessage: messageListItem.myMessage
+    property var rawMessage: messageListItem.myMessage
 
-    property variant documentData: rawMessage.content.document
+    property var documentData: rawMessage.content.document
     property bool openRequested: false;
 
     Component.onCompleted: {

--- a/qml/components/ImagePreview.qml
+++ b/qml/components/ImagePreview.qml
@@ -24,9 +24,9 @@ Item {
     id: imagePreviewItem
 
     property ListItem messageListItem
-    property variant rawMessage: messageListItem.myMessage
-    property variant photoData: rawMessage.content.photo;
-    property variant pictureFileInformation;
+    property var rawMessage: messageListItem.myMessage
+    property var photoData: rawMessage.content.photo;
+    property var pictureFileInformation;
 
     width: parent.width
     height: width * 2 / 3

--- a/qml/components/InReplyToRow.qml
+++ b/qml/components/InReplyToRow.qml
@@ -29,7 +29,7 @@ Row {
     height: inReplyToMessageColumn.height
 
     property string myUserId;
-    property variant inReplyToMessage;
+    property var inReplyToMessage;
     property bool editable: false;
 
     signal clearRequested()

--- a/qml/components/LocationPreview.qml
+++ b/qml/components/LocationPreview.qml
@@ -25,12 +25,12 @@ Item {
     id: imagePreviewItem
 
     property ListItem messageListItem
-    property variant rawMessage: messageListItem.myMessage
+    property var rawMessage: messageListItem.myMessage
 
-    property variant locationData : ( rawMessage.content['@type'] === "messageLocation" ) ?  rawMessage.content.location : ( ( rawMessage.content['@type'] === "messageVenue" ) ? rawMessage.content.venue.location : "" )
+    property var locationData : ( rawMessage.content['@type'] === "messageLocation" ) ?  rawMessage.content.location : ( ( rawMessage.content['@type'] === "messageVenue" ) ? rawMessage.content.venue.location : "" )
 
     property string chatId: messageListItem.page.chatInformation.id
-    property variant pictureFileInformation;
+    property var pictureFileInformation;
     width: parent.width
     height: width / 2
 

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -24,8 +24,8 @@ import "../js/functions.js" as Functions
 ListItem {
     id: messageListItem
     contentHeight: messageBackground.height + Theme.paddingMedium
-    property variant myMessage: display
-    property variant userInformation: tdLibWrapper.getUserInformation(display.sender_user_id)
+    property var myMessage: display
+    property var userInformation: tdLibWrapper.getUserInformation(display.sender_user_id)
     property Page page: chatPage
 
     property bool isOwnMessage: chatPage.myUserId === display.sender_user_id

--- a/qml/components/MessageListViewItemSimple.qml
+++ b/qml/components/MessageListViewItemSimple.qml
@@ -23,8 +23,8 @@ import "../js/functions.js" as Functions
 
 Item {
     id: messageListItem
-    property variant myMessage: display
-    property variant userInformation: tdLibWrapper.getUserInformation(myMessage.sender_user_id)
+    property var myMessage: display
+    property var userInformation: tdLibWrapper.getUserInformation(myMessage.sender_user_id)
     property bool isOwnMessage: chatPage.myUserId === myMessage.sender_user_id
     height: backgroundRectangle.height + Theme.paddingMedium
 

--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -28,7 +28,7 @@ Item {
 
 
     property ListItem messageListItem
-    property variant rawMessage: messageListItem.myMessage
+    property var rawMessage: messageListItem.myMessage
     property string chatId: messageListItem.page.chatInformation.id
 
     property bool isOwnMessage: messageListItem.isOwnMessage

--- a/qml/components/ProfileThumbnail.qml
+++ b/qml/components/ProfileThumbnail.qml
@@ -24,7 +24,7 @@ Item {
 
     id: profileThumbnail
 
-    property variant photoData;
+    property var photoData;
     property string replacementStringHint: "X"
     property bool forceElementUpdate: false
     property int radius: width / 2

--- a/qml/components/StickerPicker.qml
+++ b/qml/components/StickerPicker.qml
@@ -25,8 +25,8 @@ Item {
     id: stickerPickerOverlayItem
     anchors.fill: parent
 
-    property variant recentStickers: stickerManager.getRecentStickers()
-    property variant installedStickerSets: stickerManager.getInstalledStickerSets()
+    property var recentStickers: stickerManager.getRecentStickers()
+    property var installedStickerSets: stickerManager.getInstalledStickerSets()
     property bool pickerLoaded: false
 
     Timer {

--- a/qml/components/StickerPreview.qml
+++ b/qml/components/StickerPreview.qml
@@ -22,9 +22,9 @@ import Sailfish.Silica 1.0
 Item {
 
     property ListItem messageListItem
-    property variant rawMessage: messageListItem.myMessage
+    property var rawMessage: messageListItem.myMessage
 
-    property variant stickerData: rawMessage.content.sticker;
+    property var stickerData: rawMessage.content.sticker;
     property int usedFileId;
 
     width: stickerData.width

--- a/qml/components/VideoPreview.qml
+++ b/qml/components/VideoPreview.qml
@@ -25,9 +25,9 @@ Item {
     id: videoMessageComponent
 
     property ListItem messageListItem
-    property variant rawMessage: messageListItem.myMessage
+    property var rawMessage: messageListItem.myMessage
 
-    property variant videoData:  ( rawMessage.content['@type'] === "messageVideo" ) ?  rawMessage.content.video : ( ( rawMessage.content['@type'] === "messageAnimation" ) ? rawMessage.content.animation : "")
+    property var videoData:  ( rawMessage.content['@type'] === "messageVideo" ) ?  rawMessage.content.video : ( ( rawMessage.content['@type'] === "messageAnimation" ) ? rawMessage.content.animation : "")
     property string videoUrl;
     property int previewFileId;
     property int videoFileId;

--- a/qml/components/WebPagePreview.qml
+++ b/qml/components/WebPagePreview.qml
@@ -27,8 +27,8 @@ Column {
 
     id: webPagePreviewColumn
 
-    property variant webPageData;
-    property variant pictureFileInformation;
+    property var webPageData;
+    property var pictureFileInformation;
     property bool hasImage: false;
 
     spacing: Theme.paddingSmall

--- a/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
@@ -33,7 +33,7 @@ ChatInformationTabItemBase {
     loading: ( chatInformationPage.isSuperGroup || chatInformationPage.isPrivateChat) && !chatInformationPage.isChannel
     loadingVisible: loading && membersView.count === 0
 
-    property variant chatPartnerCommonGroupsIds: ([]);
+    property var chatPartnerCommonGroupsIds: ([]);
 
     SilicaListView {
         id: membersView

--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -26,7 +26,7 @@ Page {
     id: aboutPage
     allowedOrientations: Orientation.All
 
-    property variant userInformation : tdLibWrapper.getUserInformation();
+    property var userInformation : tdLibWrapper.getUserInformation();
 
     SilicaFlickable {
         id: aboutContainer

--- a/qml/pages/ChatInformationPage.qml
+++ b/qml/pages/ChatInformationPage.qml
@@ -29,12 +29,12 @@ Page {
                                     || (groupInformation.status["@type"] === "chatMemberStatusCreator" && groupInformation.status.is_member)
                                     )
 
-    property variant chatInformation:({});
-    property variant privateChatUserInformation:({});
-    property variant chatPartnerFullInformation:({});
-    property variant chatPartnerProfilePhotos:([]);
-    property variant groupInformation: ({});
-    property variant groupFullInformation: ({});
+    property var chatInformation:({});
+    property var privateChatUserInformation:({});
+    property var chatPartnerFullInformation:({});
+    property var chatPartnerProfilePhotos:([]);
+    property var groupInformation: ({});
+    property var groupFullInformation: ({});
 
     property alias membersList: membersList
 

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -33,15 +33,15 @@ Page {
     property bool loading: true;
     property bool isInitialized: false;
     property int myUserId: tdLibWrapper.getUserInformation().id;
-    property variant chatInformation;
+    property var chatInformation;
     property bool isPrivateChat: false;
     property bool isBasicGroup: false;
     property bool isSuperGroup: false;
     property bool isChannel: false;
-    property variant chatPartnerInformation;
-    property variant chatGroupInformation;
+    property var chatPartnerInformation;
+    property var chatGroupInformation;
     property int chatOnlineMemberCount: 0;
-    property variant emojiProposals;
+    property var emojiProposals;
 
     function updateChatPartnerStatusText() {
         var statusText = Functions.getChatPartnerStatusText(chatPartnerInformation.status['@type'], chatPartnerInformation.status.was_online);
@@ -543,7 +543,7 @@ Page {
                     }
 
                     model: chatModel
-                    property variant contentComponentNames: ({
+                    property var contentComponentNames: ({
                                                               messageSticker: "StickerPreview",
                                                               messagePhoto: "ImagePreview",
                                                               messageVideo: "VideoPreview",
@@ -784,7 +784,7 @@ Page {
                     property bool isPicture: false;
                     property bool isVideo: false;
                     property bool isDocument: false;
-                    property variant fileProperties:({});
+                    property var fileProperties:({});
 
                     IconButton {
                         id: removeAttachmentsIconButton

--- a/qml/pages/ImagePage.qml
+++ b/qml/pages/ImagePage.qml
@@ -26,8 +26,8 @@ Page {
     allowedOrientations: Orientation.All
     backNavigation: !imageOnly
 
-    property variant photoData;
-    property variant pictureFileInformation;
+    property var photoData;
+    property var pictureFileInformation;
 
     property string imageUrl;
     property int imageWidth;

--- a/qml/pages/VideoPage.qml
+++ b/qml/pages/VideoPage.qml
@@ -26,7 +26,7 @@ Page {
     id: videoPage
     allowedOrientations: Orientation.All
 
-    property variant videoData;
+    property var videoData;
 
     property int videoWidth : videoData.width
     property int videoHeight : videoData.height


### PR DESCRIPTION
https://doc.qt.io/archives/qt-5.6/qtquick-performance.html

> In general, "property var" should be considered to be superior to "property variant" for every use-case from QtQuick 2.0 and newer (note that "property variant" is marked as obsolete), as it allows a true JavaScript reference to be stored (which can reduce the number of conversions required in certain expressions).