### PR TITLE
Do not animation tab item width

### DIFF
--- a/qml/components/chatInformationPage/ChatInformationTabView.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabView.qml
@@ -61,7 +61,6 @@ Item {
                     width: loaded ? (headerGrid.width / tabView.count) : 0
                     opacity: loaded ? 1.0 : 0.0
 
-                    Behavior on width { PropertyAnimation {duration: 200}}
                     Behavior on opacity { FadeAnimation {}}
                     height: Theme.itemSizeLarge
                     property int itemIndex: index


### PR DESCRIPTION
It looks weird when they are moving around the screen after page orientation changes.