### PR TITLE
Add menu for "About" to InitializationPage

### DIFF
--- a/qml/pages/AboutPage.qml
+++ b/qml/pages/AboutPage.qml
@@ -156,39 +156,48 @@ Page {
                 }
             }
 
-            Text {
-                x: Theme.horizontalPageMargin
-                width: parent.width  - ( 2 * Theme.horizontalPageMargin )
-                horizontalAlignment: Text.AlignHCenter
-                text: qsTr("Logged in as %1").arg(Emoji.emojify(aboutPage.userInformation.first_name + " " + aboutPage.userInformation.last_name, Theme.fontSizeSmall))
-                font.pixelSize: Theme.fontSizeSmall
-                wrapMode: Text.Wrap
-                color: Theme.primaryColor
-                textFormat: Text.StyledText
-                anchors {
-                    horizontalCenter: parent.horizontalCenter
-                }
-            }
+            Loader {
+                active: !!aboutPage.userInformation.phone_number
+                width: parent.width
+                sourceComponent: Component {
+                    Column {
 
-            ProfileThumbnail {
-                photoData: aboutPage.userInformation.profile_photo.small
-                width: Theme.itemSizeExtraLarge
-                height: Theme.itemSizeExtraLarge
-                replacementStringHint: aboutPage.userInformation.first_name + " " + aboutPage.userInformation.last_name
-                anchors {
-                    horizontalCenter: parent.horizontalCenter
-                }
-            }
+                        Text {
+                            x: Theme.horizontalPageMargin
+                            width: parent.width  - ( 2 * Theme.horizontalPageMargin )
+                            horizontalAlignment: Text.AlignHCenter
+                            text: qsTr("Logged in as %1").arg(Emoji.emojify(aboutPage.userInformation.first_name + " " + aboutPage.userInformation.last_name + typeof aboutPage.userInformation + JSON.stringify(aboutPage.userInformation), Theme.fontSizeSmall))
+                            font.pixelSize: Theme.fontSizeSmall
+                            wrapMode: Text.Wrap
+                            color: Theme.primaryColor
+                            textFormat: Text.StyledText
+                            anchors {
+                                horizontalCenter: parent.horizontalCenter
+                            }
+                        }
 
-            Label {
-                x: Theme.horizontalPageMargin
-                width: parent.width  - ( 2 * Theme.horizontalPageMargin )
-                horizontalAlignment: Text.AlignHCenter
-                text: qsTr("Phone number: +%1").arg(aboutPage.userInformation.phone_number)
-                font.pixelSize: Theme.fontSizeSmall
-                wrapMode: Text.Wrap
-                anchors {
-                    horizontalCenter: parent.horizontalCenter
+                        ProfileThumbnail {
+                            photoData: aboutPage.userInformation.profile_photo.small
+                            width: Theme.itemSizeExtraLarge
+                            height: Theme.itemSizeExtraLarge
+                            replacementStringHint: aboutPage.userInformation.first_name + " " + aboutPage.userInformation.last_name
+                            anchors {
+                                horizontalCenter: parent.horizontalCenter
+                            }
+                        }
+
+                        Label {
+                            x: Theme.horizontalPageMargin
+                            width: parent.width  - ( 2 * Theme.horizontalPageMargin )
+                            horizontalAlignment: Text.AlignHCenter
+                            text: qsTr("Phone number: +%1").arg(aboutPage.userInformation.phone_number)
+                            font.pixelSize: Theme.fontSizeSmall
+                            wrapMode: Text.Wrap
+                            anchors {
+                                horizontalCenter: parent.horizontalCenter
+                            }
+                        }
+                    }
                 }
             }
 

--- a/qml/pages/InitializationPage.qml
+++ b/qml/pages/InitializationPage.qml
@@ -105,6 +105,13 @@ Page {
         Behavior on contentHeight { NumberAnimation {} }
         anchors.fill: parent
 
+        PullDownMenu {
+            MenuItem {
+                text: qsTr("About Fernschreiber")
+                onClicked: pageStack.push(Qt.resolvedUrl("AboutPage.qml"))
+            }
+        }
+
         Column {
             id: content
             width: parent.width

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -825,6 +825,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Nutzen Sie das internationale Format, z.B. %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>Über Fernschreiber</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -825,6 +825,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Use the international format, e.g. %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>About Fernschreiber</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>
@@ -869,7 +873,7 @@
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Pin Message</translation>
     </message>
 </context>
 <context>
@@ -883,11 +887,11 @@
     <name>MessageOverlayFlickable</name>
     <message>
         <source>You</source>
-        <translation type="unfinished">You</translation>
+        <translation>You</translation>
     </message>
     <message>
         <source>This message was forwarded. Original author: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>This message was forwarded. Original author: %1</translation>
     </message>
 </context>
 <context>
@@ -947,15 +951,15 @@
     <name>PinnedMessageItem</name>
     <message>
         <source>You</source>
-        <translation type="unfinished">You</translation>
+        <translation>You</translation>
     </message>
     <message>
         <source>Pinned Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Pinned Message</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished"></translation>
+        <translation>Message unpinned</translation>
     </message>
 </context>
 <context>
@@ -1200,7 +1204,7 @@
     </message>
     <message>
         <source>Notification turns on the display</source>
-        <translation type="unfinished"></translation>
+        <translation>Notification turns on the display</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -815,6 +815,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Usar el formato internacional %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>Acerca de</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -826,6 +826,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Käytä kansainvälistä muotoa, esimerkiksi %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>Tietoa Fernschreiberista</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -815,6 +815,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>A Fernschreiber névjegye</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -825,6 +825,10 @@
         <source>Loading...</source>
         <translation>Carica...</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>Informazioni su Fernschreiber</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -835,6 +835,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Użyj międzynarodowego formatu, %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>O Fernschreiber</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -835,6 +835,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Используйте международный формат, например %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -825,6 +825,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Använd internationellt format, t.ex. %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>Om Fernschreiber</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -815,6 +815,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>请使用国际区号格式，例如 %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>关于 Fernschreiber</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -825,6 +825,10 @@
         <source>Use the international format, e.g. %1</source>
         <translation>Use the international format, e.g. %1</translation>
     </message>
+    <message>
+        <source>About Fernschreiber</source>
+        <translation>About Fernschreiber</translation>
+    </message>
 </context>
 <context>
     <name>LocationPreview</name>


### PR DESCRIPTION
Also puts the account specific info from "AboutPage" into a Loader to make it optional without much effort.
Here's how it looks in the emulator:
https://i.imgur.com/eBVbWww.mp4
 (no clue why it doesn't have a page background – that's not Fernschreiber specific ;) )