### PR TITLE
Add switchable Debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Sebastian J. Wolf [sebastian@ygriega.de](mailto:sebastian@ygriega.de) and severa
 Fernschreiber wouldn't be the same without all the people helping in making it better. Thank you very much to all contributors!
 
 ### Code (Features, Bugfixes, Optimizations etc.)
-- Chat list model, notifications, TDLib receiver, animated stickers, project dependencies: [Slava Monich](https://github.com/monich)
-- Chat info page, performance improvements to chat page, location support, app initialization/registration with Telegram, project dependencies: [jgibbon](https://github.com/jgibbon)
+- Chat list model, chat model, notifications, TDLib receiver, animated stickers, project dependencies, qml/c++ optimizations, chatPhoto, TDLibFile, code reviews, logging categories: [Slava Monich](https://github.com/monich)
+- Chat info page, performance improvements to chat page, location support, app initialization/registration with Telegram, project dependencies, emoji handling, qml/js optimizations, multi-message actions, i18n fixes, chat permission handling, code reviews, logging categories: [jgibbon](https://github.com/jgibbon)
 - Copy message to clipboard [Christian Stemmle](https://github.com/chstem)
 
 ### Logo/Icon
@@ -43,6 +43,13 @@ const char TDLIB_API_HASH[] = "1234567890abcdef1234567890abcdef";
 You get the Telegram API ID and hash as soon as you've registered your own application on [https://my.telegram.org](https://my.telegram.org).
 
 Moreover, you need to have a compiled version of [TDLib](https://github.com/tdlib/td) in the sub-directory `tdlib`. This sub-directory must contain another sub-directory that fits to the target device architecture (e.g. armv7hl, i486). Within this directory, there needs to be a folder called `lib` that contains at least `libtdjson.so`. For armv7hl the relative path would consequently be `tdlib/armv7hl/lib`.
+
+## Debug
+Fernschreiber does only output a few TDLib messages by default. To get its own debug log messages, you can either run a debug build to see all of them or use the environment variable `QT_LOGGING_RULES` to specify/filter which messages you'd like to see.
+
+Run `QT_LOGGING_RULES="fernschreiber.*=true" harbour-fernschreiber` to see all messages or replace the `*` with specific logging categories. You'll find the logging category inside the corresponding `.cpp` file for backend usage or you can use `JS` to only see frontend messages.
+
+## Contribute
 
 If you want to contribute bug fixes, improvements, new features etc. please create a pull request (PR). PRs are always welcome and will be reviewed as soon as possible, but may take some time. :)
 

--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -64,6 +64,7 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/components/chatInformationPage/ChatInformationTextItem.qml \
     qml/components/chatInformationPage/EditGroupChatPermissionsColumn.qml \
     qml/components/chatInformationPage/EditSuperGroupSlowModeColumn.qml \
+    qml/js/debug.js \
     qml/js/functions.js \
     qml/pages/ChatInformationPage.qml \
     qml/pages/ChatPage.qml \
@@ -146,6 +147,7 @@ HEADERS += \
     src/dbusadaptor.h \
     src/dbusinterface.h \
     src/debuglog.h \
+    src/debuglogjs.h \
     src/emojisearchworker.h \
     src/fernschreiberutils.h \
     src/notificationmanager.h \

--- a/qml/components/AudioPreview.qml
+++ b/qml/components/AudioPreview.qml
@@ -20,6 +20,8 @@ import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtMultimedia 5.6
 import "../js/functions.js" as Functions
+import "../js/debug.js" as Debug
+
 
 Item {
     id: audioMessageComponent
@@ -249,39 +251,39 @@ Item {
 
                 onStatusChanged: {
                     if (status == MediaPlayer.NoMedia) {
-                        console.log("No Media");
+                        Debug.log("No Media");
                         audioBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.Loading) {
-                        console.log("Loading");
+                        Debug.log("Loading");
                         audioBusyIndicator.visible = true;
                     }
                     if (status == MediaPlayer.Loaded) {
-                        console.log("Loaded");
+                        Debug.log("Loaded");
                         audioBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.Buffering) {
-                        console.log("Buffering");
+                        Debug.log("Buffering");
                         audioBusyIndicator.visible = true;
                     }
                     if (status == MediaPlayer.Stalled) {
-                        console.log("Stalled");
+                        Debug.log("Stalled");
                         audioBusyIndicator.visible = true;
                     }
                     if (status == MediaPlayer.Buffered) {
-                        console.log("Buffered");
+                        Debug.log("Buffered");
                         audioBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.EndOfMedia) {
-                        console.log("End of Media");
+                        Debug.log("End of Media");
                         audioBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.InvalidMedia) {
-                        console.log("Invalid Media");
+                        Debug.log("Invalid Media");
                         audioBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.UnknownStatus) {
-                        console.log("Unknown Status");
+                        Debug.log("Unknown Status");
                         audioBusyIndicator.visible = false;
                     }
                 }

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -21,6 +21,7 @@ import Sailfish.Silica 1.0
 import "../js/twemoji.js" as Emoji
 import "../js/functions.js" as Functions
 import QtQml.Models 2.3
+import "../js/debug.js" as Debug
 
 ListItem {
     id: messageListItem
@@ -136,12 +137,12 @@ ListItem {
             messageBackground.isUnread = index > chatModel.getLastReadMessageIndex();
         }
         onLastReadSentMessageUpdated: {
-            console.log("[ChatModel] Messages in this chat were read, new last read: " + lastReadSentIndex + ", updating description for index " + index + ", status: " + (index <= lastReadSentIndex));
+            Debug.log("[ChatModel] Messages in this chat were read, new last read: ", lastReadSentIndex, ", updating description for index ", index, ", status: ", (index <= lastReadSentIndex));
             messageDateText.text = getMessageStatusText(myMessage, index, lastReadSentIndex, messageDateText.useElapsed);
         }
         onMessageUpdated: {
             if (index === modelIndex) {
-                console.log("[ChatModel] This message was updated, index " + index + ", updating content...");
+                Debug.log("[ChatModel] This message was updated, index ", index, ", updating content...");
                 messageDateText.text = getMessageStatusText(myMessage, index, chatView.lastReadSentIndex, messageDateText.useElapsed);
                 messageText.text = Emoji.emojify(Functions.getMessageText(myMessage, false, messageListItem.isOwnMessage), messageText.font.pixelSize);
             }

--- a/qml/components/PinnedMessageItem.qml
+++ b/qml/components/PinnedMessageItem.qml
@@ -21,6 +21,7 @@ import Sailfish.Silica 1.0
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji
+import "../js/debug.js" as Debug
 
 Item {
     id: pinnedMessageItem
@@ -31,7 +32,7 @@ Item {
 
     onPinnedMessageChanged: {
         if (pinnedMessage) {
-            console.log("[ChatPage] Activating pinned message");
+            Debug.log("[ChatPage] Activating pinned message");
             var messageUserText = (pinnedMessage.sender_user_id !== chatPage.myUserId) ? Emoji.emojify(Functions.getUserName(tdLibWrapper.getUserInformation(pinnedMessage.sender_user_id)), pinnedMessageUserText.font.pixelSize) : qsTr("You");
             pinnedMessageUserText.text = (messageUserText === "" ? qsTr("Pinned Message") : messageUserText );
             pinnedMessageText.text = Emoji.emojify(Functions.getMessageText(pinnedMessage, true, pinnedMessage.sender_user_id === chatPage.myUserId), pinnedMessageText.font.pixelSize);

--- a/qml/components/VideoPreview.qml
+++ b/qml/components/VideoPreview.qml
@@ -20,6 +20,7 @@ import QtQuick 2.6
 import Sailfish.Silica 1.0
 import QtMultimedia 5.6
 import "../js/functions.js" as Functions
+import "../js/debug.js" as Debug
 
 Item {
     id: videoMessageComponent
@@ -302,39 +303,39 @@ Item {
 
                 onStatusChanged: {
                     if (status == MediaPlayer.NoMedia) {
-                        console.log("No Media");
+                        Debug.log("No Media");
                         videoBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.Loading) {
-                        console.log("Loading");
+                        Debug.log("Loading");
                         videoBusyIndicator.visible = true;
                     }
                     if (status == MediaPlayer.Loaded) {
-                        console.log("Loaded");
+                        Debug.log("Loaded");
                         videoBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.Buffering) {
-                        console.log("Buffering");
+                        Debug.log("Buffering");
                         videoBusyIndicator.visible = true;
                     }
                     if (status == MediaPlayer.Stalled) {
-                        console.log("Stalled");
+                        Debug.log("Stalled");
                         videoBusyIndicator.visible = true;
                     }
                     if (status == MediaPlayer.Buffered) {
-                        console.log("Buffered");
+                        Debug.log("Buffered");
                         videoBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.EndOfMedia) {
-                        console.log("End of Media");
+                        Debug.log("End of Media");
                         videoBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.InvalidMedia) {
-                        console.log("Invalid Media");
+                        Debug.log("Invalid Media");
                         videoBusyIndicator.visible = false;
                     }
                     if (status == MediaPlayer.UnknownStatus) {
-                        console.log("Unknown Status");
+                        Debug.log("Unknown Status");
                         videoBusyIndicator.visible = false;
                     }
                 }

--- a/qml/components/chatInformationPage/ChatInformationPageContent.qml
+++ b/qml/components/chatInformationPage/ChatInformationPageContent.qml
@@ -21,6 +21,7 @@ import Sailfish.Silica 1.0
 import "../"
 import "../../js/twemoji.js" as Emoji
 import "../../js/functions.js" as Functions
+import "../../js/debug.js" as Debug
 
 
 SilicaFlickable {
@@ -59,7 +60,7 @@ SilicaFlickable {
             chatInformationPage.isChannel = chatInformationPage.groupInformation.is_channel;
             break;
         }
-        console.log("is set up", chatInformationPage.isPrivateChat, chatInformationPage.isBasicGroup, chatInformationPage.isSuperGroup, chatInformationPage.chatPartnerGroupId)
+        Debug.log("is set up", chatInformationPage.isPrivateChat, chatInformationPage.isBasicGroup, chatInformationPage.isSuperGroup, chatInformationPage.chatPartnerGroupId)
         if(!chatInformationPage.isPrivateChat) {
             updateGroupStatusText();
         }
@@ -123,13 +124,13 @@ SilicaFlickable {
             }
         }
         onSupergroupFullInfoReceived: {
-            console.log("onSupergroupFullInfoReceived", chatInformationPage.isSuperGroup, chatInformationPage.chatPartnerGroupId, groupId)
+            Debug.log("onSupergroupFullInfoReceived", chatInformationPage.isSuperGroup, chatInformationPage.chatPartnerGroupId, groupId)
             if(chatInformationPage.isSuperGroup && chatInformationPage.chatPartnerGroupId === groupId) {
                 chatInformationPage.groupFullInformation = groupFullInfo;
             }
         }
         onSupergroupFullInfoUpdated: {
-            console.log("onSupergroupFullInfoUpdated", chatInformationPage.isSuperGroup, chatInformationPage.chatPartnerGroupId, groupId)
+            Debug.log("onSupergroupFullInfoUpdated", chatInformationPage.isSuperGroup, chatInformationPage.chatPartnerGroupId, groupId)
             if(chatInformationPage.isSuperGroup && chatInformationPage.chatPartnerGroupId === groupId) {
                 chatInformationPage.groupFullInformation = groupFullInfo;
             }

--- a/qml/js/debug.js
+++ b/qml/js/debug.js
@@ -1,0 +1,47 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.pragma library
+.import WerkWolf.Fernschreiber 1.0 as Fernschreiber
+var enabled = Fernschreiber.DebugLog.enabled;
+var log = enabled ? console.log : function(){};
+var assert = enabled ? console.assert : function(){};
+var time = enabled ? console.time : function(){};
+var timeEnd = enabled ? console.timeEnd : function(){};
+var trace = enabled ? console.trace : function(){};
+var count = enabled ? console.count : function(){};
+var profile = enabled ? console.profile : function(){};
+var exception = enabled ? console.exception : function(){};
+
+Fernschreiber.DebugLog.enabledChanged.connect(function(isEnabled) {
+    enabled = isEnabled;
+    if(isEnabled) {
+        log = console.log;
+        assert = console.assert;
+        time = console.time;
+        timeEnd = console.timeEnd;
+        trace = console.trace;
+        count = console.count;
+        profile = console.profile;
+        exception = console.exception;
+    } else {
+        log = assert = time = timeEnd = trace = count = profile = exception = function(){};
+    }
+
+});

--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -17,6 +17,10 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 
+.pragma library
+.import "debug.js" as Debug
+.import Sailfish.Silica 1.0 as Silica
+
 function getUserName(userInformation) {
     var firstName = typeof userInformation.first_name !== "undefined" ? userInformation.first_name : "";
     var lastName = typeof userInformation.last_name !== "undefined" ? userInformation.last_name : "";
@@ -194,7 +198,7 @@ function getShortenedCount(count) {
 }
 
 function getDateTimeElapsed(timestamp) {
-    return Format.formatDate(new Date(timestamp * 1000), Formatter.DurationElapsed);
+    return Silica.Format.formatDate(new Date(timestamp * 1000), Silica.Formatter.DurationElapsed);
 }
 
 function getDateTimeTranslated(timestamp) {
@@ -344,7 +348,7 @@ function handleLink(link) {
     } else if (link.indexOf("userId://") === 0) {
         tdLibWrapper.createPrivateChat(link.substring(9));
     } else if (link.indexOf("tg://") === 0) {
-        console.log("Special TG link: " + link);
+        Debug.log("Special TG link: ", link);
         if (link.indexOf("tg://join?invite=") === 0) {
             tdLibWrapper.joinChatByInviteLink(tMePrefix + "joinchat/" + link.substring(17));
         } else if (link.indexOf("tg://resolve?domain=") === 0) {
@@ -353,12 +357,12 @@ function handleLink(link) {
     }  else {
         if (link.indexOf(tMePrefix) === 0) {
             if (link.indexOf("joinchat") !== -1) {
-                console.log("Joining Chat: " + link);
+                Debug.log("Joining Chat: ", link);
                 tdLibWrapper.joinChatByInviteLink(link);
                 // Do the necessary stuff to open the chat if successful
                 // Fail with nice error message if it doesn't work
             } else {
-                console.log("Search public chat: " + link.substring(tMePrefix.length));
+                Debug.log("Search public chat: ", link.substring(tMePrefix.length));
                 tdLibWrapper.searchPublicChat(link.substring(tMePrefix.length));
                 // Check responses for updateBasicGroup or updateSupergroup
                 // Fire createBasicGroupChat or createSupergroupChat

--- a/qml/pages/ChatInformationPage.qml
+++ b/qml/pages/ChatInformationPage.qml
@@ -22,6 +22,7 @@ import "../components"
 import "../components/chatInformationPage"
 import "../js/twemoji.js" as Emoji
 import "../js/functions.js" as Functions
+import "../js/debug.js" as Debug
 
 Page {
     id: chatInformationPage
@@ -59,7 +60,7 @@ Page {
     onStatusChanged: {
         switch(status) {
         case PageStatus.Activating:
-            console.log("activating Loader")
+            Debug.log("activating Loader")
             mainContentLoader.active = true
             break;
         case PageStatus.Active:

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -23,6 +23,7 @@ import Sailfish.Pickers 1.0
 import Nemo.Thumbnailer 1.0
 import WerkWolf.Fernschreiber 1.0
 import "../components"
+import "../js/debug.js" as Debug
 import "../js/twemoji.js" as Emoji
 import "../js/functions.js" as Functions
 
@@ -133,7 +134,7 @@ Page {
     }
 
     function initializePage() {
-        console.log("[ChatPage] Initializing chat page...");
+        Debug.log("[ChatPage] Initializing chat page...");
         chatView.currentIndex = -1;
         chatView.lastReadSentIndex = 0;
         var chatType = chatInformation.type['@type'];
@@ -154,13 +155,13 @@ Page {
             updateGroupStatusText();
         }
         if (stickerManager.needsReload()) {
-            console.log("[ChatPage] Stickers will be reloaded!");
+            Debug.log("[ChatPage] Stickers will be reloaded!");
             tdLibWrapper.getRecentStickers();
             tdLibWrapper.getInstalledStickerSets();
             stickerManager.setNeedsReload(false);
         }
         if (chatInformation.pinned_message_id.toString() !== "0") {
-            console.log("[ChatPage] Loading pinned message " + chatInformation.pinned_message_id);
+            Debug.log("[ChatPage] Loading pinned message ", chatInformation.pinned_message_id);
             tdLibWrapper.getMessage(chatInformation.id, chatInformation.pinned_message_id);
         }
     }
@@ -292,28 +293,28 @@ Page {
                     || (groupStatusType === "chatMemberStatusRestricted" && groupStatus.permissions[privilege])
     }
     function canPinMessages() {
-        console.log("Can we pin messages?");
+        Debug.log("Can we pin messages?");
         if (chatPage.isPrivateChat) {
-            console.log("Private Chat: No!");
+            Debug.log("Private Chat: No!");
             return false;
         }
         if (chatPage.chatGroupInformation.status["@type"] === "chatMemberStatusCreator") {
-            console.log("Creator of this chat: Yes!");
+            Debug.log("Creator of this chat: Yes!");
             return true;
         }
         if (chatPage.chatInformation.permissions.can_pin_messages) {
-            console.log("All people can pin: Yes!");
+            Debug.log("All people can pin: Yes!");
             return true;
         }
         if (chatPage.chatGroupInformation.status["@type"] === "chatMemberStatusAdministrator") {
-            console.log("Admin with privileges? " + chatPage.chatGroupInformation.status.can_pin_messages);
+            Debug.log("Admin with privileges? ", chatPage.chatGroupInformation.status.can_pin_messages);
             return chatPage.chatGroupInformation.status.can_pin_messages;
         }
         if (chatPage.chatGroupInformation.status["@type"] === "chatMemberStatusRestricted") {
-            console.log("Restricted, but can pin messages? " + chatPage.chatGroupInformation.status.permissions.can_pin_messages);
+            Debug.log("Restricted, but can pin messages? ", chatPage.chatGroupInformation.status.permissions.can_pin_messages);
             return chatPage.chatGroupInformation.status.permissions.can_pin_messages;
         }
-        console.log("Something else: No!");
+        Debug.log("Something else: No!");
         return false;
     }
 
@@ -384,7 +385,7 @@ Page {
             }
         }
         onChatOnlineMemberCountUpdated: {
-            console.log(isSuperGroup + "/" + isBasicGroup + "/" + chatInformation.id.toString() + "/" + chatId);
+            Debug.log(isSuperGroup, "/", isBasicGroup, "/", chatInformation.id.toString(), "/", chatId);
             if ((isSuperGroup || isBasicGroup) && chatInformation.id.toString() === chatId) {
                 chatOnlineMemberCount = onlineMemberCount;
                 updateGroupStatusText();
@@ -405,7 +406,7 @@ Page {
         }
         onReceivedMessage: {
             if (messageId === chatInformation.pinned_message_id.toString()) {
-                console.log("[ChatPage] Received pinned message");
+                Debug.log("[ChatPage] Received pinned message");
                 pinnedMessageItem.pinnedMessage = message;
             }
         }
@@ -414,11 +415,11 @@ Page {
     Connections {
         target: chatModel
         onMessagesReceived: {
-            console.log("[ChatPage] Messages received, view has " + chatView.count + " messages, setting view to index " + modelIndex + ", own messages were read before index " + lastReadSentIndex);
+            Debug.log("[ChatPage] Messages received, view has ", chatView.count, " messages, setting view to index ", modelIndex, ", own messages were read before index ", lastReadSentIndex);
             if (totalCount === 0) {
                 if (chatPage.iterativeInitialization) {
                     chatPage.iterativeInitialization = false;
-                    console.log("[ChatPage] actually, skipping that: No Messages in Chat.");
+                    Debug.log("[ChatPage] actually, skipping that: No Messages in Chat.");
                     chatView.positionViewAtEnd();
                     chatPage.loading = false;
                     return;
@@ -436,28 +437,28 @@ Page {
             }
 
             if (chatView.height > chatView.contentHeight) {
-                console.log("[ChatPage] Chat content quite small...");
+                Debug.log("[ChatPage] Chat content quite small...");
                 viewMessageTimer.queueViewMessage(chatView.count - 1);
             }
         }
         onNewMessageReceived: {
             if (chatView.manuallyScrolledToBottom || message.sender_user_id === chatPage.myUserId) {
-                console.log("[ChatPage] Own message received or was scrolled to bottom, scrolling down to see it...");
+                Debug.log("[ChatPage] Own message received or was scrolled to bottom, scrolling down to see it...");
                 chatView.scrollToIndex(chatView.count - 1);
             }
         }
         onUnreadCountUpdated: {
-            console.log("[ChatPage] Unread count updated, new count: " + unreadCount);
+            Debug.log("[ChatPage] Unread count updated, new count: ", unreadCount);
             chatInformation.unread_count = unreadCount;
             chatUnreadMessagesCountBackground.visible = ( !chatPage.loading && unreadCount > 0 );
             chatUnreadMessagesCount.text = unreadCount > 99 ? "99+" : unreadCount;
         }
         onLastReadSentMessageUpdated: {
-            console.log("[ChatPage] Updating last read sent index, new index: " + lastReadSentIndex);
+            Debug.log("[ChatPage] Updating last read sent index, new index: ", lastReadSentIndex);
             chatView.lastReadSentIndex = lastReadSentIndex;
         }
         onMessagesIncrementalUpdate: {
-            console.log("Incremental update received. View now has " + chatView.count + " messages, view is on index " + modelIndex + ", own messages were read before index " + lastReadSentIndex);
+            Debug.log("Incremental update received. View now has ", chatView.count, " messages, view is on index ", modelIndex, ", own messages were read before index ", lastReadSentIndex);
             chatView.lastReadSentIndex = lastReadSentIndex;
             chatViewCooldownTimer.start();
         }
@@ -468,7 +469,7 @@ Page {
         onPinnedMessageChanged: {
             chatInformation = chatModel.getChatInformation();
             if (chatInformation.pinned_message_id.toString() !== "0") {
-                console.log("[ChatPage] Loading pinned message " + chatInformation.pinned_message_id);
+                Debug.log("[ChatPage] Loading pinned message ", chatInformation.pinned_message_id);
                 tdLibWrapper.getMessage(chatInformation.id, chatInformation.pinned_message_id);
             } else {
                 pinnedMessageItem.pinnedMessage = undefined;
@@ -697,7 +698,7 @@ Page {
                     repeat: false
                     running: false
                     onTriggered: {
-                        console.log("[ChatPage] Cooldown completed...");
+                        Debug.log("[ChatPage] Cooldown completed...");
                         chatView.inCooldown = false;
                     }
                 }
@@ -747,7 +748,7 @@ Page {
                     }
 
                     function handleScrollPositionChanged() {
-                        console.log("Current position: " + chatView.contentY);
+                        Debug.log("Current position: ", chatView.contentY);
                         if (chatInformation.unread_count > 0) {
                             var bottomIndex = chatView.indexAt(chatView.contentX, ( chatView.contentY + chatView.height - Theme.horizontalPageMargin ));
                             if (bottomIndex > -1) {
@@ -770,11 +771,11 @@ Page {
                     onContentYChanged: {
                         if (!chatPage.loading && !chatView.inCooldown) {
                             if (chatView.indexAt(chatView.contentX, chatView.contentY) < 10) {
-                                console.log("[ChatPage] Trying to get older history items...");
+                                Debug.log("[ChatPage] Trying to get older history items...");
                                 chatView.inCooldown = true;
                                 chatModel.triggerLoadMoreHistory();
                             } else if (chatView.indexAt(chatView.contentX, chatView.contentY) > ( count - 10)) {
-                                console.log("[ChatPage] Trying to get newer history items...");
+                                Debug.log("[ChatPage] Trying to get newer history items...");
                                 chatView.inCooldown = true;
                                 chatModel.triggerLoadMoreFuture();
                             }
@@ -999,7 +1000,7 @@ Page {
                             var picker = pageStack.push("Sailfish.Pickers.ImagePickerPage");
                             picker.selectedContentPropertiesChanged.connect(function(){
                                 attachmentOptionsRow.visible = false;
-                                console.log("Selected document: " + picker.selectedContentProperties.filePath );
+                                Debug.log("Selected document: ", picker.selectedContentProperties.filePath );
                                 attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
                                 attachmentPreviewRow.isPicture = true;
                                 attachmentPreviewRow.visible = true;
@@ -1014,7 +1015,7 @@ Page {
                             var picker = pageStack.push("Sailfish.Pickers.VideoPickerPage");
                             picker.selectedContentPropertiesChanged.connect(function(){
                                 attachmentOptionsRow.visible = false;
-                                console.log("Selected video: " + picker.selectedContentProperties.filePath );
+                                Debug.log("Selected video: ", picker.selectedContentProperties.filePath );
                                 attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
                                 attachmentPreviewRow.isVideo = true;
                                 attachmentPreviewRow.visible = true;
@@ -1029,7 +1030,7 @@ Page {
                             var picker = pageStack.push("Sailfish.Pickers.DocumentPickerPage");
                             picker.selectedContentPropertiesChanged.connect(function(){
                                 attachmentOptionsRow.visible = false;
-                                console.log("Selected document: " + picker.selectedContentProperties.filePath );
+                                Debug.log("Selected document: ", picker.selectedContentProperties.filePath );
                                 attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
                                 attachmentPreviewRow.isDocument = true;
                                 attachmentPreviewRow.visible = true;

--- a/qml/pages/ImagePage.qml
+++ b/qml/pages/ImagePage.qml
@@ -20,6 +20,7 @@ import QtQuick 2.6
 import Sailfish.Silica 1.0
 import "../components"
 import "../js/functions.js" as Functions
+import "../js/debug.js" as Debug
 
 Page {
     id: imagePage
@@ -73,7 +74,7 @@ Page {
         target: tdLibWrapper
         onFileUpdated: {
             if (fileId === imagePage.pictureFileInformation.id) {
-                console.log("File updated, completed? " + fileInformation.local.is_downloading_completed);
+                Debug.log("File updated, completed? ", fileInformation.local.is_downloading_completed);
                 if (fileInformation.local.is_downloading_completed) {
                     imagePage.pictureFileInformation = fileInformation;
                     imagePage.imageUrl = fileInformation.local.path;

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -23,6 +23,7 @@ import WerkWolf.Fernschreiber 1.0
 import "../components"
 import "../js/twemoji.js" as Emoji
 import "../js/functions.js" as Functions
+import "../js/debug.js" as Debug
 
 Page {
     id: overviewPage
@@ -44,14 +45,14 @@ Page {
     Connections {
         target: dBusAdaptor
         onPleaseOpenMessage: {
-            console.log("[OverviewPage] Opening chat from external call...")
+            Debug.log("[OverviewPage] Opening chat from external call...")
             if (chatListCreated) {
                 pageStack.pop(overviewPage, PageStackAction.Immediate)
                 pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : chatListModel.getById(chatId) }, PageStackAction.Immediate)
             }
         }
         onPleaseOpenUrl: {
-            console.log("[OverviewPage] Opening URL requested: " + url);
+            Debug.log("[OverviewPage] Opening URL requested: ", url);
             Functions.handleLink(url);
         }
     }

--- a/qml/pages/PollResultsPage.qml
+++ b/qml/pages/PollResultsPage.qml
@@ -21,6 +21,7 @@ import Sailfish.Silica 1.0
 import "../components"
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji
+import "../js/debug.js" as Debug
 
 Page {
     id: pollResultsPage
@@ -146,7 +147,6 @@ Page {
                                 if(extra === optionDelegate.usersResponseIdentifierString) {
                                     for(var i = 0; i < userIds.length; i += 1) {
                                         optionDelegate.users.append({id: userIds[i], user:tdLibWrapper.getUserInformation(userIds[i])});
-                                        console.log("APPEND USER", JSON.stringify({id: userIds[i], user:tdLibWrapper.getUserInformation(userIds[i])}));
                                     }
                                     loadUsersTimer.start();
                                 }

--- a/src/debuglogjs.h
+++ b/src/debuglogjs.h
@@ -1,0 +1,52 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef DEBUGLOG_H
+#define DEBUGLOG_H
+
+
+#include <QObject>
+#include <QQmlEngine>
+
+class DebugLogJS : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled NOTIFY enabledChanged)
+public:
+
+#ifdef QT_QML_DEBUG
+    DebugLogJS(QObject* parent = Q_NULLPTR) : QObject(parent), enabled(true) {}
+#else
+    DebugLog(QObject* parent = Q_NULLPTR) : QObject(parent), enabled(false) {}
+#endif
+    static QObject* createSingleton(QQmlEngine*, QJSEngine*) { return new DebugLogJS(); }
+    bool isEnabled() const { return enabled; }
+    void setEnabled(bool value) {
+        if (enabled != value) {
+            enabled = value;
+            Q_EMIT enabledChanged(value);
+        }
+    }
+Q_SIGNALS:
+    void enabledChanged(bool value);
+private:
+    bool enabled;
+};
+
+#endif // DEBUGLOG_H

--- a/src/debuglogjs.h
+++ b/src/debuglogjs.h
@@ -23,6 +23,7 @@
 
 #include <QObject>
 #include <QQmlEngine>
+#include <QLoggingCategory>
 
 class DebugLogJS : public QObject
 {
@@ -30,11 +31,9 @@ class DebugLogJS : public QObject
     Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled NOTIFY enabledChanged)
 public:
 
-#ifdef QT_QML_DEBUG
-    DebugLogJS(QObject* parent = Q_NULLPTR) : QObject(parent), enabled(true) {}
-#else
-    DebugLog(QObject* parent = Q_NULLPTR) : QObject(parent), enabled(false) {}
-#endif
+    DebugLogJS(QObject* parent = Q_NULLPTR) : QObject(parent), category("fernschreiber.JS") {
+        enabled = category.isDebugEnabled();
+    }
     static QObject* createSingleton(QQmlEngine*, QJSEngine*) { return new DebugLogJS(); }
     bool isEnabled() const { return enabled; }
     void setEnabled(bool value) {
@@ -47,6 +46,7 @@ Q_SIGNALS:
     void enabledChanged(bool value);
 private:
     bool enabled;
+    const QLoggingCategory category;
 };
 
 #endif // DEBUGLOG_H

--- a/src/debuglogjs.h
+++ b/src/debuglogjs.h
@@ -17,9 +17,8 @@
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef DEBUGLOG_H
-#define DEBUGLOG_H
-
+#ifndef DEBUGLOGJS_H
+#define DEBUGLOGJS_H
 
 #include <QObject>
 #include <QQmlEngine>
@@ -39,14 +38,14 @@ public:
     void setEnabled(bool value) {
         if (enabled != value) {
             enabled = value;
-            Q_EMIT enabledChanged(value);
+            Q_EMIT enabledChanged();
         }
     }
 Q_SIGNALS:
-    void enabledChanged(bool value);
+    void enabledChanged();
 private:
     bool enabled;
     const QLoggingCategory category;
 };
 
-#endif // DEBUGLOG_H
+#endif // DEBUGLOGJS_H

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -29,8 +29,8 @@
 #include <QQmlEngine>
 #include <QGuiApplication>
 #include <QLoggingCategory>
-
 #include "appsettings.h"
+#include "debuglogjs.h"
 #include "tdlibfile.h"
 #include "tdlibwrapper.h"
 #include "chatlistmodel.h"
@@ -63,6 +63,7 @@ int main(int argc, char *argv[])
 
     const char *uri = "WerkWolf.Fernschreiber";
     qmlRegisterType<TDLibFile>(uri, 1, 0, "TDLibFile");
+    qmlRegisterSingletonType<DebugLogJS>(uri, 1, 0, "DebugLog", DebugLogJS::createSingleton);
 
     AppSettings *appSettings = new AppSettings(view.data());
     context->setContextProperty("appSettings", appSettings);


### PR DESCRIPTION
This PR aims to fix #174 when it's ready, but until then is a place to work on those changes together. 

As announced in the issue, I've prepared the QML/JS part based on the ideas discussed there as a start.

The JS part is basically a drop-in replacement for `console`, so it covers
 - `console.log`
 - `console.assert`
 - `console.time` & - `console.timeEnd`
 - `console.trace`
 - `console.count`
 - `console.profile`
 - `console.exception`

If you previously would've used `console.*`, make sure to:
 - import `debug.js`
 - just use `Debug.*` instead

Also, I've changed functions.js to a shared JavaScript resource (".pragma library") to make usage in there easier. According to the qml docs, this also "can save significant amounts of memory and speed up the instantiation of QML components". Win-win.

For now, the C++ part is basically copied from the issue comments by @monich with a small `ifdef` thrown in.