### PR TITLE
Initialize TDLibWrapper::joinChatRequested

### DIFF
--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -47,7 +47,7 @@ namespace {
     const QString _EXTRA("@extra");
 }
 
-TDLibWrapper::TDLibWrapper(AppSettings *appSettings, QObject *parent) : QObject(parent)
+TDLibWrapper::TDLibWrapper(AppSettings *appSettings, QObject *parent) : QObject(parent), joinChatRequested(false)
 {
     LOG("Initializing TD Lib...");
     this->appSettings = appSettings;


### PR DESCRIPTION
Caught by valgrind:
```
==9299== Conditional jump or move depends on uninitialised value(s)
==9299==    at 0x23F0E4: ChatListModel::addVisibleChat(ChatListModel::ChatData*) (chatlistmodel.cpp:408)
==9299==    by 0x23F683: ChatListModel::handleChatDiscovered(QString const&, QMap<QString, QVariant> const&) (chatlistmodel.cpp:477)
==9299==    by 0x2DB991: ChatListModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_chatlistmodel.cpp:155)
==9299==    by 0x5DFC257: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3730)
==9299==    by 0x2E4AAB: TDLibWrapper::newChatDiscovered(QString const&, QMap<QString, QVariant> const&) (moc_tdlibwrapper.cpp:1374)
==9299==    by 0x265275: TDLibWrapper::handleNewChatDiscovered(QMap<QString, QVariant> const&) (tdlibwrapper.cpp:1017)
==9299==    by 0x2E1F77: TDLibWrapper::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_tdlibwrapper.cpp:839)
==9299==    by 0x5DFC71B: QObject::event(QEvent*) (qobject.cpp:1256)
==9299==    by 0x5DDFC43: doNotify (qcoreapplication.cpp:1090)
==9299==    by 0x5DDFC43: QCoreApplication::notify(QObject*, QEvent*) (qcoreapplication.cpp:1076)
==9299==    by 0x5DDFD51: QCoreApplication::notifyInternal2(QObject*, QEvent*) (qcoreapplication.cpp:1015)
==9299==    by 0x5DE1659: sendEvent (qcoreapplication.h:225)
==9299==    by 0x5DE1659: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (qcoreapplication.cpp:1650)
==9299==    by 0x5E186BB: postEventSourceDispatch(_GSource*, int (*)(void*), void*) (qeventdispatcher_glib.cpp:275)
==9299==    by 0x6AFCA63: g_main_dispatch (gmain.c:3325)
==9299==    by 0x6AFCA63: g_main_context_dispatch (gmain.c:4016)
==9299==    by 0x6AFCBFB: g_main_context_iterate.isra.23 (gmain.c:4092)
==9299==    by 0x6AFCC53: g_main_context_iteration (gmain.c:4157)
==9299==    by 0x5E189A1: QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) (qeventdispatcher_glib.cpp:423)
==9299==    by 0x5DDE9E9: QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) (qeventloop.cpp:206)
==9299==    by 0x5DE41DF: QCoreApplication::exec() (qcoreapplication.cpp:1285)
==9299==    by 0x23A0D7: main (harbour-fernschreiber.cpp:83)
```