### PR TITLE
Bugfix/message permissions

### DIFF
--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -412,7 +412,7 @@ function getMessagesNeededForwardPermissions(messages) {
 
     var mediaMessageTypes = ["messageAudio", "messageDocument", "messagePhoto", "messageVideo", "messageVideoNote", "messageVoiceNote"];
     var otherMessageTypes = ["messageAnimation", "messageGame", "messageSticker"]
-    for(var i = 0; i < messages.length; i += 1) {
+    for(var i = 0; i < messages.length && neededPermissions.length < 3; i += 1) {
         var type = messages[i]["content"]["@type"];
         var permission = "";
         if(type === "messageText") {

--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -406,3 +406,28 @@ function handleErrorMessage(code, message) {
         appNotification.show(message);
     }
 }
+
+function getMessagesNeededForwardPermissions(messages) {
+    var neededPermissions = ["can_send_messages"];
+
+    var mediaMessageTypes = ["messageAudio", "messageDocument", "messagePhoto", "messageVideo", "messageVideoNote", "messageVoiceNote"];
+    var otherMessageTypes = ["messageAnimation", "messageGame", "messageSticker"]
+    for(var i = 0; i < messages.length; i += 1) {
+        var type = messages[i]["content"]["@type"];
+        var permission = "";
+        if(type === "messageText") {
+            continue;
+        } else if(type === "messagePoll") {
+            permission = "can_send_polls";
+        } else if(mediaMessageTypes.indexOf(type) > -1) {
+            permission = "can_send_media_messages";
+        } else if(otherMessageTypes.indexOf(type) > -1) {
+            permission = "can_send_other_messages";
+        }
+
+        if(permission !== "" && neededPermissions.indexOf(permission) === -1) {
+            neededPermissions.push(permission);
+        }
+    }
+    return neededPermissions;
+}

--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -408,26 +408,26 @@ function handleErrorMessage(code, message) {
 }
 
 function getMessagesNeededForwardPermissions(messages) {
-    var neededPermissions = ["can_send_messages"];
+    var neededPermissions = ["can_send_messages"]
 
-    var mediaMessageTypes = ["messageAudio", "messageDocument", "messagePhoto", "messageVideo", "messageVideoNote", "messageVoiceNote"];
+    var mediaMessageTypes = ["messageAudio", "messageDocument", "messagePhoto", "messageVideo", "messageVideoNote", "messageVoiceNote"]
     var otherMessageTypes = ["messageAnimation", "messageGame", "messageSticker"]
     for(var i = 0; i < messages.length && neededPermissions.length < 3; i += 1) {
-        var type = messages[i]["content"]["@type"];
-        var permission = "";
+        var type = messages[i]["content"]["@type"]
+        var permission = ""
         if(type === "messageText") {
-            continue;
+            continue
         } else if(type === "messagePoll") {
-            permission = "can_send_polls";
+            permission = "can_send_polls"
         } else if(mediaMessageTypes.indexOf(type) > -1) {
-            permission = "can_send_media_messages";
+            permission = "can_send_media_messages"
         } else if(otherMessageTypes.indexOf(type) > -1) {
-            permission = "can_send_other_messages";
+            permission = "can_send_other_messages"
         }
 
         if(permission !== "" && neededPermissions.indexOf(permission) === -1) {
-            neededPermissions.push(permission);
+            neededPermissions.push(permission)
         }
     }
-    return neededPermissions;
+    return neededPermissions
 }

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -270,8 +270,8 @@ Page {
         forwardMessagesTimer.start();
     }
     function hasSendPrivilege(privilege) {
-        var groupStatus = chatGroupInformation ? chatGroupInformation.status : null;
-        var groupStatusType = groupStatus ? groupStatus["@type"] : null;
+        var groupStatus = chatGroupInformation ? chatGroupInformation.status : null
+        var groupStatusType = groupStatus ? groupStatus["@type"] : null
         return chatPage.isPrivateChat
                     || (groupStatusType === "chatMemberStatusMember" && chatInformation.permissions[privilege])
                     || groupStatusType === "chatMemberStatusAdministrator"
@@ -1216,15 +1216,15 @@ Page {
                             width: visible ? Theme.itemSizeMedium : 0
                             icon.source: "image://theme/icon-m-forward"
                             onClicked: {
-                                var ids = Functions.getMessagesArrayIds(chatPage.selectedMessages);
-                                var neededPermissions = Functions.getMessagesNeededForwardPermissions(chatPage.selectedMessages);
-                                var chatId = chatInformation.id;
+                                var ids = Functions.getMessagesArrayIds(chatPage.selectedMessages)
+                                var neededPermissions = Functions.getMessagesNeededForwardPermissions(chatPage.selectedMessages)
+                                var chatId = chatInformation.id
                                 pageStack.push(Qt.resolvedUrl("../pages/ChatSelectionPage.qml"), {
                                     myUserId: chatPage.myUserId,
                                     headerDescription: qsTr("Forward %n messages", "dialog header", ids.length).arg(ids.length),
                                     payload: {fromChatId: chatId, messageIds:ids, neededPermissions: neededPermissions},
                                     state: "forwardMessages"
-                                });
+                                })
                             }
 
                         }

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -108,6 +108,9 @@ Page {
     }
 
     function updateGroupStatusText() {
+        if(chatPage.state === "selectMessages") {
+            return
+        }
         if (chatOnlineMemberCount > 0) {
             chatStatusText.text = qsTr("%1 members, %2 online").arg(Functions.getShortenedCount(chatGroupInformation.member_count)).arg(Functions.getShortenedCount(chatOnlineMemberCount));
         } else {
@@ -268,14 +271,12 @@ Page {
     }
     function hasSendPrivilege(privilege) {
         var groupStatus = chatGroupInformation ? chatGroupInformation.status : null;
-        var groupStatusType = grouptStatus ? groupStatus["@type"] : null;
+        var groupStatusType = groupStatus ? groupStatus["@type"] : null;
         return chatPage.isPrivateChat
                     || (groupStatusType === "chatMemberStatusMember" && chatInformation.permissions[privilege])
                     || groupStatusType === "chatMemberStatusAdministrator"
                     || groupStatusType === "chatMemberStatusCreator"
                     || (groupStatusType === "chatMemberStatusRestricted" && groupStatus.permissions[privilege])
-
-
     }
 
     Timer {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1208,7 +1208,7 @@ Page {
                                 leftMargin: visible ? Theme.paddingSmall : 0
                                 verticalCenter: parent.verticalCenter
                             }
-                            visible: chatPage.chatInformation.can_be_forwarded &&  selectedMessages.every(function(message){
+                            visible: selectedMessages.every(function(message){
                                 return message.can_be_forwarded
                             })
                             width: visible ? Theme.itemSizeMedium : 0
@@ -1218,6 +1218,7 @@ Page {
                                 var neededPermissions = Functions.getMessagesNeededForwardPermissions(chatPage.selectedMessages);
                                 var chatId = chatInformation.id;
                                 pageStack.push(Qt.resolvedUrl("../pages/ChatSelectionPage.qml"), {
+                                    myUserId: chatPage.myUserId,
                                     headerDescription: qsTr("Forward %n messages", "dialog header", ids.length).arg(ids.length),
                                     payload: {fromChatId: chatId, messageIds:ids, neededPermissions: neededPermissions},
                                     state: "forwardMessages"

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -267,14 +267,15 @@ Page {
         forwardMessagesTimer.start();
     }
     function hasSendPrivilege(privilege) {
-        return chatPage.isPrivateChat ||
-                chatGroupInformation &&
-                (
-                    (chatGroupInformation.status["@type"] === "chatMemberStatusMember" && chatGroupInformation.status.permissions[privilege])
-                    || chatGroupInformation.status["@type"] === "chatMemberStatusAdministrator"
-                    || chatGroupInformation.status["@type"] === "chatMemberStatusCreator"
-                    || (chatGroupInformation.status["@type"] === "chatMemberStatusRestricted" && chatGroupInformation.status.permissions[privilege])
-                 )
+        var groupStatus = chatGroupInformation ? chatGroupInformation.status : null;
+        var groupStatusType = grouptStatus ? groupStatus["@type"] : null;
+        return chatPage.isPrivateChat
+                    || (groupStatusType === "chatMemberStatusMember" && chatInformation.permissions[privilege])
+                    || groupStatusType === "chatMemberStatusAdministrator"
+                    || groupStatusType === "chatMemberStatusCreator"
+                    || (groupStatusType === "chatMemberStatusRestricted" && groupStatus.permissions[privilege])
+
+
     }
 
     Timer {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -273,7 +273,7 @@ Page {
                     (chatGroupInformation.status["@type"] === "chatMemberStatusMember" && chatGroupInformation.status.permissions[privilege])
                     || chatGroupInformation.status["@type"] === "chatMemberStatusAdministrator"
                     || chatGroupInformation.status["@type"] === "chatMemberStatusCreator"
-                    || (chatGroupInformation.status["@type"] === "chatMemberStatusRestricted" && chatInformation.permissions[privilege])
+                    || (chatGroupInformation.status["@type"] === "chatMemberStatusRestricted" && chatGroupInformation.status.permissions[privilege])
                  )
     }
 

--- a/qml/pages/ChatSelectionPage.qml
+++ b/qml/pages/ChatSelectionPage.qml
@@ -73,11 +73,11 @@ Dialog {
                 asynchronous: true
                 sourceComponent: Component {
                     QtObject {
-                        property var chatGroupInformation: ({})
                         property bool visible: false
                         Component.onCompleted: {
                             if(chatSelectionPage.state === "forwardMessages") {
                                 var chatType = display.type['@type'];
+                                var chatGroupInformation;
                                 if(chatType === "chatTypePrivate" || chatType === "chatTypeSecret") {
                                     visible = true
                                     return;
@@ -88,14 +88,22 @@ Dialog {
                                 else if (chatType === "chatTypeSupergroup" ) {
                                     chatGroupInformation = tdLibWrapper.getSuperGroup(display.type.supergroup_id);
                                 }
-
-                                visible = (chatGroupInformation.status["@type"] === "chatMemberStatusCreator"
-                                        || chatGroupInformation.status["@type"] === "chatMemberStatusAdministrator"
-                                        || (chatGroupInformation.status["@type"] === "chatMemberStatusMember"
+                                var groupStatus = chatGroupInformation.status;
+                                var groupStatusType = groupStatus["@type"];
+                                var groupStatusPermissions = groupStatus.permissions;
+                                var groupPermissions = display.permissions;
+                                visible = (groupStatusType === "chatMemberStatusCreator"
+                                        || groupStatusType === "chatMemberStatusAdministrator"
+                                        || (groupStatusType === "chatMemberStatusMember"
                                                 && chatSelectionPage.payload.neededPermissions.every(function(neededPermission){
-                                                    return display.permissions[neededPermission];
+                                                    return groupPermissions[neededPermission];
                                                 })
                                             )
+                                        || (groupStatusType === "chatMemberStatusRestricted"
+                                           && chatSelectionPage.payload.neededPermissions.every(function(neededPermission){
+                                               return groupStatusPermissions[neededPermission];
+                                           })
+                                       )
                                         );
                             } else { // future uses of chat selection can be processed here
                                 visible = true;

--- a/qml/pages/ChatSelectionPage.qml
+++ b/qml/pages/ChatSelectionPage.qml
@@ -29,7 +29,7 @@ Dialog {
     canAccept: false
     acceptDestinationAction: PageStackAction.Replace
     acceptDestinationReplaceTarget: pageStack.find( function(page){ return(page._depth === 0)} )
-    property int myUserId: tdLibWrapper.getUserInformation().id;
+    property int myUserId: tdLibWrapper.getUserInformation().id
     property alias headerTitle: pageHeader.title
     property alias headerDescription: pageHeader.description
     /*
@@ -76,37 +76,37 @@ Dialog {
                         property bool visible: false
                         Component.onCompleted: {
                             if(chatSelectionPage.state === "forwardMessages") {
-                                var chatType = display.type['@type'];
-                                var chatGroupInformation;
+                                var chatType = display.type['@type']
+                                var chatGroupInformation
                                 if(chatType === "chatTypePrivate" || chatType === "chatTypeSecret") {
                                     visible = true
                                     return;
                                 }
                                 else if (chatType === "chatTypeBasicGroup" ) {
-                                    chatGroupInformation = tdLibWrapper.getBasicGroup(display.type.basic_group_id);
+                                    chatGroupInformation = tdLibWrapper.getBasicGroup(display.type.basic_group_id)
                                 }
                                 else if (chatType === "chatTypeSupergroup" ) {
-                                    chatGroupInformation = tdLibWrapper.getSuperGroup(display.type.supergroup_id);
+                                    chatGroupInformation = tdLibWrapper.getSuperGroup(display.type.supergroup_id)
                                 }
-                                var groupStatus = chatGroupInformation.status;
-                                var groupStatusType = groupStatus["@type"];
-                                var groupStatusPermissions = groupStatus.permissions;
-                                var groupPermissions = display.permissions;
+                                var groupStatus = chatGroupInformation.status
+                                var groupStatusType = groupStatus["@type"]
+                                var groupStatusPermissions = groupStatus.permissions
+                                var groupPermissions = display.permissions
                                 visible = (groupStatusType === "chatMemberStatusCreator"
                                         || groupStatusType === "chatMemberStatusAdministrator"
                                         || (groupStatusType === "chatMemberStatusMember"
                                                 && chatSelectionPage.payload.neededPermissions.every(function(neededPermission){
-                                                    return groupPermissions[neededPermission];
+                                                    return groupPermissions[neededPermission]
                                                 })
                                             )
                                         || (groupStatusType === "chatMemberStatusRestricted"
                                            && chatSelectionPage.payload.neededPermissions.every(function(neededPermission){
-                                               return groupStatusPermissions[neededPermission];
+                                               return groupStatusPermissions[neededPermission]
                                            })
                                        )
-                                        );
+                                    )
                             } else { // future uses of chat selection can be processed here
-                                visible = true;
+                                visible = true
                             }
                         }
                     }

--- a/qml/pages/ChatSelectionPage.qml
+++ b/qml/pages/ChatSelectionPage.qml
@@ -29,6 +29,7 @@ Dialog {
     canAccept: false
     acceptDestinationAction: PageStackAction.Replace
     acceptDestinationReplaceTarget: pageStack.find( function(page){ return(page._depth === 0)} )
+    property int myUserId: tdLibWrapper.getUserInformation().id;
     property alias headerTitle: pageHeader.title
     property alias headerDescription: pageHeader.description
     /*
@@ -66,7 +67,7 @@ Dialog {
 
         model: chatListModel
         delegate: ChatListViewItem {
-            ownUserId: overviewPage.ownUserId
+            ownUserId: chatSelectionPage.myUserId
             Loader { // checking permissions takes a while, so we defer those calculations
                 id: visibleLoader
                 asynchronous: true
@@ -105,13 +106,13 @@ Dialog {
             }
 
             property bool valid: visibleLoader && visibleLoader.item && visibleLoader.item.visible
-            opacity: valid ? 1.0 : 0.5
+            opacity: valid ? 1.0 : 0
 
             Behavior on opacity { FadeAnimation {}}
             Behavior on height { NumberAnimation {}}
 
             // normal height while calculating, otherwise all elements get displayed at once
-            height: !visibleLoader.item || visible ? contentHeight : 0
+            height: !visibleLoader.item || valid ? contentHeight : 0
             enabled: valid
             onClicked: {
                 var chat = tdLibWrapper.getChat(display.id);

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -39,6 +39,7 @@
 #include "processlauncher.h"
 #include "stickermanager.h"
 #include "tgsplugin.h"
+#include "fernschreiberutils.h"
 
 Q_IMPORT_PLUGIN(TgsIOPlugin)
 
@@ -59,6 +60,9 @@ int main(int argc, char *argv[])
     TDLibWrapper *tdLibWrapper = new TDLibWrapper(appSettings, view.data());
     context->setContextProperty("tdLibWrapper", tdLibWrapper);
     qmlRegisterUncreatableType<TDLibWrapper>(uri, 1, 0, "TelegramAPI", QString());
+
+    FernschreiberUtils *fernschreiberUtils = new FernschreiberUtils(view.data());
+    context->setContextProperty("fernschreiberUtils", fernschreiberUtils);
 
     DBusAdaptor *dBusAdaptor = tdLibWrapper->getDBusAdaptor();
     context->setContextProperty("dBusAdaptor", dBusAdaptor);


### PR DESCRIPTION
enhances #159 PR, hopefully fixes #164 issue
### Info for "beta testers" ###
If anyone uses groups with message restrictions (you're not allowed to post messages, videos, polls, stickers, …), a bit of help testing would be very appreciated. 
This applies to the whole message entry area, the attachment icon buttons (should be hidden) as well as forwarding messages (chats should become hidden; you can forward by selecting messages via long press context menu). Thanks in advance! ;)


### ChatPage ###
**Please mind,** I wasn't able to verify all permissions in real world examples, so a short sanity check of changes is strongly advised to make sure I didn't miss anything serious.

According to TDLib documentation, animations and videos use different permissions for some reason.
The attachment icon is only dependent on "can_send_media_messages" (video), because AFAICT we only send those.

I've not yet set anything up for secret chats (despite "proposing" it in #164) because that heavily depends on how those will be implemented.

This PR has a slight performance impact on the ChatPage, but that should sort itself out with the next round of optimizations (perhaps while implementing #154).

### ChatSelectionPage ###
Changes try to hide chats where the selected messages can't be forwarded to. 
This is very expensive computationally, since it has to check the member status (inside groupInformation, which has to be aquired) for every group chat.
For that reason, initially, all delegates are shown dimmed (but not clickable) and the permission check has been off-loaded to an asynchronous Loader. 
The "delegate-based filtering" has some draw-backs (like showing/hiding when scrolling back and forth), but it gets stuff drawn bearably fast on initialization.

I tried to keep the ChatSelectionPage easily extendable for future purposes (perhaps system integration for sharing texts/urls/media?) by using/checking its "state" property. Right now, it only uses the string "forwardMessages".

cheers