### PR TITLE
Show notification popups except for the current chat

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -14,7 +14,7 @@ TARGET = harbour-fernschreiber
 
 CONFIG += sailfishapp sailfishapp_i18n
 
-PKGCONFIG += nemonotifications-qt5 ngf-qt5 zlib
+PKGCONFIG += nemonotifications-qt5 zlib
 
 QT += core dbus sql
 

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -35,6 +35,7 @@ Page {
     property bool isInitialized: false;
     readonly property int myUserId: tdLibWrapper.getUserInformation().id;
     property var chatInformation;
+    property alias chatPicture: chatPictureThumbnail.photoData
     property bool isPrivateChat: false;
     property bool isBasicGroup: false;
     property bool isSuperGroup: false;
@@ -352,6 +353,9 @@ Page {
                 pageStack.pushAttached(Qt.resolvedUrl("ChatInformationPage.qml"), { "chatInformation" : chatInformation, "privateChatUserInformation": chatPartnerInformation, "groupInformation": chatGroupInformation, "chatOnlineMemberCount": chatOnlineMemberCount});
                 chatPage.isInitialized = true;
             }
+            break;
+        case PageStatus.Inactive:
+            chatModel.clear();
             break;
         }
     }

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -237,7 +237,10 @@ Page {
                         ownUserId: overviewPage.ownUserId
 
                         onClicked: {
-                           pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : display });
+                            pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), {
+                                chatInformation : display,
+                                chatPicture: photo_small
+                            })
                         }
 
                         Connections {

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -85,6 +85,23 @@ bool ChatModel::insertRows(int row, int count, const QModelIndex &parent)
     return true;
 }
 
+void ChatModel::clear()
+{
+    LOG("Clearing chat model");
+    chatId = 0;
+    inReload = false;
+    inIncrementalUpdate = false;
+    if (!messages.isEmpty()) {
+        beginResetModel();
+        messages.clear();
+        endResetModel();
+    }
+    if (!chatInformation.isEmpty()) {
+        chatInformation.clear();
+        emit smallPhotoChanged();
+    }
+}
+
 void ChatModel::initialize(const QVariantMap &chatInformation)
 {
     LOG("Initializing chat model...");
@@ -155,6 +172,11 @@ int ChatModel::getLastReadMessageIndex()
 QVariantMap ChatModel::smallPhoto() const
 {
     return chatInformation.value(PHOTO).toMap().value(SMALL).toMap();
+}
+
+qlonglong ChatModel::getChatId() const
+{
+    return chatId;
 }
 
 static bool compareMessages(const QVariant &message1, const QVariant &message2)

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -36,14 +36,16 @@ public:
     virtual QVariant data(const QModelIndex &index, int role) const override;
     virtual bool insertRows(int row, int count, const QModelIndex &parent = QModelIndex()) override;
 
-
+    Q_INVOKABLE void clear();
     Q_INVOKABLE void initialize(const QVariantMap &chatInformation);
     Q_INVOKABLE void triggerLoadMoreHistory();
     Q_INVOKABLE void triggerLoadMoreFuture();
     Q_INVOKABLE QVariantMap getChatInformation();
     Q_INVOKABLE QVariantMap getMessage(int index);
     Q_INVOKABLE int getLastReadMessageIndex();
+
     QVariantMap smallPhoto() const;
+    qlonglong getChatId() const;
 
 signals:
     void messagesReceived(int modelIndex, int lastReadSentIndex, int totalCount);

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
     ChatModel chatModel(tdLibWrapper);
     context->setContextProperty("chatModel", &chatModel);
 
-    NotificationManager notificationManager(tdLibWrapper, appSettings);
+    NotificationManager notificationManager(tdLibWrapper, appSettings, &chatModel);
     context->setContextProperty("notificationManager", &notificationManager);
 
     ProcessLauncher processLauncher;

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -23,9 +23,10 @@
 #include <QObject>
 #include <QDBusInterface>
 #include <nemonotifications-qt5/notification.h>
-#include <ngf-qt5/NgfClient>
 #include "tdlibwrapper.h"
 #include "appsettings.h"
+
+class ChatModel;
 
 class NotificationManager : public QObject
 {
@@ -35,7 +36,7 @@ class NotificationManager : public QObject
 
 public:
 
-    NotificationManager(TDLibWrapper *tdLibWrapper, AppSettings *appSettings);
+    NotificationManager(TDLibWrapper *tdLibWrapper, AppSettings *appSettings, ChatModel *chatModel);
     ~NotificationManager() override;
 
 public slots:
@@ -45,11 +46,6 @@ public slots:
     void handleUpdateNotification(const QVariantMap &updatedNotification);
     void handleChatDiscovered(const QString &chatId, const QVariantMap &chatInformation);
     void handleChatTitleUpdated(const QString &chatId, const QString &title);
-    void handleNgfConnectionStatus(bool connected);
-    void handleNgfEventFailed(quint32 eventId);
-    void handleNgfEventCompleted(quint32 eventId);
-    void handleNgfEventPlaying(quint32 eventId);
-    void handleNgfEventPaused(quint32 eventId);
 
 private:
 
@@ -65,7 +61,7 @@ private:
 
     TDLibWrapper *tdLibWrapper;
     AppSettings *appSettings;
-    Ngf::Client *ngfClient;
+    ChatModel *chatModel;
     QMap<qlonglong,ChatInfo*> chatMap;
     QMap<int,NotificationGroup*> notificationGroups;
     QDBusInterface mceInterface;


### PR DESCRIPTION
And a few other related tweaks:

1. Drop dependency on Ngf
2. Pre-initialize the chat photo when pushing the chat page.

The "display on" option for popups will be made configurable once this is merged.