### PR TITLE
fix functions scope; make appNotification global

### DIFF
--- a/qml/components/chatInformationPage/ChatInformationPageContent.qml
+++ b/qml/components/chatInformationPage/ChatInformationPageContent.qml
@@ -192,9 +192,6 @@ SilicaFlickable {
         id: membersList
     }
 
-    AppNotification {
-        id: infoNotification
-    }
     PullDownMenu {
         MenuItem {
             visible: (chatInformationPage.isSuperGroup || chatInformationPage.isBasicGroup) && chatInformationPage.groupInformation && chatInformationPage.groupInformation.status["@type"] !== "chatMemberStatusBanned"
@@ -420,7 +417,7 @@ SilicaFlickable {
                     anchors.verticalCenter: inviteLinkItem.verticalCenter
                     onClicked: {
                         Clipboard.text = chatInformationPage.groupFullInformation.invite_link
-                        infoNotification.show(qsTr("The Invite Link has been copied to the clipboard."));
+                        appNotification.show(qsTr("The Invite Link has been copied to the clipboard."));
                     }
                 }
             }

--- a/qml/harbour-fernschreiber.qml
+++ b/qml/harbour-fernschreiber.qml
@@ -19,6 +19,8 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import "pages"
+import "components"
+import "./js/functions.js" as Functions
 
 ApplicationWindow
 {
@@ -36,5 +38,17 @@ ApplicationWindow
         onPleaseOpenUrl: {
             appWindow.activate();
         }
+    }
+
+    AppNotification {
+        id: appNotification
+        parent: pageStack.currentPage
+    }
+
+    Component.onCompleted: {
+        Functions.setGlobals({
+            tdLibWrapper: tdLibWrapper,
+            appNotification: appNotification
+        });
     }
 }

--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -21,6 +21,13 @@
 .import "debug.js" as Debug
 .import Sailfish.Silica 1.0 as Silica
 
+var tdLibWrapper;
+var appNotification;
+function setGlobals(globals) {
+    tdLibWrapper = globals.tdLibWrapper;
+    appNotification = globals.appNotification;
+}
+
 function getUserName(userInformation) {
     var firstName = typeof userInformation.first_name !== "undefined" ? userInformation.first_name : "";
     var lastName = typeof userInformation.last_name !== "undefined" ? userInformation.last_name : "";

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -579,10 +579,6 @@ Page {
             }
         }
 
-        AppNotification {
-            id: appNotification
-        }
-
         BackgroundItem {
             id: headerMouseArea
             height: headerRow.height

--- a/qml/pages/ImagePage.qml
+++ b/qml/pages/ImagePage.qml
@@ -82,11 +82,11 @@ Page {
             }
         }
         onCopyToDownloadsSuccessful: {
-            imageNotification.show(qsTr("Download of %1 successful.").arg(fileName), filePath);
+            appNotification.show(qsTr("Download of %1 successful.").arg(fileName), filePath);
         }
 
         onCopyToDownloadsError: {
-            imageNotification.show(qsTr("Download failed."));
+            appNotification.show(qsTr("Download failed."));
         }
     }
 
@@ -103,10 +103,6 @@ Page {
                     tdLibWrapper.copyFileToDownloads(imagePage.imageUrl);
                 }
             }
-        }
-
-        AppNotification {
-            id: imageNotification
         }
 
         SilicaFlickable {

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -187,10 +187,6 @@ Page {
             }
         }
 
-        AppNotification {
-            id: appNotification
-        }
-
         Column {
             id: column
             width: parent.width

--- a/qml/pages/VideoPage.qml
+++ b/qml/pages/VideoPage.qml
@@ -74,16 +74,12 @@ Page {
                 }
             }
             onCopyToDownloadsSuccessful: {
-                videoNotification.show(qsTr("Download of %1 successful.").arg(fileName), filePath);
+                appNotification.show(qsTr("Download of %1 successful.").arg(fileName), filePath);
             }
 
             onCopyToDownloadsError: {
-                videoNotification.show(qsTr("Download failed."));
+                appNotification.show(qsTr("Download failed."));
             }
-        }
-
-        AppNotification {
-            id: videoNotification
         }
 
         Item {


### PR DESCRIPTION
appNotification now resides (only) in the appWindow scope, where it is accessible from everywhere.
Defining the parent takes care of sizing/rotation.
I've left some instances of AppNotification items where they're supposed to be centered inside a component, not the whole page.

functions.js globals (tdLibWrapper/appNotification) get set in harbour-fernschreiber.qml, as well.