### PR TITLE
Update chat photo

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -448,7 +448,7 @@ Page {
 
                 ProfileThumbnail {
                     id: chatPictureThumbnail
-                    photoData: (typeof chatInformation.photo !== "undefined") ? chatInformation.photo.small : ""
+                    photoData: chatModel.smallPhoto
                     replacementStringHint: chatNameText.text
                     width: chatOverviewColumn.height
                     height: chatOverviewColumn.height

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -295,6 +295,7 @@ ChatListModel::ChatListModel(TDLibWrapper *tdLibWrapper) : showHiddenChats(false
     connect(tdLibWrapper, SIGNAL(chatOrderUpdated(QString, QString)), this, SLOT(handleChatOrderUpdated(QString, QString)));
     connect(tdLibWrapper, SIGNAL(chatReadInboxUpdated(QString, QString, int)), this, SLOT(handleChatReadInboxUpdated(QString, QString, int)));
     connect(tdLibWrapper, SIGNAL(chatReadOutboxUpdated(QString, QString)), this, SLOT(handleChatReadOutboxUpdated(QString, QString)));
+    connect(tdLibWrapper, SIGNAL(chatPhotoUpdated(qlonglong, QVariantMap)), this, SLOT(handleChatPhotoUpdated(qlonglong, QVariantMap)));
     connect(tdLibWrapper, SIGNAL(messageSendSucceeded(QString, QString, QVariantMap)), this, SLOT(handleMessageSendSucceeded(QString, QString, QVariantMap)));
     connect(tdLibWrapper, SIGNAL(chatNotificationSettingsUpdated(QString, QVariantMap)), this, SLOT(handleChatNotificationSettingsUpdated(QString, QVariantMap)));
     connect(tdLibWrapper, SIGNAL(superGroupUpdated(qlonglong)), this, SLOT(handleGroupUpdated(qlonglong)));
@@ -610,6 +611,26 @@ void ChatListModel::handleChatReadOutboxUpdated(const QString &id, const QString
             if (chat) {
                 chat->chatData.insert(LAST_READ_OUTBOX_MESSAGE_ID, lastReadOutboxMessageId);
             }
+        }
+    }
+}
+
+void ChatListModel::handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &photo)
+{
+    if (chatIndexMap.contains(chatId)) {
+        LOG("Updating chat photo for" << chatId);
+        const int chatIndex = chatIndexMap.value(chatId);
+        ChatData *chat = chatList.at(chatIndex);
+        chat->chatData.insert(PHOTO, photo);
+        QVector<int> changedRoles;
+        changedRoles.append(ChatData::RolePhotoSmall);
+        const QModelIndex modelIndex(index(chatIndex));
+        emit dataChanged(modelIndex, modelIndex, changedRoles);
+    } else {
+        ChatData *chat = hiddenChats.value(chatId);
+        if (chat) {
+            LOG("Updating photo for hidden chat" << chatId);
+            chat->chatData.insert(PHOTO, photo);
         }
     }
 }

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -48,6 +48,7 @@ private slots:
     void handleChatOrderUpdated(const QString &chatId, const QString &order);
     void handleChatReadInboxUpdated(const QString &chatId, const QString &lastReadInboxMessageId, int unreadCount);
     void handleChatReadOutboxUpdated(const QString &chatId, const QString &lastReadOutboxMessageId);
+    void handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &photo);
     void handleMessageSendSucceeded(const QString &messageId, const QString &oldMessageId, const QVariantMap &message);
     void handleChatNotificationSettingsUpdated(const QString &chatId, const QVariantMap &chatNotificationSettings);
     void handleGroupUpdated(qlonglong groupId);

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -28,6 +28,8 @@
 class ChatModel : public QAbstractListModel
 {
     Q_OBJECT
+    Q_PROPERTY(QVariantMap smallPhoto READ smallPhoto NOTIFY smallPhotoChanged)
+
 public:
     ChatModel(TDLibWrapper *tdLibWrapper);
     ~ChatModel() override;
@@ -36,40 +38,43 @@ public:
     virtual QVariant data(const QModelIndex &index, int role) const override;
     virtual bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
 
+
     Q_INVOKABLE void initialize(const QVariantMap &chatInformation);
     Q_INVOKABLE void triggerLoadMoreHistory();
     Q_INVOKABLE QVariantMap getChatInformation();
-    Q_INVOKABLE QVariantMap getMessage(const int &index);
+    Q_INVOKABLE QVariantMap getMessage(int index);
+    QVariantMap smallPhoto() const;
 
 signals:
-    void messagesReceived(const int &modelIndex, const int &lastReadSentIndex, const int &totalCount);
-    void messagesIncrementalUpdate(const int &modelIndex, const int &lastReadSentIndex);
+    void messagesReceived(int modelIndex, int lastReadSentIndex, int totalCount);
+    void messagesIncrementalUpdate(int modelIndex, int lastReadSentIndex);
     void newMessageReceived(const QVariantMap &message);
-    void unreadCountUpdated(const int &unreadCount, const QString &lastReadInboxMessageId);
-    void lastReadSentMessageUpdated(const int &lastReadSentIndex);
+    void unreadCountUpdated(int unreadCount, const QString &lastReadInboxMessageId);
+    void lastReadSentMessageUpdated(int lastReadSentIndex);
     void notificationSettingsUpdated();
-    void messageUpdated(const int &modelIndex);
+    void messageUpdated(int modelIndex);
     void messagesDeleted();
+    void smallPhotoChanged();
 
 public slots:
-    void handleMessagesReceived(const QVariantList &messages, const int &totalCount);
+    void handleMessagesReceived(const QVariantList &messages, int totalCount);
     void handleNewMessageReceived(const QString &chatId, const QVariantMap &message);
-    void handleChatReadInboxUpdated(const QString &chatId, const QString &lastReadInboxMessageId, const int &unreadCount);
+    void handleChatReadInboxUpdated(const QString &chatId, const QString &lastReadInboxMessageId, int unreadCount);
     void handleChatReadOutboxUpdated(const QString &chatId, const QString &lastReadOutboxMessageId);
     void handleMessageSendSucceeded(const QString &messageId, const QString &oldMessageId, const QVariantMap &message);
     void handleChatNotificationSettingsUpdated(const QString &chatId, const QVariantMap &chatNotificationSettings);
+    void handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &photo);
     void handleMessageContentUpdated(const QString &chatId, const QString &messageId, const QVariantMap &newContent);
     void handleMessagesDeleted(const QString &chatId, const QVariantList &messageIds);
 
 private:
-
     TDLibWrapper *tdLibWrapper;
     QVariantList messages;
     QVariantList messagesToBeAdded;
     QVariantMap messageIndexMap;
     QMutex messagesMutex;
     QVariantMap chatInformation;
-    QString chatId;
+    qlonglong chatId;
     bool inReload;
     bool inIncrementalUpdate;
 

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -40,6 +40,7 @@ namespace {
     const QString VALUE("value");
     const QString POSITION("position");
     const QString POSITIONS("positions");
+    const QString PHOTO("photo");
     const QString ORDER("order");
     const QString BASIC_GROUP("basic_group");
     const QString SUPERGROUP("supergroup");
@@ -124,6 +125,7 @@ TDLibReceiver::TDLibReceiver(void *tdLibClient, QObject *parent) : QThread(paren
     handlers.insert("updateSupergroupFullInfo", &TDLibReceiver::processUpdateSupergroupFullInfo);
     handlers.insert("userProfilePhotos", &TDLibReceiver::processUserProfilePhotos);
     handlers.insert("updateChatPermissions", &TDLibReceiver::processUpdateChatPermissions);
+    handlers.insert("updateChatPhoto", &TDLibReceiver::processUpdateChatPhoto);
     handlers.insert("updateChatTitle", &TDLibReceiver::processUpdateChatTitle);
     handlers.insert("users", &TDLibReceiver::processUsers);
     handlers.insert("error", &TDLibReceiver::processError);
@@ -489,6 +491,13 @@ void TDLibReceiver::processUserProfilePhotos(const QVariantMap &receivedInformat
 void TDLibReceiver::processUpdateChatPermissions(const QVariantMap &receivedInformation)
 {
     emit chatPermissionsUpdated(receivedInformation.value(CHAT_ID).toString(), receivedInformation.value("permissions").toMap());
+}
+
+void TDLibReceiver::processUpdateChatPhoto(const QVariantMap &receivedInformation)
+{
+    const qlonglong chatId = receivedInformation.value(CHAT_ID).toLongLong();
+    LOG("Photo updated for chat" << chatId);
+    emit chatPhotoUpdated(chatId, receivedInformation.value(PHOTO).toMap());
 }
 
 void TDLibReceiver::processUpdateChatTitle(const QVariantMap &receivedInformation)

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -118,6 +118,7 @@ TDLibReceiver::TDLibReceiver(void *tdLibClient, QObject *parent) : QThread(paren
     handlers.insert("updateChatTitle", &TDLibReceiver::processUpdateChatTitle);
     handlers.insert("users", &TDLibReceiver::processUsers);
     handlers.insert("error", &TDLibReceiver::processError);
+    handlers.insert("ok", &TDLibReceiver::nop);
 }
 
 void TDLibReceiver::setActive(bool active)
@@ -507,4 +508,8 @@ void TDLibReceiver::processError(const QVariantMap &receivedInformation)
 {
     LOG("Received an error");
     emit errorReceived(receivedInformation.value("code").toInt(), receivedInformation.value("message").toString());
+}
+
+void TDLibReceiver::nop(const QVariantMap &)
+{
 }

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -138,6 +138,7 @@ private:
     void processUpdateChatTitle(const QVariantMap &receivedInformation);
     void processUsers(const QVariantMap &receivedInformation);
     void processError(const QVariantMap &receivedInformation);
+    void nop(const QVariantMap &receivedInformation);
 };
 
 #endif // TDLIBRECEIVER_H

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -79,9 +79,11 @@ signals:
     void supergroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
     void userProfilePhotos(const QString &extra, const QVariantList &photos, int totalPhotos);
     void chatPermissionsUpdated(const QString &chatId, const QVariantMap &chatPermissions);
+    void chatPhotoUpdated(qlonglong chatId, const QVariantMap &photo);
     void chatTitleUpdated(const QString &chatId, const QString &title);
     void usersReceived(const QString &extra, const QVariantList &userIds, int totalUsers);
     void errorReceived(const int code, const QString &message);
+
 private:
     typedef void (TDLibReceiver::*Handler)(const QVariantMap &);
 
@@ -135,6 +137,7 @@ private:
     void processUpdateSupergroupFullInfo(const QVariantMap &receivedInformation);
     void processUserProfilePhotos(const QVariantMap &receivedInformation);
     void processUpdateChatPermissions(const QVariantMap &receivedInformation);
+    void processUpdateChatPhoto(const QVariantMap &receivedInformation);
     void processUpdateChatTitle(const QVariantMap &receivedInformation);
     void processUsers(const QVariantMap &receivedInformation);
     void processError(const QVariantMap &receivedInformation);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -110,6 +110,7 @@ TDLibWrapper::TDLibWrapper(AppSettings *appSettings, QObject *parent) : QObject(
     connect(this->tdLibReceiver, SIGNAL(supergroupFullInfoUpdated(QString, QVariantMap)), this, SIGNAL(supergroupFullInfoUpdated(QString, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(userProfilePhotos(QString, QVariantList, int)), this, SIGNAL(userProfilePhotosReceived(QString, QVariantList, int)));
     connect(this->tdLibReceiver, SIGNAL(chatPermissionsUpdated(QString, QVariantMap)), this, SIGNAL(chatPermissionsUpdated(QString, QVariantMap)));
+    connect(this->tdLibReceiver, SIGNAL(chatPhotoUpdated(qlonglong, QVariantMap)), this, SIGNAL(chatPhotoUpdated(qlonglong, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(chatTitleUpdated(QString, QString)), this, SIGNAL(chatTitleUpdated(QString, QString)));
     connect(this->tdLibReceiver, SIGNAL(usersReceived(QString, QVariantList, int)), this, SIGNAL(usersReceived(QString, QVariantList, int)));
     connect(this->tdLibReceiver, SIGNAL(errorReceived(int, QString)), this, SIGNAL(errorReceived(int, QString)));
@@ -264,7 +265,7 @@ void TDLibWrapper::leaveChat(const QString &chatId)
     this->sendRequest(requestObject);
 }
 
-void TDLibWrapper::getChatHistory(const QString &chatId, const qlonglong &fromMessageId, int offset, int limit, bool onlyLocal)
+void TDLibWrapper::getChatHistory(qlonglong chatId, const qlonglong &fromMessageId, int offset, int limit, bool onlyLocal)
 {
     LOG("Retrieving chat history" << chatId << fromMessageId << offset << limit << onlyLocal);
     QVariantMap requestObject;

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -120,7 +120,7 @@ public:
     Q_INVOKABLE void closeChat(const QString &chatId);
     Q_INVOKABLE void joinChat(const QString &chatId);
     Q_INVOKABLE void leaveChat(const QString &chatId);
-    Q_INVOKABLE void getChatHistory(const QString &chatId, const qlonglong &fromMessageId = 0, int offset = 0, int limit = 50, bool onlyLocal = false);
+    Q_INVOKABLE void getChatHistory(qlonglong chatId, const qlonglong &fromMessageId = 0, int offset = 0, int limit = 50, bool onlyLocal = false);
     Q_INVOKABLE void viewMessage(const QString &chatId, const QString &messageId, bool force);
     Q_INVOKABLE void sendTextMessage(const QString &chatId, const QString &message, const QString &replyToMessageId = "0");
     Q_INVOKABLE void sendPhotoMessage(const QString &chatId, const QString &filePath, const QString &message, const QString &replyToMessageId = "0");
@@ -215,6 +215,7 @@ signals:
     void supergroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
     void userProfilePhotosReceived(const QString &extra, const QVariantList &photos, int totalPhotos);
     void chatPermissionsUpdated(const QString &chatId, const QVariantMap &permissions);
+    void chatPhotoUpdated(qlonglong chatId, const QVariantMap &photo);
     void chatTitleUpdated(const QString &chatId, const QString &title);
     void usersReceived(const QString &extra, const QVariantList &userIds, int totalUsers);
     void errorReceived(const int code, const QString &message);


### PR DESCRIPTION
Basically, handle `"updateChatPhoto"` and propagate it to chat and chat list models + assorted fixes on C++ side. Trying to gradually move towards storing and passing numbers as numbers rather than QStrings or QVariants.