### PR TITLE
Bugfix/#20 translation plurals

### DIFF
--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -178,7 +178,7 @@ Item {
                     Label {
                         id: optionVoterPercentage
                         font.pixelSize: Theme.fontSizeTiny
-                        text: qsTr("%L1\%", "% of votes for option").arg(modelData.vote_percentage)
+                        text: qsTr("%Ln\%", "% of votes for option").arg(modelData.vote_percentage)
                         horizontalAlignment: Text.AlignRight
                         anchors {
                             right: parent.right
@@ -226,7 +226,7 @@ Item {
                 id: totalVoterCount
                 font.pixelSize: Theme.fontSizeTiny
                 anchors.verticalCenter: parent.verticalCenter
-                text: qsTr("%L1 vote(s) total", "number of total votes", pollData.total_voter_count).arg(pollData.total_voter_count)
+                text: qsTr("%Ln vote(s) total", "number of total votes", pollData.total_voter_count).arg(pollData.total_voter_count)
                 width: contentWidth
                 height: contentHeight
                 horizontalAlignment: Text.AlignRight

--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -178,7 +178,7 @@ Item {
                     Label {
                         id: optionVoterPercentage
                         font.pixelSize: Theme.fontSizeTiny
-                        text: qsTr("%Ln\%", "% of votes for option").arg(modelData.vote_percentage)
+                        text: qsTr("%Ln\%", "% of votes for option", modelData.vote_percentage)
                         horizontalAlignment: Text.AlignRight
                         anchors {
                             right: parent.right
@@ -226,7 +226,7 @@ Item {
                 id: totalVoterCount
                 font.pixelSize: Theme.fontSizeTiny
                 anchors.verticalCenter: parent.verticalCenter
-                text: qsTr("%Ln vote(s) total", "number of total votes", pollData.total_voter_count).arg(pollData.total_voter_count)
+                text: qsTr("%Ln vote(s) total", "number of total votes", pollData.total_voter_count)
                 width: contentWidth
                 height: contentHeight
                 horizontalAlignment: Text.AlignRight

--- a/qml/components/chatInformationPage/ChatInformationPageContent.qml
+++ b/qml/components/chatInformationPage/ChatInformationPageContent.qml
@@ -98,13 +98,17 @@ SilicaFlickable {
         }
     }
     function updateGroupStatusText() {
-        if (chatOnlineMemberCount > 0) {
-            headerItem.description = qsTr("%1 members, %2 online").arg(Functions.getShortenedCount(chatInformationPage.groupInformation.member_count)).arg(Functions.getShortenedCount(chatInformationPage.chatOnlineMemberCount));
+        if (chatInformationPage.chatOnlineMemberCount > 0) {
+            headerItem.description = qsTr("%1, %2", "combination of '[x members], [y online]', which are separate translations")
+                .arg(qsTr("%1 members", "", chatInformationPage.groupInformation.member_count)
+                    .arg(Functions.getShortenedCount(chatInformationPage.groupInformation.member_count)))
+                .arg(qsTr("%1 online", "", chatInformationPage.chatOnlineMemberCount)
+                    .arg(Functions.getShortenedCount(chatInformationPage.chatOnlineMemberCount)));
         } else {
             if (isChannel) {
-                headerItem.description = qsTr("%1 subscribers").arg(Functions.getShortenedCount(chatInformationPage.groupInformation.member_count));
+                headerItem.description = qsTr("%1 subscribers", "", chatInformationPage.groupInformation.member_count ).arg(Functions.getShortenedCount(chatInformationPage.groupInformation.member_count));
             } else {
-                headerItem.description = qsTr("%1 members").arg(Functions.getShortenedCount(chatInformationPage.groupInformation.member_count));
+                headerItem.description = qsTr("%1 members", "", chatInformationPage.groupInformation.member_count).arg(Functions.getShortenedCount(chatInformationPage.groupInformation.member_count));
             }
         }
     }

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -67,7 +67,7 @@ Page {
             }
             PropertyChanges {
                 target: chatStatusText
-                text: qsTr("%n messages selected", "number of messages selected", chatPage.selectedMessages.length).arg(chatPage.selectedMessages.length)
+                text: qsTr("%Ln messages selected", "number of messages selected", chatPage.selectedMessages.length).arg(chatPage.selectedMessages.length)
             }
             PropertyChanges {
                 target: selectedMessagesActions
@@ -102,6 +102,9 @@ Page {
     }
 
     function updateChatPartnerStatusText() {
+        if(chatPage.state === "selectMessages") {
+            return
+        }
         var statusText = Functions.getChatPartnerStatusText(chatPartnerInformation.status['@type'], chatPartnerInformation.status.was_online);
         if(statusText) {
             chatStatusText.text = statusText;
@@ -113,12 +116,16 @@ Page {
             return
         }
         if (chatOnlineMemberCount > 0) {
-            chatStatusText.text = qsTr("%1 members, %2 online").arg(Functions.getShortenedCount(chatGroupInformation.member_count)).arg(Functions.getShortenedCount(chatOnlineMemberCount));
+            chatStatusText.text = qsTr("%1, %2", "combination of '[x members], [y online]', which are separate translations")
+                .arg(qsTr("%1 members", "", chatGroupInformation.member_count)
+                    .arg(Functions.getShortenedCount(chatGroupInformation.member_count)))
+                .arg(qsTr("%1 online", "", chatOnlineMemberCount)
+                    .arg(Functions.getShortenedCount(chatOnlineMemberCount)));
         } else {
             if (isChannel) {
-                chatStatusText.text = qsTr("%1 subscribers").arg(Functions.getShortenedCount(chatGroupInformation.member_count));
+                chatStatusText.text = qsTr("%1 subscribers", "", chatGroupInformation.member_count).arg(Functions.getShortenedCount(chatGroupInformation.member_count));
             } else {
-                chatStatusText.text = qsTr("%1 members").arg(Functions.getShortenedCount(chatGroupInformation.member_count));
+                chatStatusText.text = qsTr("%1 members", "", chatGroupInformation.member_count).arg(Functions.getShortenedCount(chatGroupInformation.member_count));
             }
         }
         joinLeaveChatMenuItem.text = chatPage.userIsMember ? qsTr("Leave Chat") : qsTr("Join Chat");

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1299,7 +1299,7 @@ Page {
                             }
                             onClicked: {
                                 Clipboard.text = Functions.getMessagesArrayText(chatPage.selectedMessages);
-                                appNotification.show(qsTr("%n messages have been copied", "", selectedMessages.length).arg(selectedMessages.length));
+                                appNotification.show(qsTr("%Ln messages have been copied", "", selectedMessages.length));
                                 chatPage.selectedMessages = [];
                             }
                         }
@@ -1323,7 +1323,7 @@ Page {
                                 var chatId = chatInformation.id
                                 pageStack.push(Qt.resolvedUrl("../pages/ChatSelectionPage.qml"), {
                                     myUserId: chatPage.myUserId,
-                                    headerDescription: qsTr("Forward %n messages", "dialog header", ids.length).arg(ids.length),
+                                    headerDescription: qsTr("Forward %Ln messages", "dialog header", ids.length),
                                     payload: {fromChatId: chatId, messageIds:ids, neededPermissions: neededPermissions},
                                     state: "forwardMessages"
                                 })
@@ -1347,7 +1347,7 @@ Page {
                                 var ids = Functions.getMessagesArrayIds(selectedMessages);
                                 var chatId = chatInformation.id
                                 var wrapper = tdLibWrapper;
-                                Remorse.popupAction(chatPage, qsTr("%n Messages deleted", "", ids.length).arg(ids.length), function() {
+                                Remorse.popupAction(chatPage, qsTr("%Ln Messages deleted", "", ids.length), function() {
                                     wrapper.deleteMessages(chatId, ids);
                                 });
                                 chatPage.selectedMessages = [];

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -67,7 +67,7 @@ Page {
             }
             PropertyChanges {
                 target: chatStatusText
-                text: qsTr("%Ln messages selected", "number of messages selected", chatPage.selectedMessages.length).arg(chatPage.selectedMessages.length)
+                text: qsTr("%Ln messages selected", "number of messages selected", chatPage.selectedMessages.length)
             }
             PropertyChanges {
                 target: selectedMessagesActions

--- a/qml/pages/PollCreationPage.qml
+++ b/qml/pages/PollCreationPage.qml
@@ -193,7 +193,7 @@ Dialog {
                 placeholderText: qsTr("Enter your question here")
                 property int charactersLeft: 255 - text.length
                 color: charactersLeft < 0 ? Theme.errorColor : Theme.highlightColor
-                label: qsTr("Question (%n1 characters left)", "", charactersLeft).arg(charactersLeft)
+                label: qsTr("Question (%Ln characters left)", "", charactersLeft).arg(charactersLeft)
                 wrapMode: TextEdit.Wrap
                 onFocusChanged: {
                     validate();
@@ -253,7 +253,7 @@ Dialog {
                             placeholderText: qsTr("Enter an answer here")
                             property int charactersLeft: 100 - text.length
                             color: charactersLeft < 0 ? Theme.errorColor : Theme.highlightColor
-                            label: qsTr("Answer (%n1 characters left)", "", charactersLeft).arg(charactersLeft)
+                            label: qsTr("Answer (%Ln characters left)", "", charactersLeft).arg(charactersLeft)
                             property bool hasNextOption: index < pollCreationPage.options.count - 1
                             EnterKey.onClicked: {
                                 if(hasNextOption) {

--- a/qml/pages/PollCreationPage.qml
+++ b/qml/pages/PollCreationPage.qml
@@ -193,7 +193,7 @@ Dialog {
                 placeholderText: qsTr("Enter your question here")
                 property int charactersLeft: 255 - text.length
                 color: charactersLeft < 0 ? Theme.errorColor : Theme.highlightColor
-                label: qsTr("Question (%Ln characters left)", "", charactersLeft).arg(charactersLeft)
+                label: qsTr("Question (%Ln characters left)", "", charactersLeft)
                 wrapMode: TextEdit.Wrap
                 onFocusChanged: {
                     validate();
@@ -253,7 +253,7 @@ Dialog {
                             placeholderText: qsTr("Enter an answer here")
                             property int charactersLeft: 100 - text.length
                             color: charactersLeft < 0 ? Theme.errorColor : Theme.highlightColor
-                            label: qsTr("Answer (%Ln characters left)", "", charactersLeft).arg(charactersLeft)
+                            label: qsTr("Answer (%Ln characters left)", "", charactersLeft)
                             property bool hasNextOption: index < pollCreationPage.options.count - 1
                             EnterKey.onClicked: {
                                 if(hasNextOption) {

--- a/qml/pages/PollResultsPage.qml
+++ b/qml/pages/PollResultsPage.qml
@@ -56,7 +56,7 @@ Page {
         PageHeader {
             id: pageHeader
             title: pollResultsPage.isQuiz ? qsTr("Quiz Results") : qsTr("Poll Results")
-            description: qsTr("%Ln vote(s) total", "number of total votes", pollData.total_voter_count).arg(pollData.total_voter_count)
+            description: qsTr("%Ln vote(s) total", "number of total votes", pollData.total_voter_count)
             leftMargin: headerPictureThumbnail.width + Theme.paddingLarge + Theme.horizontalPageMargin
             ProfileThumbnail {
                 id: headerPictureThumbnail
@@ -205,7 +205,7 @@ Page {
                             Label {
                                 id: optionVoterCount
                                 font.pixelSize: Theme.fontSizeTiny
-                                text: modelData.is_chosen ? qsTr("%Ln vote(s) including yours", "number of votes for option", modelData.voter_count).arg(modelData.voter_count) : qsTr("%Ln vote(s)", "number of votes for option", modelData.voter_count).arg(modelData.voter_count)
+                                text: modelData.is_chosen ? qsTr("%Ln vote(s) including yours", "number of votes for option", modelData.voter_count) : qsTr("%Ln vote(s)", "number of votes for option", modelData.voter_count)
                                 anchors {
                                     left: parent.left
                                     right: parent.horizontalCenter
@@ -216,7 +216,7 @@ Page {
                             Label {
                                 id: optionVoterPercentage
                                 font.pixelSize: Theme.fontSizeTiny
-                                text: qsTr("%Ln\%", "% of votes for option").arg(modelData.vote_percentage)
+                                text: qsTr("%Ln\%", "% of votes for option", modelData.vote_percentage)
                                 horizontalAlignment: Text.AlignRight
                                 anchors {
                                     right: parent.right

--- a/qml/pages/PollResultsPage.qml
+++ b/qml/pages/PollResultsPage.qml
@@ -56,7 +56,7 @@ Page {
         PageHeader {
             id: pageHeader
             title: pollResultsPage.isQuiz ? qsTr("Quiz Results") : qsTr("Poll Results")
-            description: qsTr("%L1 vote(s) total", "number of total votes", pollData.total_voter_count).arg(pollData.total_voter_count)
+            description: qsTr("%Ln vote(s) total", "number of total votes", pollData.total_voter_count).arg(pollData.total_voter_count)
             leftMargin: headerPictureThumbnail.width + Theme.paddingLarge + Theme.horizontalPageMargin
             ProfileThumbnail {
                 id: headerPictureThumbnail
@@ -205,7 +205,7 @@ Page {
                             Label {
                                 id: optionVoterCount
                                 font.pixelSize: Theme.fontSizeTiny
-                                text: modelData.is_chosen ? qsTr("%L1 vote(s) including yours", "number of votes for option", modelData.voter_count).arg(modelData.voter_count) : qsTr("%L1 vote(s)", "number of votes for option", modelData.voter_count).arg(modelData.voter_count)
+                                text: modelData.is_chosen ? qsTr("%Ln vote(s) including yours", "number of votes for option", modelData.voter_count).arg(modelData.voter_count) : qsTr("%Ln vote(s)", "number of votes for option", modelData.voter_count).arg(modelData.voter_count)
                                 anchors {
                                     left: parent.left
                                     right: parent.horizontalCenter
@@ -216,7 +216,7 @@ Page {
                             Label {
                                 id: optionVoterPercentage
                                 font.pixelSize: Theme.fontSizeTiny
-                                text: qsTr("%L1\%", "% of votes for option").arg(modelData.vote_percentage)
+                                text: qsTr("%Ln\%", "% of votes for option").arg(modelData.vote_percentage)
                                 horizontalAlignment: Text.AlignRight
                                 anchors {
                                     right: parent.right

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -371,7 +371,7 @@ void NotificationManager::publishNotification(const NotificationGroup *notificat
     } else {
         // Either we have more than one notification or we have no content to display
         LOG("Group" << notificationGroup->notificationGroupId << "has" << notificationGroup->totalCount << "notifications");
-        notificationBody = tr("%1 unread messages").arg(notificationGroup->totalCount);
+        notificationBody = tr("%Ln unread messages", "", notificationGroup->totalCount).arg(notificationGroup->totalCount);
     }
 
     nemoNotification->setBody(notificationBody);

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -371,7 +371,7 @@ void NotificationManager::publishNotification(const NotificationGroup *notificat
     } else {
         // Either we have more than one notification or we have no content to display
         LOG("Group" << notificationGroup->notificationGroupId << "has" << notificationGroup->totalCount << "notifications");
-        notificationBody = tr("%Ln unread messages", "", notificationGroup->totalCount).arg(notificationGroup->totalCount);
+        notificationBody = tr("%Ln unread messages", "", notificationGroup->totalCount);
     }
 
     nemoNotification->setBody(notificationBody);

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -334,25 +334,25 @@
         <translation>Nachrichtenauswahl</translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation>
-            <numerusform>%n Nachrichten gelöscht</numerusform>
+            <numerusform>%Ln Nachrichten gelöscht</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation>
-            <numerusform>%n Nachrichten wurden kopiert</numerusform>
+            <numerusform>%Ln Nachrichten wurden kopiert</numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation>
-            <numerusform>%n Nachricht weiterleiten</numerusform>
-            <numerusform>%n Nachrichten weiterleiten</numerusform>
+            <numerusform>%Ln Nachricht weiterleiten</numerusform>
+            <numerusform>%Ln Nachrichten weiterleiten</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1045,10 +1045,13 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation>
+            <numerusform>%Ln%</numerusform>
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1111,10 +1114,13 @@
             <numerusform>%Ln Antworten</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation>
+            <numerusform>%Ln%</numerusform>
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -964,10 +964,10 @@
         <translation>Geben Sie Ihre Frage ein</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>Frage (%n1 Zeichen übrig)</numerusform>
-            <numerusform>Frage (%n1 Zeichen übrig)</numerusform>
+            <numerusform>Frage (%Ln Zeichen übrig)</numerusform>
+            <numerusform>Frage (%Ln Zeichen übrig)</numerusform>
         </translation>
     </message>
     <message>
@@ -980,10 +980,10 @@
         <translation>Geben Sie eine Antwort ein</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>Antwort (%n1 Zeichen übrig)</numerusform>
-            <numerusform>Antwort (%n1 Zeichen übrig)</numerusform>
+            <numerusform>Antwort (%Ln Zeichen übrig)</numerusform>
+            <numerusform>Antwort (%Ln Zeichen übrig)</numerusform>
         </translation>
     </message>
     <message>
@@ -1015,9 +1015,9 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1028,11 +1028,11 @@
         <translation>Mehrfachauswahl ist erlaubt.</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 Stimme insgesamt</numerusform>
-            <numerusform>%L1 Stimmen insgesamt</numerusform>
+            <numerusform>%Ln Stimme insgesamt</numerusform>
+            <numerusform>%Ln Stimmen insgesamt</numerusform>
         </translation>
     </message>
     <message>
@@ -1055,11 +1055,11 @@
         <translation>Umfrageergebnis</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 Stimme insgesamt</numerusform>
-            <numerusform>%L1 Stimmen insgesamt</numerusform>
+            <numerusform>%Ln Stimme insgesamt</numerusform>
+            <numerusform>%Ln Stimmen insgesamt</numerusform>
         </translation>
     </message>
     <message>
@@ -1073,17 +1073,17 @@
         <translation>Ergebnis</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 Antwort</numerusform>
-            <numerusform>%L1 Antworten</numerusform>
+            <numerusform>%Ln Antwort</numerusform>
+            <numerusform>%Ln Antworten</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
@@ -1091,11 +1091,11 @@
         <translation>Gewählt von:</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 Antwort inklusive Ihrer</numerusform>
-            <numerusform>%L1 Antworten inklusive Ihrer</numerusform>
+            <numerusform>%Ln Antwort inklusive Ihrer</numerusform>
+            <numerusform>%Ln Antworten inklusive Ihrer</numerusform>
         </translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -97,73 +97,87 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 Mitglieder, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 Abonnenten</translation>
+        <translation>
+            <numerusform>%1 Abonnent</numerusform>
+            <numerusform>%1 Abonnenten</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 Mitglieder</translation>
+        <translation>
+            <numerusform>%1 Mitglied</numerusform>
+            <numerusform>%1 Mitglieder</numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
-        <translation type="unfinished">Chat verlassen</translation>
+        <translation>Chat verlassen</translation>
     </message>
     <message>
         <source>Join Chat</source>
-        <translation type="unfinished">Chat beitreten</translation>
+        <translation>Chat beitreten</translation>
     </message>
     <message>
         <source>Leaving chat</source>
-        <translation type="unfinished">Verlasse Chat</translation>
+        <translation>Verlasse Chat</translation>
     </message>
     <message>
         <source>Unmute Chat</source>
-        <translation type="unfinished">Stummschaltung des Chats aufheben</translation>
+        <translation>Stummschaltung des Chats aufheben</translation>
     </message>
     <message>
         <source>Mute Chat</source>
-        <translation type="unfinished">Chat stummschalten</translation>
+        <translation>Chat stummschalten</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished">Unbekannt</translation>
+        <translation>Unbekannt</translation>
     </message>
     <message>
         <source>Chat Title</source>
         <comment>group title header</comment>
-        <translation type="unfinished">Chattitel</translation>
+        <translation>Chattitel</translation>
     </message>
     <message>
         <source>Enter 1-128 characters</source>
-        <translation type="unfinished">Geben Sie 1-128 Zeichen ein</translation>
+        <translation>Geben Sie 1-128 Zeichen ein</translation>
     </message>
     <message>
         <source>There is no information text available, yet.</source>
-        <translation type="unfinished">Es gibt noch keinen Informationstext.</translation>
+        <translation>Es gibt noch keinen Informationstext.</translation>
     </message>
     <message>
         <source>Info</source>
         <comment>group or user infotext header</comment>
-        <translation type="unfinished">Info</translation>
+        <translation>Info</translation>
     </message>
     <message>
         <source>Phone Number</source>
         <comment>user phone number header</comment>
-        <translation type="unfinished">Telefonnummer</translation>
+        <translation>Telefonnummer</translation>
     </message>
     <message>
         <source>Invite Link</source>
         <comment>header</comment>
-        <translation type="unfinished">Einladungslink</translation>
+        <translation>Einladungslink</translation>
     </message>
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
-        <translation type="unfinished">Der Einladungslink wurde in die Zwischenablage kopiert.</translation>
+        <translation>Der Einladungslink wurde in die Zwischenablage kopiert.</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation>%1, %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation>
+            <numerusform>%1 online</numerusform>
+            <numerusform>%1 online</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -203,17 +217,17 @@
     <message>
         <source>Groups</source>
         <comment>Button: groups in common (short)</comment>
-        <translation type="unfinished">Gruppen</translation>
+        <translation>Gruppen</translation>
     </message>
     <message>
         <source>Members</source>
         <comment>Button: Group Members</comment>
-        <translation type="unfinished">Mitglieder</translation>
+        <translation>Mitglieder</translation>
     </message>
     <message>
         <source>Settings</source>
         <comment>Button: Chat Settings</comment>
-        <translation type="unfinished">Einstellungen</translation>
+        <translation>Einstellungen</translation>
     </message>
 </context>
 <context>
@@ -257,17 +271,19 @@
         <source>Your message</source>
         <translation>Ihre Nachricht</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 Mitglieder, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 Mitglieder</translation>
+        <translation>
+            <numerusform>%1 Mitglied</numerusform>
+            <numerusform>%1 Mitglieder</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 Abonnenten</translation>
+        <translation>
+            <numerusform>%1 Abonnent</numerusform>
+            <numerusform>%1 Abonnenten</numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -332,19 +348,31 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
-        <translation>
-            <numerusform>%n Nachricht ausgewählt</numerusform>
-            <numerusform>%n Nachrichten ausgewählt</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <source>Forward %n messages</source>
         <comment>dialog header</comment>
         <translation>
             <numerusform>%n Nachricht weiterleiten</numerusform>
             <numerusform>%n Nachrichten weiterleiten</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation>
+            <numerusform>%Ln Nachricht ausgewählt</numerusform>
+            <numerusform>%Ln Nachrichten ausgewählt</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation>%1, %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation>
+            <numerusform>%1 online</numerusform>
+            <numerusform>%1 online</numerusform>
         </translation>
     </message>
 </context>
@@ -864,9 +892,12 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 ungelesene Nachrichten</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation>
+            <numerusform>%Ln ungelesene Nachricht</numerusform>
+            <numerusform>%Ln ungelesene Nachrichten</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -97,73 +97,87 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 members, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 subscribers</translation>
+        <translation>
+            <numerusform>%1 subscriber</numerusform>
+            <numerusform>%1 subscribers</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 members</translation>
+        <translation>
+            <numerusform>%1 member</numerusform>
+            <numerusform>%1 members</numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
-        <translation type="unfinished">Leave Chat</translation>
+        <translation>Leave Chat</translation>
     </message>
     <message>
         <source>Join Chat</source>
-        <translation type="unfinished">Join Chat</translation>
+        <translation>Join Chat</translation>
     </message>
     <message>
         <source>Leaving chat</source>
-        <translation type="unfinished">Leaving chat</translation>
+        <translation>Leaving chat</translation>
     </message>
     <message>
         <source>Unmute Chat</source>
-        <translation type="unfinished">Unmute Chat</translation>
+        <translation>Unmute Chat</translation>
     </message>
     <message>
         <source>Mute Chat</source>
-        <translation type="unfinished">Mute Chat</translation>
+        <translation>Mute Chat</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished">Unknown</translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <source>Chat Title</source>
         <comment>group title header</comment>
-        <translation type="unfinished">Chat Title</translation>
+        <translation>Chat Title</translation>
     </message>
     <message>
         <source>Enter 1-128 characters</source>
-        <translation type="unfinished">Enter 1-128 characters</translation>
+        <translation>Enter 1-128 characters</translation>
     </message>
     <message>
         <source>There is no information text available, yet.</source>
-        <translation type="unfinished">There is no information text available, yet.</translation>
+        <translation>There is no information text available, yet.</translation>
     </message>
     <message>
         <source>Info</source>
         <comment>group or user infotext header</comment>
-        <translation type="unfinished">Info</translation>
+        <translation>Info</translation>
     </message>
     <message>
         <source>Phone Number</source>
         <comment>user phone number header</comment>
-        <translation type="unfinished">Phone Number</translation>
+        <translation>Phone Number</translation>
     </message>
     <message>
         <source>Invite Link</source>
         <comment>header</comment>
-        <translation type="unfinished">Invite Link</translation>
+        <translation>Invite Link</translation>
     </message>
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
-        <translation type="unfinished">The Invite Link has been copied to the clipboard.</translation>
+        <translation>The Invite Link has been copied to the clipboard.</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation>%1, %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation>
+            <numerusform>%1 online</numerusform>
+            <numerusform>%1 online</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -203,17 +217,17 @@
     <message>
         <source>Groups</source>
         <comment>Button: groups in common (short)</comment>
-        <translation type="unfinished">Groups</translation>
+        <translation>Groups</translation>
     </message>
     <message>
         <source>Members</source>
         <comment>Button: Group Members</comment>
-        <translation type="unfinished">Members</translation>
+        <translation>Members</translation>
     </message>
     <message>
         <source>Settings</source>
         <comment>Button: Chat Settings</comment>
-        <translation type="unfinished">Settings</translation>
+        <translation>Settings</translation>
     </message>
 </context>
 <context>
@@ -257,17 +271,19 @@
         <source>Your message</source>
         <translation>Your message</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 members, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 members</translation>
+        <translation>
+            <numerusform>%1 member</numerusform>
+            <numerusform>%1 members</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 subscribers</translation>
+        <translation>
+            <numerusform>%1 subscriber</numerusform>
+            <numerusform>%1 subscribers</numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -332,19 +348,31 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
-        <translation>
-            <numerusform>%n message selected</numerusform>
-            <numerusform>%n messages selected</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <source>Forward %n messages</source>
         <comment>dialog header</comment>
         <translation>
             <numerusform>Forward %n message</numerusform>
             <numerusform>Forward %n messages</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation>
+            <numerusform>%Ln message selected</numerusform>
+            <numerusform>%Ln messages selected</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation>
+            <numerusform>%1 online</numerusform>
+            <numerusform>%1 online</numerusform>
         </translation>
     </message>
 </context>
@@ -864,9 +892,12 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 unread messages</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation>
+            <numerusform>%Ln unread message</numerusform>
+            <numerusform>%Ln unread messages</numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -334,25 +334,25 @@
         <translation>Select Messages</translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation>
-            <numerusform>%n Message deleted</numerusform>
-            <numerusform>%n Messages deleted</numerusform>
+            <numerusform>%Ln Message deleted</numerusform>
+            <numerusform>%Ln Messages deleted</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation>
-            <numerusform>%n message has been copied</numerusform>
-            <numerusform>%n messages have been copied</numerusform>
+            <numerusform>%Ln message has been copied</numerusform>
+            <numerusform>%Ln messages have been copied</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation>
-            <numerusform>Forward %n message</numerusform>
-            <numerusform>Forward %n messages</numerusform>
+            <numerusform>Forward %Ln message</numerusform>
+            <numerusform>Forward %Ln messages</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1045,10 +1045,13 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation>
+            <numerusform>%Ln%</numerusform>
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1111,10 +1114,13 @@
             <numerusform>%Ln votes</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation>
+            <numerusform>%Ln%</numerusform>
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -964,10 +964,10 @@
         <translation>Enter your question here</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>Question (%n1 character left)</numerusform>
-            <numerusform>Question (%n1 characters left)</numerusform>
+            <numerusform>Question (%Ln character left)</numerusform>
+            <numerusform>Question (%Ln characters left)</numerusform>
         </translation>
     </message>
     <message>
@@ -980,10 +980,10 @@
         <translation>Enter an answer here</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>Answer (%n1 character left)</numerusform>
-            <numerusform>Answer (%n1 characters left)</numerusform>
+            <numerusform>Answer (%Ln character left)</numerusform>
+            <numerusform>Answer (%Ln characters left)</numerusform>
         </translation>
     </message>
     <message>
@@ -1015,9 +1015,9 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1028,11 +1028,11 @@
         <translation>Multiple Answers are allowed.</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 vote total</numerusform>
-            <numerusform>%L1 votes total</numerusform>
+            <numerusform>%Ln vote total</numerusform>
+            <numerusform>%Ln votes total</numerusform>
         </translation>
     </message>
     <message>
@@ -1055,11 +1055,11 @@
         <translation>Poll Results</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 vote total</numerusform>
-            <numerusform>%L1 votes total</numerusform>
+            <numerusform>%Ln vote total</numerusform>
+            <numerusform>%Ln votes total</numerusform>
         </translation>
     </message>
     <message>
@@ -1073,17 +1073,17 @@
         <translation>Results</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 vote</numerusform>
-            <numerusform>%L1 votes</numerusform>
+            <numerusform>%Ln vote</numerusform>
+            <numerusform>%Ln votes</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
@@ -1091,11 +1091,11 @@
         <translation>Chosen by:</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 vote including yours</numerusform>
-            <numerusform>%L1 votes including yours</numerusform>
+            <numerusform>%Ln vote including yours</numerusform>
+            <numerusform>%Ln votes including yours</numerusform>
         </translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -329,22 +329,22 @@
         <translation>Seleccionar mensajes</translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation>
-            <numerusform>%n Mensajes borrados</numerusform>
+            <numerusform>%Ln Mensajes borrados</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation>
-            <numerusform>%n se han copiado los mensajes</numerusform>
+            <numerusform>%Ln se han copiado los mensajes</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation>
-            <numerusform>Reenviar %n mensajes</numerusform>
+            <numerusform>Reenviar %Ln mensajes</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1032,10 +1032,12 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1095,10 +1097,12 @@
             <numerusform>%Ln votos</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -97,17 +97,17 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 miembros, %2 en línea</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 suscriptores</translation>
+        <translation type="unfinished">
+            <numerusform>%1 suscriptores</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 miembros</translation>
+        <translation type="unfinished">
+            <numerusform>%1 miembros</numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
@@ -164,6 +164,17 @@
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation type="unfinished">El enlace de invitación se ha copiado en el portapapeles.</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +268,17 @@
         <source>Your message</source>
         <translation>Abc</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 miembros, %2 en línea</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 miembros</translation>
+        <translation type="unfinished">
+            <numerusform>%1 miembros</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 suscriptores</translation>
+        <translation type="unfinished">
+            <numerusform>%1 suscriptores</numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -330,17 +341,28 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
-        <translation>
-            <numerusform>%n mensajes seleccionados</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <source>Forward %n messages</source>
         <comment>dialog header</comment>
         <translation>
             <numerusform>Reenviar %n mensajes</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -860,9 +882,11 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 mensajes no leídos</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -960,9 +960,9 @@
         <translation>Marcar su pregunta aquí</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>Pregunta (quedan %n1 caracteres)</numerusform>
+            <numerusform>Pregunta (quedan %Ln caracteres)</numerusform>
         </translation>
     </message>
     <message>
@@ -975,9 +975,9 @@
         <translation>Marcar una respuesta aquí</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>Respuesta (quedan %n1 caracteres)</numerusform>
+            <numerusform>Respuesta (quedan %Ln caracteres)</numerusform>
         </translation>
     </message>
     <message>
@@ -1009,9 +1009,9 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1022,10 +1022,10 @@
         <translation>Se permiten múltiples respuestas.</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 votos totales</numerusform>
+            <numerusform>%Ln votos totales</numerusform>
         </translation>
     </message>
     <message>
@@ -1048,10 +1048,10 @@
         <translation>Resultados de encuesta</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 total de votos</numerusform>
+            <numerusform>%Ln total de votos</numerusform>
         </translation>
     </message>
     <message>
@@ -1065,16 +1065,16 @@
         <translation>Resultados</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 votos</numerusform>
+            <numerusform>%Ln votos</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
@@ -1082,10 +1082,10 @@
         <translation>Elegido por:</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 votos incluyendo el suyo</numerusform>
+            <numerusform>%Ln votos incluyendo el suyo</numerusform>
         </translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -334,21 +334,21 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -998,8 +998,8 @@
     <message numerus="yes">
         <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>Kysymys (%n merkki jäljellä)</numerusform>
-            <numerusform>Kysymys (%n merkkiä jäljellä)</numerusform>
+            <numerusform>Kysymys (%Ln merkki jäljellä)</numerusform>
+            <numerusform>Kysymys (%Ln merkkiä jäljellä)</numerusform>
         </translation>
     </message>
     <message>
@@ -1014,8 +1014,8 @@
     <message numerus="yes">
         <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>Vastaus (%n merkki jäljellä)</numerusform>
-            <numerusform>Vastaus (%n merkkiä jäljellä)</numerusform>
+            <numerusform>Vastaus (%Ln merkki jäljellä)</numerusform>
+            <numerusform>Vastaus (%Ln merkkiä jäljellä)</numerusform>
         </translation>
     </message>
     <message>
@@ -1046,10 +1046,13 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1112,10 +1115,13 @@
             <numerusform>%Ln ääntä</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -97,17 +97,19 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 jäsentä, %2 paikalla</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 tilaajaa</translation>
+        <translation type="unfinished">
+            <numerusform>%1 tilaajaa</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 jäsentä</translation>
+        <translation type="unfinished">
+            <numerusform>%1 jäsentä</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
@@ -164,6 +166,18 @@
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation type="unfinished">Kutsulinkki on kopioitu leikepöydälle.</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +271,19 @@
         <source>Your message</source>
         <translation>Viestisi</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 jäsentä, %2 paikalla</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 jäsentä</translation>
+        <translation type="unfinished">
+            <numerusform>%1 jäsentä</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 tilaajaa</translation>
+        <translation type="unfinished">
+            <numerusform>%1 tilaajaa</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -332,16 +348,28 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
+        <source>Forward %n messages</source>
+        <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
-        <comment>dialog header</comment>
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -865,9 +893,12 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 lukematonta viestiä</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -965,7 +965,7 @@
         <translation>Kirjoita kysymyksesi tähän</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
             <numerusform>Kysymys (%n merkki jäljellä)</numerusform>
             <numerusform>Kysymys (%n merkkiä jäljellä)</numerusform>
@@ -981,7 +981,7 @@
         <translation>Kirjoita vastaus tähän</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
             <numerusform>Vastaus (%n merkki jäljellä)</numerusform>
             <numerusform>Vastaus (%n merkkiä jäljellä)</numerusform>
@@ -1016,9 +1016,9 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1029,11 +1029,11 @@
         <translation>Useampi vastaus sallittu.</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>yhteensä %L1 ääni</numerusform>
-            <numerusform>yhteensä %L1 ääntä</numerusform>
+            <numerusform>yhteensä %Ln ääni</numerusform>
+            <numerusform>yhteensä %Ln ääntä</numerusform>
         </translation>
     </message>
     <message>
@@ -1056,11 +1056,11 @@
         <translation>Kyselyn tulokset</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>yhteensä %L1 ääni </numerusform>
-            <numerusform>yhteensä %L1 ääntä</numerusform>
+            <numerusform>yhteensä %Ln ääni </numerusform>
+            <numerusform>yhteensä %Ln ääntä</numerusform>
         </translation>
     </message>
     <message>
@@ -1074,17 +1074,17 @@
         <translation>Tulokset</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 ääni</numerusform>
-            <numerusform>%L1 ääntä</numerusform>
+            <numerusform>%Ln ääni</numerusform>
+            <numerusform>%Ln ääntä</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
@@ -1092,11 +1092,11 @@
         <translation>Valinnut:</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 ääni (sinun)</numerusform>
-            <numerusform>%L1 ääntä (mukaan lukien sinun)</numerusform>
+            <numerusform>%Ln ääni (sinun)</numerusform>
+            <numerusform>%Ln ääntä (mukaan lukien sinun)</numerusform>
         </translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -329,19 +329,19 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1032,10 +1032,12 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1095,10 +1097,12 @@
             <numerusform></numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -97,17 +97,17 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 tag, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 feliratkozott</translation>
+        <translation type="unfinished">
+            <numerusform>%1 feliratkozott</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 tag</translation>
+        <translation type="unfinished">
+            <numerusform>%1 tag</numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
@@ -164,6 +164,17 @@
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +268,17 @@
         <source>Your message</source>
         <translation>Üzeneted</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 tag, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 tag</translation>
+        <translation type="unfinished">
+            <numerusform>%1 tag</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 feliratkozott</translation>
+        <translation type="unfinished">
+            <numerusform>%1 feliratkozott</numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -330,15 +341,26 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
+        <source>Forward %n messages</source>
+        <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
-        <comment>dialog header</comment>
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
@@ -860,9 +882,11 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 olvasatlan üzenet</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -960,7 +960,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
@@ -975,7 +975,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
@@ -1009,7 +1009,7 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -1022,7 +1022,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1048,7 +1048,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1065,14 +1065,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -1082,7 +1082,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -964,10 +964,10 @@
         <translation>Scrivi la tua domanda</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>Domanda (%n1 carattere rimanente)</numerusform>
-            <numerusform>Domanda (%n1 caratteri rimanenti)</numerusform>
+            <numerusform>Domanda (%Ln carattere rimanente)</numerusform>
+            <numerusform>Domanda (%Ln caratteri rimanenti)</numerusform>
         </translation>
     </message>
     <message>
@@ -980,10 +980,10 @@
         <translation>Scrivi una risposta</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>Risposta (%n1 carattere rimanente)</numerusform>
-            <numerusform>Risposta (%n1 caratteri rimanenti)</numerusform>
+            <numerusform>Risposta (%Ln carattere rimanente)</numerusform>
+            <numerusform>Risposta (%Ln caratteri rimanenti)</numerusform>
         </translation>
     </message>
     <message>
@@ -1015,9 +1015,9 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1028,11 +1028,11 @@
         <translation>Risposte multiple consentite.</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 voto in totale</numerusform>
-            <numerusform>%L1 voti in totale</numerusform>
+            <numerusform>%Ln voto in totale</numerusform>
+            <numerusform>%Ln voti in totale</numerusform>
         </translation>
     </message>
     <message>
@@ -1055,11 +1055,11 @@
         <translation>Risultati sondaggio</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 voto in totale</numerusform>
-            <numerusform>%L1 voti in totale</numerusform>
+            <numerusform>%Ln voto in totale</numerusform>
+            <numerusform>%Ln voti in totale</numerusform>
         </translation>
     </message>
     <message>
@@ -1073,17 +1073,17 @@
         <translation>Risultati</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 voto</numerusform>
-            <numerusform>%L1 voti</numerusform>
+            <numerusform>%Ln voto</numerusform>
+            <numerusform>%Ln voti</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
@@ -1091,11 +1091,11 @@
         <translation>Scelta da:</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 voto incluso il tuo</numerusform>
-            <numerusform>%L1 voti incluso il tuo</numerusform>
+            <numerusform>%Ln voto incluso il tuo</numerusform>
+            <numerusform>%Ln voti incluso il tuo</numerusform>
         </translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -97,17 +97,19 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 membri, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 abbonati</translation>
+        <translation type="unfinished">
+            <numerusform>%1 abbonati</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 membri</translation>
+        <translation type="unfinished">
+            <numerusform>%1 membri</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
@@ -164,6 +166,18 @@
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation type="unfinished">Il link d&apos;invito è stato copiato nella clipboard.</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +271,19 @@
         <source>Your message</source>
         <translation>Tuo messaggio</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 membri, %2 online</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 membri</translation>
+        <translation type="unfinished">
+            <numerusform>%1 membri</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 abbonati</translation>
+        <translation type="unfinished">
+            <numerusform>%1 abbonati</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Unmute Chat</source>
@@ -332,16 +348,28 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
+        <source>Forward %n messages</source>
+        <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
-        <comment>dialog header</comment>
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -864,9 +892,12 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 messaggi non letti</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -334,21 +334,21 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1045,10 +1045,13 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1111,10 +1114,13 @@
             <numerusform>%Ln voti</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -339,28 +339,28 @@
         <translation>Wybierz wiadomości</translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation>
-            <numerusform>%n wiadomość została usunięta</numerusform>
-            <numerusform>%n wiadomości zostały usunięte</numerusform>
-            <numerusform>%n wiadomości zostało usunięte</numerusform>
+            <numerusform>%Ln wiadomość została usunięta</numerusform>
+            <numerusform>%Ln wiadomości zostały usunięte</numerusform>
+            <numerusform>%Ln wiadomości zostało usunięte</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation>
-            <numerusform>%n wiadomość została skopiowana</numerusform>
-            <numerusform>%n wiadomości zostały skopiowane</numerusform>
-            <numerusform>%n wiadomość zostało skopiowane</numerusform>
+            <numerusform>%Ln wiadomość została skopiowana</numerusform>
+            <numerusform>%Ln wiadomości zostały skopiowane</numerusform>
+            <numerusform>%Ln wiadomość zostało skopiowane</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation>
-            <numerusform>Przekaż %n wiadomość</numerusform>
-            <numerusform>Przekaż %n wiadomości</numerusform>
-            <numerusform>Przekaż %n wiadomości</numerusform>
+            <numerusform>Przekaż %Ln wiadomość</numerusform>
+            <numerusform>Przekaż %Ln wiadomości</numerusform>
+            <numerusform>Przekaż %Ln wiadomości</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1058,10 +1058,14 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1127,10 +1131,14 @@
             <numerusform>%Ln głosów</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -968,11 +968,11 @@
         <translation>Wprowadź tutaj swoje pytanie</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>Pytanie (pozostał %n1 znak)</numerusform>
-            <numerusform>Pytanie (pozostały %n1 znaki)</numerusform>
-            <numerusform>Pytanie (pozostało %n1 znaków)</numerusform>
+            <numerusform>Pytanie (pozostał %Ln znak)</numerusform>
+            <numerusform>Pytanie (pozostały %Ln znaki)</numerusform>
+            <numerusform>Pytanie (pozostało %Ln znaków)</numerusform>
         </translation>
     </message>
     <message>
@@ -985,11 +985,11 @@
         <translation>Wprowadź tutaj swoją odpowiedź</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>Odpowiedź (pozostał %n1 znak)</numerusform>
-            <numerusform>Odpowiedź (pozostały %n1 znaki)</numerusform>
-            <numerusform>Odpowiedź (pozostało %n1 znaków)</numerusform>
+            <numerusform>Odpowiedź (pozostał %Ln znak)</numerusform>
+            <numerusform>Odpowiedź (pozostały %Ln znaki)</numerusform>
+            <numerusform>Odpowiedź (pozostało %Ln znaków)</numerusform>
         </translation>
     </message>
     <message>
@@ -1021,9 +1021,9 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1034,12 +1034,12 @@
         <translation>Dozwolonych jest wiele odpowiedzi.</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 odpowiedź</numerusform>
-            <numerusform>%L1 odpowiedzi</numerusform>
-            <numerusform>%L1 odpowiedzi</numerusform>
+            <numerusform>%Ln odpowiedź</numerusform>
+            <numerusform>%Ln odpowiedzi</numerusform>
+            <numerusform>%Ln odpowiedzi</numerusform>
         </translation>
     </message>
     <message>
@@ -1062,12 +1062,12 @@
         <translation>Wyniki ankiety</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 odpowiedź</numerusform>
-            <numerusform>%L1 odpowiedzi</numerusform>
-            <numerusform>%L1 odpowiedzi</numerusform>
+            <numerusform>%Ln odpowiedź</numerusform>
+            <numerusform>%Ln odpowiedzi</numerusform>
+            <numerusform>%Ln odpowiedzi</numerusform>
         </translation>
     </message>
     <message>
@@ -1081,18 +1081,18 @@
         <translation>Wyniki</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 glos</numerusform>
-            <numerusform>%L1 głosy</numerusform>
-            <numerusform>%L1 głosów</numerusform>
+            <numerusform>%Ln glos</numerusform>
+            <numerusform>%Ln głosy</numerusform>
+            <numerusform>%Ln głosów</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
@@ -1100,12 +1100,12 @@
         <translation>Wybrany przez:</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 głos, w tym twój</numerusform>
-            <numerusform>%L1 głosy, w tym twój</numerusform>
-            <numerusform>%L1 głosów, w tym twój</numerusform>
+            <numerusform>%Ln głos, w tym twój</numerusform>
+            <numerusform>%Ln głosy, w tym twój</numerusform>
+            <numerusform>%Ln głosów, w tym twój</numerusform>
         </translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -113,17 +113,21 @@
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation>Link do zaproszenia został skopiowany do schowka.</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>$1 członków, %2 online </translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 subskrybentów</translation>
+        <translation type="unfinished">
+            <numerusform>%1 subskrybentów</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 czlonków</translation>
+        <translation type="unfinished">
+            <numerusform>%1 czlonków</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Leaving chat</source>
@@ -164,6 +168,19 @@
     <message>
         <source>Join Chat</source>
         <translation>Dołącz do czatu</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +274,21 @@
         <source>Your message</source>
         <translation>Twoja wiadomość</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>$1 członków, %2 online </translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 czlonków</translation>
+        <translation type="unfinished">
+            <numerusform>%1 czlonków</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 subskrybentów</translation>
+        <translation type="unfinished">
+            <numerusform>%1 subskrybentów</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -334,21 +355,34 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
-        <translation>
-            <numerusform>%n wiadomość została wybrana</numerusform>
-            <numerusform>%n wiadomości zostały wybrane</numerusform>
-            <numerusform>%n wiadomości zostało wybrane</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <source>Forward %n messages</source>
         <comment>dialog header</comment>
         <translation>
             <numerusform>Przekaż %n wiadomość</numerusform>
             <numerusform>Przekaż %n wiadomości</numerusform>
             <numerusform>Przekaż %n wiadomości</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -868,9 +902,13 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 nieprzeczytanych wiadomości</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -97,17 +97,21 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 участников, %2 онлайн</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 подписчиков</translation>
+        <translation type="unfinished">
+            <numerusform>%1 подписчиков</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 участников</translation>
+        <translation type="unfinished">
+            <numerusform>%1 участников</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
@@ -164,6 +168,19 @@
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation type="unfinished">Ссылка для приглашения скопирована в буффер обмена</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +274,21 @@
         <source>Your message</source>
         <translation>Ваше сообщение</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 участников, %2 онлайн</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 участников</translation>
+        <translation type="unfinished">
+            <numerusform>%1 участников</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 подписчиков</translation>
+        <translation type="unfinished">
+            <numerusform>%1 подписчиков</numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -334,8 +355,8 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
+        <source>Forward %n messages</source>
+        <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -343,8 +364,21 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
-        <comment>dialog header</comment>
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -868,9 +902,13 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 непрочитанных сообщений</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -968,7 +968,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -985,7 +985,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -1021,7 +1021,7 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -1034,7 +1034,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1062,7 +1062,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1081,7 +1081,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1090,7 +1090,7 @@
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -1100,7 +1100,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -339,7 +339,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -347,7 +347,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation type="unfinished">
             <numerusform></numerusform>
             <numerusform></numerusform>
@@ -355,7 +355,7 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1058,10 +1058,14 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1127,10 +1131,14 @@
             <numerusform></numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -334,25 +334,25 @@
         <translation>Välj meddelanden</translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation>
-            <numerusform>%n meddelande borttaget</numerusform>
-            <numerusform>%n meddelanden borttagna</numerusform>
+            <numerusform>%Ln meddelande borttaget</numerusform>
+            <numerusform>%Ln meddelanden borttagna</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation>
-            <numerusform>%n meddelande har kopierats</numerusform>
-            <numerusform>%n meddelanden har kopierats</numerusform>
+            <numerusform>%Ln meddelande har kopierats</numerusform>
+            <numerusform>%Ln meddelanden har kopierats</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation>
-            <numerusform>Vidarebefordra %n meddelande</numerusform>
-            <numerusform>Vidarebefordra %n meddelanden</numerusform>
+            <numerusform>Vidarebefordra %Ln meddelande</numerusform>
+            <numerusform>Vidarebefordra %Ln meddelanden</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1053,10 +1053,13 @@
         <source>Multiple Answers are allowed.</source>
         <translation>Flera svarsalternativ tillåtna.</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message numerus="yes">
         <source>%Ln vote(s) total</source>
@@ -1119,10 +1122,13 @@
             <numerusform>%Ln röster</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -97,17 +97,19 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 medlem(mar), %2 inloggad(e)</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 prenumerant(er)</translation>
+        <translation type="unfinished">
+            <numerusform>%1 prenumerant(er)</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 medlem(mar)</translation>
+        <translation type="unfinished">
+            <numerusform>%1 medlem(mar)</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
@@ -164,6 +166,18 @@
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation type="unfinished">Inbjudningslänken har kopierats till urklipp.</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +271,19 @@
         <source>Your message</source>
         <translation>Ditt meddelande</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 medlem(mar), %2 inloggad(e)</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 medlem(mar)</translation>
+        <translation type="unfinished">
+            <numerusform>%1 medlem(mar)</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 prenumerant(er)</translation>
+        <translation type="unfinished">
+            <numerusform>%1 prenumerant(er)</numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -332,19 +348,31 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
-        <translation>
-            <numerusform>%n meddelande valt</numerusform>
-            <numerusform>%n meddelanden valda</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <source>Forward %n messages</source>
         <comment>dialog header</comment>
         <translation>
             <numerusform>Vidarebefordra %n meddelande</numerusform>
             <numerusform>Vidarebefordra %n meddelanden</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -864,9 +892,12 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 oläst(a) meddelande(n)</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -964,10 +964,10 @@
         <translation>Ange din fråga här</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>Fråga (%n1 tecken kvar)</numerusform>
-            <numerusform>Fråga (%n1 tecken kvar)</numerusform>
+            <numerusform>Fråga (%Ln tecken kvar)</numerusform>
+            <numerusform>Fråga (%Ln tecken kvar)</numerusform>
         </translation>
     </message>
     <message>
@@ -980,10 +980,10 @@
         <translation>Ange svaret här</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>Svar (%n1 tecken kvar)</numerusform>
-            <numerusform>Svar (%n1 tecken kvar)</numerusform>
+            <numerusform>Svar (%Ln tecken kvar)</numerusform>
+            <numerusform>Svar (%Ln tecken kvar)</numerusform>
         </translation>
     </message>
     <message>
@@ -1023,16 +1023,16 @@
         <translation>Flera svarsalternativ tillåtna.</translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 röst sammanlagt</numerusform>
-            <numerusform>%L1 röster sammanlagt</numerusform>
+            <numerusform>%Ln röst sammanlagt</numerusform>
+            <numerusform>%Ln röster sammanlagt</numerusform>
         </translation>
     </message>
     <message>
@@ -1055,11 +1055,11 @@
         <translation>Omröstningsresultat</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>%L1 röst sammanlagt</numerusform>
-            <numerusform>%L1 röster sammanlagt</numerusform>
+            <numerusform>%Ln röst sammanlagt</numerusform>
+            <numerusform>%Ln röster sammanlagt</numerusform>
         </translation>
     </message>
     <message>
@@ -1073,25 +1073,25 @@
         <translation>Resultat</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 röst inklusive din</numerusform>
-            <numerusform>%L1 röster inklusive din</numerusform>
+            <numerusform>%Ln röst inklusive din</numerusform>
+            <numerusform>%Ln röster inklusive din</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 röst</numerusform>
-            <numerusform>%L1 röster</numerusform>
+            <numerusform>%Ln röst</numerusform>
+            <numerusform>%Ln röster</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -960,9 +960,9 @@
         <translation>在此输入你的问题</translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation>
-            <numerusform>问题(剩余 %n1 个字符)</numerusform>
+            <numerusform>问题(剩余 %Ln 个字符)</numerusform>
         </translation>
     </message>
     <message>
@@ -975,9 +975,9 @@
         <translation>在此输入回答</translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation>
-            <numerusform>回答(剩余 %n1 个字符)</numerusform>
+            <numerusform>回答(剩余 %Ln 个字符)</numerusform>
         </translation>
     </message>
     <message>
@@ -1009,9 +1009,9 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1022,10 +1022,10 @@
         <translation>允许多个回答。</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>总计 %L1 次回答</numerusform>
+            <numerusform>总计 %Ln 次回答</numerusform>
         </translation>
     </message>
     <message>
@@ -1048,10 +1048,10 @@
         <translation>投票结果</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation>
-            <numerusform>总计 %L1 次投票</numerusform>
+            <numerusform>总计 %Ln 次投票</numerusform>
         </translation>
     </message>
     <message>
@@ -1065,16 +1065,16 @@
         <translation>结果</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 次投票</numerusform>
+            <numerusform>%Ln 次投票</numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%L1%</translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
@@ -1082,10 +1082,10 @@
         <translation>选择此项的人:</translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation>
-            <numerusform>%L1 次投票，包括你</numerusform>
+            <numerusform>%Ln 次投票，包括你</numerusform>
         </translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -97,17 +97,17 @@
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished">%1 位成员, %2 位在线</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished">%1 位订阅者</translation>
+        <translation type="unfinished">
+            <numerusform>%1 位订阅者</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished">%1 位成员</translation>
+        <translation type="unfinished">
+            <numerusform>%1 位成员</numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
@@ -164,6 +164,17 @@
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
         <translation type="unfinished">邀请链接已复制到剪切板</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -257,17 +268,17 @@
         <source>Your message</source>
         <translation>你的消息</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation>%1 位成员, %2 位在线</translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation>%1 位成员</translation>
+        <translation type="unfinished">
+            <numerusform>%1 位成员</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation>%1 位订阅者</translation>
+        <translation type="unfinished">
+            <numerusform>%1 位订阅者</numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
@@ -330,17 +341,28 @@
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
-        <translation>
-            <numerusform>已选择 %n 则消息</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
         <source>Forward %n messages</source>
         <comment>dialog header</comment>
         <translation>
             <numerusform>转发 %n 则消息</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
         </translation>
     </message>
 </context>
@@ -860,9 +882,11 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation>%1 则未读消息</translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -329,22 +329,22 @@
         <translation>选择消息</translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation>
-            <numerusform>已删除 %n 则消息</numerusform>
+            <numerusform>已删除 %Ln 则消息</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation>
-            <numerusform>已复制 %n 则消息</numerusform>
+            <numerusform>已复制 %Ln 则消息</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation>
-            <numerusform>转发 %n 则消息</numerusform>
+            <numerusform>转发 %Ln 则消息</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1032,10 +1032,12 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1095,10 +1097,12 @@
             <numerusform>%Ln 次投票</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation type="unfinished">
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -1,169 +1,183 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="en">
 <context>
     <name>AboutPage</name>
     <message>
         <source>About Fernschreiber</source>
-        <translation type="unfinished"></translation>
+        <translation>About Fernschreiber</translation>
     </message>
     <message>
         <source>A Telegram client for Sailfish OS</source>
-        <translation type="unfinished"></translation>
+        <translation>A Telegram client for Sailfish OS</translation>
     </message>
     <message>
         <source>Send E-Mail</source>
-        <translation type="unfinished"></translation>
+        <translation>Send E-Mail</translation>
     </message>
     <message>
         <source>Licensed under GNU GPLv3</source>
-        <translation type="unfinished"></translation>
+        <translation>Licensed under GNU GPLv3</translation>
     </message>
     <message>
         <source>Sources on GitHub</source>
-        <translation type="unfinished"></translation>
+        <translation>Sources on GitHub</translation>
     </message>
     <message>
         <source>Terms of Service</source>
-        <translation type="unfinished"></translation>
+        <translation>Terms of Service</translation>
     </message>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"></translation>
+        <translation>Privacy Policy</translation>
     </message>
     <message>
         <source>Credits</source>
-        <translation type="unfinished"></translation>
+        <translation>Credits</translation>
     </message>
     <message>
         <source>This project uses the Telegram Database Library (TDLib). Thanks for making it available under the conditions of the Boost Software License 1.0!</source>
-        <translation type="unfinished"></translation>
+        <translation>This project uses the Telegram Database Library (TDLib). Thanks for making it available under the conditions of the Boost Software License 1.0!</translation>
     </message>
     <message>
         <source>Open Telegram Database Library on GitHub</source>
-        <translation type="unfinished"></translation>
+        <translation>Open Telegram Database Library on GitHub</translation>
     </message>
     <message>
         <source>About Telegram</source>
-        <translation type="unfinished"></translation>
+        <translation>About Telegram</translation>
     </message>
     <message>
         <source>This product uses the Telegram API but is not endorsed or certified by Telegram.</source>
-        <translation type="unfinished"></translation>
+        <translation>This product uses the Telegram API but is not endorsed or certified by Telegram.</translation>
     </message>
     <message>
         <source>TDLib version %1</source>
-        <translation type="unfinished"></translation>
+        <translation>TDLib version %1</translation>
     </message>
     <message>
         <source>Logged in as %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Logged in as %1</translation>
     </message>
     <message>
         <source>Phone number: +%1</source>
-        <translation type="unfinished"></translation>
+        <translation>Phone number: +%1</translation>
     </message>
     <message>
         <source>This project uses twemoji. Copyright 2018 Twitter, Inc. and other contributors. Thanks for making it available under the conditions of the MIT License (coding) and CC-BY 4.0 (graphics)!</source>
-        <translation type="unfinished"></translation>
+        <translation>This project uses twemoji. Copyright 2018 Twitter, Inc. and other contributors. Thanks for making it available under the conditions of the MIT License (coding) and CC-BY 4.0 (graphics)!</translation>
     </message>
     <message>
         <source>Open twemoji on GitHub</source>
-        <translation type="unfinished"></translation>
+        <translation>Open twemoji on GitHub</translation>
     </message>
     <message>
         <source>By Sebastian J. Wolf and &lt;a href=&quot;https://github.com/Wunderfitz/harbour-fernschreiber#contributions&quot;&gt;other contributors&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>By Sebastian J. Wolf and &lt;a href=&quot;https://github.com/Wunderfitz/harbour-fernschreiber#contributions&quot;&gt;other contributors&lt;/a&gt;</translation>
     </message>
     <message>
         <source>This project uses rlottie. Copyright 2020 Samsung Electronics Co., Ltd. and other contributors. Thanks for making it available under the conditions of the MIT License!</source>
-        <translation type="unfinished"></translation>
+        <translation>This project uses rlottie. Copyright 2020 Samsung Electronics Co., Ltd. and other contributors. Thanks for making it available under the conditions of the MIT License!</translation>
     </message>
     <message>
         <source>Open rlottie on GitHub</source>
-        <translation type="unfinished"></translation>
+        <translation>Open rlottie on GitHub</translation>
     </message>
 </context>
 <context>
     <name>BackgroundProgressIndicator</name>
     <message>
         <source>%1 %</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 %</translation>
     </message>
     <message>
         <source>%1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1</translation>
     </message>
 </context>
 <context>
     <name>ChatInformationPageContent</name>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>%1 subscriber</numerusform>
+            <numerusform>%1 subscribers</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>%1 member</numerusform>
+            <numerusform>%1 members</numerusform>
+        </translation>
     </message>
     <message>
         <source>Leave Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Leave Chat</translation>
     </message>
     <message>
         <source>Join Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Join Chat</translation>
     </message>
     <message>
         <source>Leaving chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Leaving chat</translation>
     </message>
     <message>
         <source>Unmute Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmute Chat</translation>
     </message>
     <message>
         <source>Mute Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Mute Chat</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <source>Chat Title</source>
         <comment>group title header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Chat Title</translation>
     </message>
     <message>
         <source>Enter 1-128 characters</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter 1-128 characters</translation>
     </message>
     <message>
         <source>There is no information text available, yet.</source>
-        <translation type="unfinished"></translation>
+        <translation>There is no information text available, yet.</translation>
     </message>
     <message>
         <source>Info</source>
         <comment>group or user infotext header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Info</translation>
     </message>
     <message>
         <source>Phone Number</source>
         <comment>user phone number header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Phone Number</translation>
     </message>
     <message>
         <source>Invite Link</source>
         <comment>header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Invite Link</translation>
     </message>
     <message>
         <source>The Invite Link has been copied to the clipboard.</source>
-        <translation type="unfinished"></translation>
+        <translation>The Invite Link has been copied to the clipboard.</translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation>%1, %2</translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation>
+            <numerusform>%1 online</numerusform>
+            <numerusform>%1 online</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -171,31 +185,31 @@
     <message>
         <source>Loading common chats…</source>
         <comment>chats you have in common with a user</comment>
-        <translation type="unfinished"></translation>
+        <translation>Loading common chats…</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <source>Loading group members…</source>
-        <translation type="unfinished"></translation>
+        <translation>Loading group members…</translation>
     </message>
     <message>
         <source>You</source>
-        <translation type="unfinished"></translation>
+        <translation>You</translation>
     </message>
     <message>
         <source>You don&apos;t have any groups in common with this user.</source>
-        <translation type="unfinished"></translation>
+        <translation>You don&apos;t have any groups in common with this user.</translation>
     </message>
     <message>
         <source>This group is empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>This group is empty.</translation>
     </message>
     <message>
         <source>Channel members are anonymous.</source>
-        <translation type="unfinished"></translation>
+        <translation>Channel members are anonymous.</translation>
     </message>
 </context>
 <context>
@@ -203,144 +217,162 @@
     <message>
         <source>Groups</source>
         <comment>Button: groups in common (short)</comment>
-        <translation type="unfinished"></translation>
+        <translation>Groups</translation>
     </message>
     <message>
         <source>Members</source>
         <comment>Button: Group Members</comment>
-        <translation type="unfinished"></translation>
+        <translation>Members</translation>
     </message>
     <message>
         <source>Settings</source>
         <comment>Button: Chat Settings</comment>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
 </context>
 <context>
     <name>ChatListViewItem</name>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <source>You</source>
-        <translation type="unfinished"></translation>
+        <translation>You</translation>
     </message>
     <message>
         <source>Unmute Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmute Chat</translation>
     </message>
     <message>
         <source>Mute Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Mute Chat</translation>
     </message>
     <message>
         <source>User Info</source>
-        <translation type="unfinished"></translation>
+        <translation>User Info</translation>
     </message>
     <message>
         <source>Group Info</source>
-        <translation type="unfinished"></translation>
+        <translation>Group Info</translation>
     </message>
     <message>
         <source>Mark all messages as read</source>
-        <translation type="unfinished"></translation>
+        <translation>Mark all messages as read</translation>
     </message>
 </context>
 <context>
     <name>ChatPage</name>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <source>Your message</source>
-        <translation type="unfinished"></translation>
+        <translation>Your message</translation>
     </message>
-    <message>
-        <source>%1 members, %2 online</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+    <message numerus="yes">
         <source>%1 members</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>%1 member</numerusform>
+            <numerusform>%1 members</numerusform>
+        </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%1 subscribers</source>
-        <translation type="unfinished"></translation>
+        <translation>
+            <numerusform>%1 subscriber</numerusform>
+            <numerusform>%1 subscribers</numerusform>
+        </translation>
     </message>
     <message>
         <source>Loading messages...</source>
-        <translation type="unfinished"></translation>
+        <translation>Loading messages...</translation>
     </message>
     <message>
         <source>Unmute Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Unmute Chat</translation>
     </message>
     <message>
         <source>Mute Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Mute Chat</translation>
     </message>
     <message>
         <source>Edit Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit Message</translation>
     </message>
     <message>
         <source>edited</source>
-        <translation type="unfinished"></translation>
+        <translation>edited</translation>
     </message>
     <message>
         <source>Uploading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Uploading...</translation>
     </message>
     <message>
         <source>This chat is empty.</source>
-        <translation type="unfinished"></translation>
+        <translation>This chat is empty.</translation>
     </message>
     <message>
         <source>Leave Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Leave Chat</translation>
     </message>
     <message>
         <source>Join Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Join Chat</translation>
     </message>
     <message>
         <source>Leaving chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Leaving chat</translation>
     </message>
     <message>
         <source>You joined the chat %1</source>
-        <translation type="unfinished"></translation>
+        <translation>You joined the chat %1</translation>
     </message>
     <message>
         <source>Select Messages</source>
-        <translation type="unfinished"></translation>
+        <translation>Select Messages</translation>
     </message>
     <message numerus="yes">
         <source>%n Messages deleted</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n Message deleted</numerusform>
+            <numerusform>%n Messages deleted</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>%n messages have been copied</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n messages selected</source>
-        <comment>number of messages selected</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%n message has been copied</numerusform>
+            <numerusform>%n messages have been copied</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <source>Forward %n messages</source>
         <comment>dialog header</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Forward %n message</numerusform>
+            <numerusform>Forward %n messages</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <source>%Ln messages selected</source>
+        <comment>number of messages selected</comment>
+        <translation>
+            <numerusform>%Ln message selected</numerusform>
+            <numerusform>%Ln messages selected</numerusform>
+        </translation>
+    </message>
+    <message>
+        <source>%1, %2</source>
+        <comment>combination of &apos;[x members], [y online]&apos;, which are separate translations</comment>
+        <translation></translation>
+    </message>
+    <message numerus="yes">
+        <source>%1 online</source>
+        <translation>
+            <numerusform>%1 online</numerusform>
+            <numerusform>%1 online</numerusform>
         </translation>
     </message>
 </context>
@@ -348,65 +380,65 @@
     <name>ChatSelectionPage</name>
     <message>
         <source>Select Chat</source>
-        <translation type="unfinished"></translation>
+        <translation>Select Chat</translation>
     </message>
     <message>
         <source>You don&apos;t have any chats yet.</source>
-        <translation type="unfinished"></translation>
+        <translation>You don&apos;t have any chats yet.</translation>
     </message>
 </context>
 <context>
     <name>CoverPage</name>
     <message>
         <source>unread message</source>
-        <translation type="unfinished"></translation>
+        <translation>unread message</translation>
     </message>
     <message>
         <source>unread messages</source>
-        <translation type="unfinished"></translation>
+        <translation>unread messages</translation>
     </message>
     <message>
         <source>in</source>
-        <translation type="unfinished"></translation>
+        <translation>in</translation>
     </message>
     <message>
         <source>Waiting for network...</source>
-        <translation type="unfinished"></translation>
+        <translation>Waiting for network...</translation>
     </message>
     <message>
         <source>Connecting to network...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecting to network...</translation>
     </message>
     <message>
         <source>Connecting to proxy...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecting to proxy...</translation>
     </message>
     <message>
         <source>Connected</source>
-        <translation type="unfinished"></translation>
+        <translation>Connected</translation>
     </message>
     <message>
         <source>Updating content...</source>
-        <translation type="unfinished"></translation>
+        <translation>Updating content...</translation>
     </message>
     <message>
         <source>chat</source>
-        <translation type="unfinished"></translation>
+        <translation>chat</translation>
     </message>
     <message>
         <source>chats</source>
-        <translation type="unfinished"></translation>
+        <translation>chats</translation>
     </message>
 </context>
 <context>
     <name>DocumentPreview</name>
     <message>
         <source>Download Document</source>
-        <translation type="unfinished"></translation>
+        <translation>Download Document</translation>
     </message>
     <message>
         <source>Open Document</source>
-        <translation type="unfinished"></translation>
+        <translation>Open Document</translation>
     </message>
 </context>
 <context>
@@ -414,67 +446,67 @@
     <message>
         <source>Group Member Permissions</source>
         <comment>what can normal group members do</comment>
-        <translation type="unfinished"></translation>
+        <translation>Group Member Permissions</translation>
     </message>
     <message>
         <source>Send Messages</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>Send Messages</translation>
     </message>
     <message>
         <source>Send Media Messages</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>Send Media Messages</translation>
     </message>
     <message>
         <source>Send Other Messages</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>Send Other Messages</translation>
     </message>
     <message>
         <source>Add Web Page Previews</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>Add Web Page Previews</translation>
     </message>
     <message>
         <source>Change Chat Info</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>Change Chat Info</translation>
     </message>
     <message>
         <source>Invite Users</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>Invite Users</translation>
     </message>
     <message>
         <source>Pin Messages</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>Pin Messages</translation>
     </message>
     <message>
         <source>New Members</source>
         <comment>what can new group members do</comment>
-        <translation type="unfinished"></translation>
+        <translation>New Members</translation>
     </message>
     <message>
         <source>New members can see older messages</source>
         <comment>member permission</comment>
-        <translation type="unfinished"></translation>
+        <translation>New members can see older messages</translation>
     </message>
 </context>
 <context>
     <name>EditSuperGroupSlowModeColumn</name>
     <message>
         <source>Slow Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Slow Mode</translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation>Off</translation>
     </message>
     <message>
         <source>Set how long every chat member has to wait between Messages</source>
-        <translation type="unfinished"></translation>
+        <translation>Set how long every chat member has to wait between Messages</translation>
     </message>
 </context>
 <context>
@@ -482,358 +514,358 @@
     <message>
         <source>sent a picture</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a picture</translation>
     </message>
     <message>
         <source>sent a picture</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a picture</translation>
     </message>
     <message>
         <source>sent a video</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a video</translation>
     </message>
     <message>
         <source>sent a video</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a video</translation>
     </message>
     <message>
         <source>sent an animation</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an animation</translation>
     </message>
     <message>
         <source>sent an animation</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an animation</translation>
     </message>
     <message>
         <source>sent a voice note</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a voice note</translation>
     </message>
     <message>
         <source>sent a document</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a document</translation>
     </message>
     <message>
         <source>sent a document</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a document</translation>
     </message>
     <message>
         <source>sent a location</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a location</translation>
     </message>
     <message>
         <source>sent a location</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a location</translation>
     </message>
     <message>
         <source>have registered with Telegram</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>have registered with Telegram</translation>
     </message>
     <message>
         <source>has registered with Telegram</source>
-        <translation type="unfinished"></translation>
+        <translation>has registered with Telegram</translation>
     </message>
     <message>
         <source>joined this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>joined this chat</translation>
     </message>
     <message>
         <source>joined this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>joined this chat</translation>
     </message>
     <message>
         <source>were added to this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>were added to this chat</translation>
     </message>
     <message>
         <source>was added to this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>was added to this chat</translation>
     </message>
     <message>
         <source>left this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>left this chat</translation>
     </message>
     <message>
         <source>left this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>left this chat</translation>
     </message>
     <message>
         <source>Sticker: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Sticker: %1</translation>
     </message>
     <message>
         <source>sent a voice note</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a voice note</translation>
     </message>
     <message>
         <source>sent a venue</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a venue</translation>
     </message>
     <message>
         <source>sent a venue</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a venue</translation>
     </message>
     <message>
         <source>changed the chat title</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat title</translation>
     </message>
     <message>
         <source>changed the chat title</source>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat title</translation>
     </message>
     <message>
         <source>sent a poll</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a poll</translation>
     </message>
     <message>
         <source>sent a poll</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a poll</translation>
     </message>
     <message>
         <source>sent a quiz</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a quiz</translation>
     </message>
     <message>
         <source>sent a quiz</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a quiz</translation>
     </message>
     <message>
         <source>created this group</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>created this group</translation>
     </message>
     <message>
         <source>created this group</source>
-        <translation type="unfinished"></translation>
+        <translation>created this group</translation>
     </message>
     <message>
         <source>changed the chat photo</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat photo</translation>
     </message>
     <message>
         <source>changed the chat photo</source>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat photo</translation>
     </message>
     <message>
         <source>deleted the chat photo</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>deleted the chat photo</translation>
     </message>
     <message>
         <source>deleted the chat photo</source>
-        <translation type="unfinished"></translation>
+        <translation>deleted the chat photo</translation>
     </message>
     <message>
         <source>changed the secret chat TTL setting</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the secret chat TTL setting</translation>
     </message>
     <message>
         <source>changed the secret chat TTL setting</source>
-        <translation type="unfinished"></translation>
+        <translation>changed the secret chat TTL setting</translation>
     </message>
     <message>
         <source>upgraded this group to a supergroup</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>upgraded this group to a supergroup</translation>
     </message>
     <message>
         <source>changed the pinned message</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the pinned message</translation>
     </message>
     <message>
         <source>changed the pinned message</source>
-        <translation type="unfinished"></translation>
+        <translation>changed the pinned message</translation>
     </message>
     <message>
         <source>created a screenshot in this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>created a screenshot in this chat</translation>
     </message>
     <message>
         <source>created a screenshot in this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>created a screenshot in this chat</translation>
     </message>
     <message>
         <source>sent an unsupported message</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message</translation>
     </message>
     <message>
         <source>sent an unsupported message</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message</translation>
     </message>
     <message>
         <source>sent an unsupported message: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message: %1</translation>
     </message>
     <message>
         <source>upgraded this group to a supergroup</source>
-        <translation type="unfinished"></translation>
+        <translation>upgraded this group to a supergroup</translation>
     </message>
     <message>
         <source>sent a self-destructing photo that is expired</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing photo that is expired</translation>
     </message>
     <message>
         <source>sent a self-destructing video that is expired</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing video that is expired</translation>
     </message>
     <message>
         <source>sent a self-destructing video that is expired</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing video that is expired</translation>
     </message>
     <message>
         <source>sent an unsupported message: %1</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message: %1</translation>
     </message>
     <message>
         <source>sent a self-destructing photo that is expired</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing photo that is expired</translation>
     </message>
 </context>
 <context>
     <name>ImagePage</name>
     <message>
         <source>Download Picture</source>
-        <translation type="unfinished"></translation>
+        <translation>Download Picture</translation>
     </message>
     <message>
         <source>Download of %1 successful.</source>
-        <translation type="unfinished"></translation>
+        <translation>Download of %1 successful.</translation>
     </message>
     <message>
         <source>Download failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Download failed.</translation>
     </message>
 </context>
 <context>
     <name>InReplyToRow</name>
     <message>
         <source>You</source>
-        <translation type="unfinished"></translation>
+        <translation>You</translation>
     </message>
 </context>
 <context>
     <name>InitializationPage</name>
     <message>
         <source>OK</source>
-        <translation type="unfinished"></translation>
+        <translation>OK</translation>
     </message>
     <message>
         <source>Welcome to Fernschreiber!</source>
-        <translation type="unfinished"></translation>
+        <translation>Welcome to Fernschreiber!</translation>
     </message>
     <message>
         <source>Please enter your phone number to continue.</source>
-        <translation type="unfinished"></translation>
+        <translation>Please enter your phone number to continue.</translation>
     </message>
     <message>
         <source>Continue</source>
-        <translation type="unfinished"></translation>
+        <translation>Continue</translation>
     </message>
     <message>
         <source>Please enter the code that you received:</source>
-        <translation type="unfinished"></translation>
+        <translation>Please enter the code that you received:</translation>
     </message>
     <message>
         <source>Loading...</source>
-        <translation type="unfinished"></translation>
+        <translation>Loading...</translation>
     </message>
     <message>
         <source>Unable to authenticate you with the entered code.</source>
-        <translation type="unfinished"></translation>
+        <translation>Unable to authenticate you with the entered code.</translation>
     </message>
     <message>
         <source>Enter code again</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter code again</translation>
     </message>
     <message>
         <source>Restart authentication</source>
-        <translation type="unfinished"></translation>
+        <translation>Restart authentication</translation>
     </message>
     <message>
         <source>Please enter your password:</source>
-        <translation type="unfinished"></translation>
+        <translation>Please enter your password:</translation>
     </message>
     <message>
         <source>User Registration</source>
-        <translation type="unfinished"></translation>
+        <translation>User Registration</translation>
     </message>
     <message>
         <source>Enter your First Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter your First Name</translation>
     </message>
     <message>
         <source>Enter your Last Name</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter your Last Name</translation>
     </message>
     <message>
         <source>Register User</source>
-        <translation type="unfinished"></translation>
+        <translation>Register User</translation>
     </message>
     <message>
         <source>Use the international format, e.g. %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Use the international format, e.g. %1</translation>
     </message>
 </context>
 <context>
     <name>LocationPreview</name>
     <message>
         <source>Install Pure Maps to inspect this location.</source>
-        <translation type="unfinished"></translation>
+        <translation>Install Pure Maps to inspect this location.</translation>
     </message>
 </context>
 <context>
     <name>MessageListViewItem</name>
     <message>
         <source>Reply to Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Reply to Message</translation>
     </message>
     <message>
         <source>Edit Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Edit Message</translation>
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Copy Message to Clipboard</translation>
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished"></translation>
+        <translation>Message deleted</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Delete Message</translation>
     </message>
     <message>
         <source>You</source>
-        <translation type="unfinished"></translation>
+        <translation>You</translation>
     </message>
     <message>
         <source>Forwarded Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Forwarded Message</translation>
     </message>
     <message>
         <source>Select Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Select Message</translation>
     </message>
     <message>
         <source>Pin Message</source>
@@ -844,7 +876,7 @@
     <name>MessageListViewItemSimple</name>
     <message>
         <source>You</source>
-        <translation type="unfinished"></translation>
+        <translation>You</translation>
     </message>
 </context>
 <context>
@@ -860,52 +892,55 @@
 </context>
 <context>
     <name>NotificationManager</name>
-    <message>
-        <source>%1 unread messages</source>
-        <translation type="unfinished"></translation>
+    <message numerus="yes">
+        <source>%Ln unread messages</source>
+        <translation>
+            <numerusform>%Ln unread message</numerusform>
+            <numerusform>%Ln unread messages</numerusform>
+        </translation>
     </message>
 </context>
 <context>
     <name>OverviewPage</name>
     <message>
         <source>About Fernschreiber</source>
-        <translation type="unfinished"></translation>
+        <translation>About Fernschreiber</translation>
     </message>
     <message>
         <source>Fernschreiber</source>
-        <translation type="unfinished"></translation>
+        <translation>Fernschreiber</translation>
     </message>
     <message>
         <source>Waiting for network...</source>
-        <translation type="unfinished"></translation>
+        <translation>Waiting for network...</translation>
     </message>
     <message>
         <source>Connecting to network...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecting to network...</translation>
     </message>
     <message>
         <source>Connecting to proxy...</source>
-        <translation type="unfinished"></translation>
+        <translation>Connecting to proxy...</translation>
     </message>
     <message>
         <source>Updating content...</source>
-        <translation type="unfinished"></translation>
+        <translation>Updating content...</translation>
     </message>
     <message>
         <source>Unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>Unknown</translation>
     </message>
     <message>
         <source>Loading chat list...</source>
-        <translation type="unfinished"></translation>
+        <translation>Loading chat list...</translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <source>You don&apos;t have any chats yet.</source>
-        <translation type="unfinished"></translation>
+        <translation>You don&apos;t have any chats yet.</translation>
     </message>
 </context>
 <context>
@@ -927,83 +962,85 @@
     <name>PollCreationPage</name>
     <message>
         <source>All answers have to contain 1-100 characters.</source>
-        <translation type="unfinished"></translation>
+        <translation>All answers have to contain 1-100 characters.</translation>
     </message>
     <message>
         <source>To send a quiz, you have to specify the right answer.</source>
-        <translation type="unfinished"></translation>
+        <translation>To send a quiz, you have to specify the right answer.</translation>
     </message>
     <message>
         <source>You have to enter a question.</source>
-        <translation type="unfinished"></translation>
+        <translation>You have to enter a question.</translation>
     </message>
     <message>
         <source>The question has to be shorter than 256 characters.</source>
-        <translation type="unfinished"></translation>
+        <translation>The question has to be shorter than 256 characters.</translation>
     </message>
     <message>
         <source>A poll requires 2-10 answers.</source>
-        <translation type="unfinished"></translation>
+        <translation>A poll requires 2-10 answers.</translation>
     </message>
     <message>
         <source>Create a Poll</source>
         <comment>Dialog Header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Create a Poll</translation>
     </message>
     <message>
         <source>in %1</source>
         <comment>After dialog header… Create a Poll in [group name]</comment>
-        <translation type="unfinished"></translation>
+        <translation>in %1</translation>
     </message>
     <message>
         <source>Enter your question here</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter your question here</translation>
     </message>
     <message numerus="yes">
         <source>Question (%Ln characters left)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Question (%Ln character left)</numerusform>
+            <numerusform>Question (%Ln characters left)</numerusform>
         </translation>
     </message>
     <message>
         <source>Answers</source>
         <comment>Section header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Answers</translation>
     </message>
     <message>
         <source>Enter an answer here</source>
-        <translation type="unfinished"></translation>
+        <translation>Enter an answer here</translation>
     </message>
     <message numerus="yes">
         <source>Answer (%Ln characters left)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Answer (%Ln character left)</numerusform>
+            <numerusform>Answer (%Ln characters left)</numerusform>
         </translation>
     </message>
     <message>
         <source>Add an answer</source>
-        <translation type="unfinished"></translation>
+        <translation>Add an answer</translation>
     </message>
     <message>
         <source>Poll Options</source>
         <comment>Section header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Poll Options</translation>
     </message>
     <message>
         <source>Anonymous answers</source>
-        <translation type="unfinished"></translation>
+        <translation>Anonymous answers</translation>
     </message>
     <message>
         <source>Multiple answers allowed</source>
-        <translation type="unfinished"></translation>
+        <translation>Multiple answers allowed</translation>
     </message>
     <message>
         <source>Quiz Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Quiz Mode</translation>
     </message>
     <message>
         <source>Quizzes have one correct answer. Participants can&apos;t revoke their responses.</source>
-        <translation type="unfinished"></translation>
+        <translation>Quizzes have one correct answer. Participants can&apos;t revoke their responses.</translation>
     </message>
 </context>
 <context>
@@ -1011,81 +1048,85 @@
     <message>
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation type="unfinished"></translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Final Result:</source>
-        <translation type="unfinished"></translation>
+        <translation>Final Result:</translation>
     </message>
     <message>
         <source>Multiple Answers are allowed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Multiple Answers are allowed.</translation>
     </message>
     <message numerus="yes">
         <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%Ln vote total</numerusform>
+            <numerusform>%Ln votes total</numerusform>
         </translation>
     </message>
     <message>
         <source>Close Poll</source>
-        <translation type="unfinished"></translation>
+        <translation>Close Poll</translation>
     </message>
     <message>
         <source>Reset Answer</source>
-        <translation type="unfinished"></translation>
+        <translation>Reset Answer</translation>
     </message>
 </context>
 <context>
     <name>PollResultsPage</name>
     <message>
         <source>Quiz Results</source>
-        <translation type="unfinished"></translation>
+        <translation>Quiz Results</translation>
     </message>
     <message>
         <source>Poll Results</source>
-        <translation type="unfinished"></translation>
+        <translation>Poll Results</translation>
     </message>
     <message numerus="yes">
         <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%Ln vote total</numerusform>
+            <numerusform>%Ln votes total</numerusform>
         </translation>
     </message>
     <message>
         <source>Question</source>
         <comment>section header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Question</translation>
     </message>
     <message>
         <source>Results</source>
         <comment>section header</comment>
-        <translation type="unfinished"></translation>
+        <translation>Results</translation>
     </message>
     <message numerus="yes">
         <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%Ln vote</numerusform>
+            <numerusform>%Ln votes</numerusform>
         </translation>
     </message>
     <message>
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation type="unfinished"></translation>
+        <translation>%Ln%</translation>
     </message>
     <message>
         <source>Chosen by:</source>
         <comment>This answer has been chosen by the following users</comment>
-        <translation type="unfinished"></translation>
+        <translation>Chosen by:</translation>
     </message>
     <message numerus="yes">
         <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>%Ln vote including yours</numerusform>
+            <numerusform>%Ln votes including yours</numerusform>
         </translation>
     </message>
 </context>
@@ -1093,465 +1134,465 @@
     <name>SettingsPage</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Settings</translation>
     </message>
     <message>
         <source>Behavior</source>
-        <translation type="unfinished"></translation>
+        <translation>Behavior</translation>
     </message>
     <message>
         <source>Send message by enter</source>
-        <translation type="unfinished"></translation>
+        <translation>Send message by enter</translation>
     </message>
     <message>
         <source>Send your message by pressing the enter key</source>
-        <translation type="unfinished"></translation>
+        <translation>Send your message by pressing the enter key</translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="unfinished"></translation>
+        <translation>Appearance</translation>
     </message>
     <message>
         <source>Show stickers as images</source>
-        <translation type="unfinished"></translation>
+        <translation>Show stickers as images</translation>
     </message>
     <message>
         <source>Show background for stickers and align them centrally like images</source>
-        <translation type="unfinished"></translation>
+        <translation>Show background for stickers and align them centrally like images</translation>
     </message>
     <message>
         <source>Notification feedback</source>
-        <translation type="unfinished"></translation>
+        <translation>Notification feedback</translation>
     </message>
     <message>
         <source>All events</source>
-        <translation type="unfinished"></translation>
+        <translation>All events</translation>
     </message>
     <message>
         <source>Only new events</source>
-        <translation type="unfinished"></translation>
+        <translation>Only new events</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>None</translation>
     </message>
     <message>
         <source>Use non-graphical feedback (sound, vibration) for notifications</source>
-        <translation type="unfinished"></translation>
+        <translation>Use non-graphical feedback (sound, vibration) for notifications</translation>
     </message>
     <message>
         <source>Open-with menu integration</source>
-        <translation type="unfinished"></translation>
+        <translation>Open-with menu integration</translation>
     </message>
     <message>
         <source>Integrate Fernschreiber into open-with menu of Sailfish OS</source>
-        <translation type="unfinished"></translation>
+        <translation>Integrate Fernschreiber into open-with menu of Sailfish OS</translation>
     </message>
     <message>
         <source>Animate stickers</source>
-        <translation type="unfinished"></translation>
+        <translation>Animate stickers</translation>
     </message>
 </context>
 <context>
     <name>StickerPicker</name>
     <message>
         <source>Recently used</source>
-        <translation type="unfinished"></translation>
+        <translation>Recently used</translation>
     </message>
     <message>
         <source>Loading stickers...</source>
-        <translation type="unfinished"></translation>
+        <translation>Loading stickers...</translation>
     </message>
 </context>
 <context>
     <name>VideoPage</name>
     <message>
         <source>Download Video</source>
-        <translation type="unfinished"></translation>
+        <translation>Download Video</translation>
     </message>
     <message>
         <source>Download of %1 successful.</source>
-        <translation type="unfinished"></translation>
+        <translation>Download of %1 successful.</translation>
     </message>
     <message>
         <source>Download failed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Download failed.</translation>
     </message>
 </context>
 <context>
     <name>WebPagePreview</name>
     <message>
         <source>Preview not supported for this link...</source>
-        <translation type="unfinished"></translation>
+        <translation>Preview not supported for this link...</translation>
     </message>
 </context>
 <context>
     <name>functions</name>
     <message>
         <source>Video: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Video: %1</translation>
     </message>
     <message>
         <source>has registered with Telegram</source>
-        <translation type="unfinished"></translation>
+        <translation>has registered with Telegram</translation>
     </message>
     <message>
         <source>Picture: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Picture: %1</translation>
     </message>
     <message>
         <source>Sticker: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Sticker: %1</translation>
     </message>
     <message>
         <source>Audio: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Audio: %1</translation>
     </message>
     <message>
         <source>Voice Note: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Voice Note: %1</translation>
     </message>
     <message>
         <source>Animation: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Animation: %1</translation>
     </message>
     <message>
         <source>Document: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Document: %1</translation>
     </message>
     <message>
         <source>sent a picture</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a picture</translation>
     </message>
     <message>
         <source>sent a video</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a video</translation>
     </message>
     <message>
         <source>sent an animation</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an animation</translation>
     </message>
     <message>
         <source>sent an audio</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an audio</translation>
     </message>
     <message>
         <source>sent a voice note</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a voice note</translation>
     </message>
     <message>
         <source>sent a document</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a document</translation>
     </message>
     <message>
         <source>sent a location</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a location</translation>
     </message>
     <message>
         <source>joined this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>joined this chat</translation>
     </message>
     <message>
         <source>was added to this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>was added to this chat</translation>
     </message>
     <message>
         <source>left this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>left this chat</translation>
     </message>
     <message>
         <source>%1M</source>
-        <translation type="unfinished"></translation>
+        <translation>%1M</translation>
     </message>
     <message>
         <source>%1K</source>
-        <translation type="unfinished"></translation>
+        <translation>%1K</translation>
     </message>
     <message>
         <source>sent a venue</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a venue</translation>
     </message>
     <message>
         <source>sent a picture</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a picture</translation>
     </message>
     <message>
         <source>sent a video</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a video</translation>
     </message>
     <message>
         <source>sent an animation</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an animation</translation>
     </message>
     <message>
         <source>sent an audio</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an audio</translation>
     </message>
     <message>
         <source>sent a voice note</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a voice note</translation>
     </message>
     <message>
         <source>sent a document</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a document</translation>
     </message>
     <message>
         <source>sent a location</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a location</translation>
     </message>
     <message>
         <source>sent a venue</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a venue</translation>
     </message>
     <message>
         <source>have registered with Telegram</source>
-        <translation type="unfinished"></translation>
+        <translation>have registered with Telegram</translation>
     </message>
     <message>
         <source>joined this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>joined this chat</translation>
     </message>
     <message>
         <source>were added to this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>were added to this chat</translation>
     </message>
     <message>
         <source>left this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>left this chat</translation>
     </message>
     <message>
         <source>was never online</source>
-        <translation type="unfinished"></translation>
+        <translation>was never online</translation>
     </message>
     <message>
         <source>offline, last online: last month</source>
-        <translation type="unfinished"></translation>
+        <translation>offline, last online: last month</translation>
     </message>
     <message>
         <source>offline, last online: last week</source>
-        <translation type="unfinished"></translation>
+        <translation>offline, last online: last week</translation>
     </message>
     <message>
         <source>offline, last online: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>offline, last online: %1</translation>
     </message>
     <message>
         <source>online</source>
-        <translation type="unfinished"></translation>
+        <translation>online</translation>
     </message>
     <message>
         <source>offline, was recently online</source>
-        <translation type="unfinished"></translation>
+        <translation>offline, was recently online</translation>
     </message>
     <message>
         <source>Admin</source>
         <comment>channel user role</comment>
-        <translation type="unfinished"></translation>
+        <translation>Admin</translation>
     </message>
     <message>
         <source>Banned</source>
         <comment>channel user role</comment>
-        <translation type="unfinished"></translation>
+        <translation>Banned</translation>
     </message>
     <message>
         <source>Creator</source>
         <comment>channel user role</comment>
-        <translation type="unfinished"></translation>
+        <translation>Creator</translation>
     </message>
     <message>
         <source>Restricted</source>
         <comment>channel user role</comment>
-        <translation type="unfinished"></translation>
+        <translation>Restricted</translation>
     </message>
     <message>
         <source>changed the chat title to %1</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat title to %1</translation>
     </message>
     <message>
         <source>changed the chat title to %1</source>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat title to %1</translation>
     </message>
     <message>
         <source>sent a poll</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a poll</translation>
     </message>
     <message>
         <source>sent a poll</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a poll</translation>
     </message>
     <message>
         <source>sent an anonymous quiz</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an anonymous quiz</translation>
     </message>
     <message>
         <source>sent an anonymous quiz</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an anonymous quiz</translation>
     </message>
     <message>
         <source>sent a quiz</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a quiz</translation>
     </message>
     <message>
         <source>sent a quiz</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a quiz</translation>
     </message>
     <message>
         <source>sent an anonymous poll</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an anonymous poll</translation>
     </message>
     <message>
         <source>sent an anonymous poll</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an anonymous poll</translation>
     </message>
     <message>
         <source>Anonymous Quiz</source>
-        <translation type="unfinished"></translation>
+        <translation>Anonymous Quiz</translation>
     </message>
     <message>
         <source>Quiz</source>
-        <translation type="unfinished"></translation>
+        <translation>Quiz</translation>
     </message>
     <message>
         <source>Anonymous Poll</source>
-        <translation type="unfinished"></translation>
+        <translation>Anonymous Poll</translation>
     </message>
     <message>
         <source>Poll</source>
-        <translation type="unfinished"></translation>
+        <translation>Poll</translation>
     </message>
     <message>
         <source>created this group</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>created this group</translation>
     </message>
     <message>
         <source>created this group</source>
-        <translation type="unfinished"></translation>
+        <translation>created this group</translation>
     </message>
     <message>
         <source>changed the chat photo</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat photo</translation>
     </message>
     <message>
         <source>changed the chat photo</source>
-        <translation type="unfinished"></translation>
+        <translation>changed the chat photo</translation>
     </message>
     <message>
         <source>deleted the chat photo</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>deleted the chat photo</translation>
     </message>
     <message>
         <source>deleted the chat photo</source>
-        <translation type="unfinished"></translation>
+        <translation>deleted the chat photo</translation>
     </message>
     <message>
         <source>changed the secret chat TTL setting</source>
         <comment>myself; TTL = Time To Live</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the secret chat TTL setting</translation>
     </message>
     <message>
         <source>changed the secret chat TTL setting</source>
         <comment>TTL = Time To Live</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the secret chat TTL setting</translation>
     </message>
     <message>
         <source>upgraded this group to a supergroup</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>upgraded this group to a supergroup</translation>
     </message>
     <message>
         <source>changed the pinned message</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>changed the pinned message</translation>
     </message>
     <message>
         <source>changed the pinned message</source>
-        <translation type="unfinished"></translation>
+        <translation>changed the pinned message</translation>
     </message>
     <message>
         <source>created a screenshot in this chat</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>created a screenshot in this chat</translation>
     </message>
     <message>
         <source>created a screenshot in this chat</source>
-        <translation type="unfinished"></translation>
+        <translation>created a screenshot in this chat</translation>
     </message>
     <message>
         <source>sent an unsupported message</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message</translation>
     </message>
     <message>
         <source>sent an unsupported message</source>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message</translation>
     </message>
     <message>
         <source>sent an unsupported message: %1</source>
         <comment>myself; %1 is message type</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message: %1</translation>
     </message>
     <message>
         <source>sent an unsupported message: %1</source>
         <comment>%1 is message type</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent an unsupported message: %1</translation>
     </message>
     <message>
         <source>upgraded this group to a supergroup</source>
-        <translation type="unfinished"></translation>
+        <translation>upgraded this group to a supergroup</translation>
     </message>
     <message>
         <source>sent a self-destructing photo that is expired</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing photo that is expired</translation>
     </message>
     <message>
         <source>sent a self-destructing photo that is expired</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing photo that is expired</translation>
     </message>
     <message>
         <source>sent a self-destructing video that is expired</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing video that is expired</translation>
     </message>
     <message>
         <source>sent a self-destructing video that is expired</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a self-destructing video that is expired</translation>
     </message>
     <message>
         <source>Unable to find user %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Unable to find user %1</translation>
     </message>
     <message>
         <source>sent a video note</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation>sent a video note</translation>
     </message>
     <message>
         <source>sent a video note</source>
-        <translation type="unfinished"></translation>
+        <translation>sent a video note</translation>
     </message>
     <message>
         <source>You are already a member of this chat.</source>
-        <translation type="unfinished"></translation>
+        <translation>You are already a member of this chat.</translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -960,7 +960,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>Question (%n1 characters left)</source>
+        <source>Question (%Ln characters left)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
@@ -975,7 +975,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>Answer (%n1 characters left)</source>
+        <source>Answer (%Ln characters left)</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
@@ -1009,7 +1009,7 @@
 <context>
     <name>PollPreview</name>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -1022,7 +1022,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1048,7 +1048,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) total</source>
+        <source>%Ln vote(s) total</source>
         <comment>number of total votes</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
@@ -1065,14 +1065,14 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s)</source>
+        <source>%Ln vote(s)</source>
         <comment>number of votes for option</comment>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <source>%L1%</source>
+        <source>%Ln%</source>
         <comment>% of votes for option</comment>
         <translation type="unfinished"></translation>
     </message>
@@ -1082,7 +1082,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <source>%L1 vote(s) including yours</source>
+        <source>%Ln vote(s) including yours</source>
         <comment>number of votes for option</comment>
         <translation type="unfinished">
             <numerusform></numerusform>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -334,25 +334,25 @@
         <translation>Select Messages</translation>
     </message>
     <message numerus="yes">
-        <source>%n Messages deleted</source>
+        <source>%Ln Messages deleted</source>
         <translation>
-            <numerusform>%n Message deleted</numerusform>
-            <numerusform>%n Messages deleted</numerusform>
+            <numerusform>%Ln Message deleted</numerusform>
+            <numerusform>%Ln Messages deleted</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>%n messages have been copied</source>
+        <source>%Ln messages have been copied</source>
         <translation>
-            <numerusform>%n message has been copied</numerusform>
-            <numerusform>%n messages have been copied</numerusform>
+            <numerusform>%Ln message has been copied</numerusform>
+            <numerusform>%Ln messages have been copied</numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <source>Forward %n messages</source>
+        <source>Forward %Ln messages</source>
         <comment>dialog header</comment>
         <translation>
-            <numerusform>Forward %n message</numerusform>
-            <numerusform>Forward %n messages</numerusform>
+            <numerusform>Forward %Ln message</numerusform>
+            <numerusform>Forward %Ln messages</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -1045,10 +1045,13 @@
 </context>
 <context>
     <name>PollPreview</name>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation>
+            <numerusform>%Ln%</numerusform>
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Final Result:</source>
@@ -1111,10 +1114,13 @@
             <numerusform>%Ln votes</numerusform>
         </translation>
     </message>
-    <message>
+    <message numerus="yes">
         <source>%Ln%</source>
         <comment>% of votes for option</comment>
-        <translation>%Ln%</translation>
+        <translation>
+            <numerusform>%Ln%</numerusform>
+            <numerusform>%Ln%</numerusform>
+        </translation>
     </message>
     <message>
         <source>Chosen by:</source>


### PR DESCRIPTION
This should fix #20.

I've also added  `language="en"` to the base `harbour-fernschreiber.ts` – while it doesn't seem to be used for in-app output (it shows the same "untranslated" output when run from SDK, for example), this seems to generate/retain the `<numerusform>`-tags, which should be less confusing for translators using it as a base.

Sadly, it's inevitable that the "broken" strings now have to be re-translated.

Funny anecdote: 
At some point I really scratched my head, because I didn't think about how number placeholders like `%Ln` handle replacements within qsTr(), while `%i` requires a dedicated `.arg()` call. So I had a lot of useless `.arg()` calls spewing warnings left and right. While that took me more time I care to admit, these are removed now and it seems to work nicely.

Cheers!