### PR TITLE
Fix initial auth handling

### DIFF
--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -68,6 +68,14 @@ Page {
         }
     }
 
+    Timer {
+        id: openInitializationPageTimer
+        interval: 0
+        onTriggered: {
+            pageStack.push(Qt.resolvedUrl("../pages/InitializationPage.qml"));
+        }
+    }
+
     function setPageStatus() {
         switch (overviewPage.connectionState) {
         case TelegramAPI.WaitingForNetwork:
@@ -101,19 +109,23 @@ Page {
 
     function initializePage() {
         overviewPage.authorizationState = tdLibWrapper.getAuthorizationState();
-        overviewPage.handleAuthorizationState();
+        overviewPage.handleAuthorizationState(true);
         overviewPage.connectionState = tdLibWrapper.getConnectionState();
         overviewPage.setPageStatus();
     }
 
-    function handleAuthorizationState() {
+    function handleAuthorizationState(isOnInitialization) {
         switch (overviewPage.authorizationState) {
         case TelegramAPI.WaitPhoneNumber:
         case TelegramAPI.WaitCode:
         case TelegramAPI.WaitPassword:
         case TelegramAPI.WaitRegistration:
             overviewPage.loading = false;
-            pageStack.push(Qt.resolvedUrl("../pages/InitializationPage.qml"));
+            if(isOnInitialization) { // pageStack isn't ready on Component.onCompleted
+                openInitializationPageTimer.start()
+            } else {
+                pageStack.push(Qt.resolvedUrl("../pages/InitializationPage.qml"));
+            }
             break;
         case TelegramAPI.AuthorizationReady:
             overviewPage.loading = false;

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -49,6 +49,7 @@ TDLibWrapper::TDLibWrapper(AppSettings *appSettings, MceInterface *mceInterface,
     this->appSettings = appSettings;
     this->mceInterface = mceInterface;
     this->tdLibClient = td_json_client_create();
+    this->authorizationState = AuthorizationState::Closed;
     this->tdLibReceiver = new TDLibReceiver(this->tdLibClient, this);
 
     QString tdLibDatabaseDirectoryPath = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation) + "/tdlib";


### PR DESCRIPTION
This (hopefully, it at least LGTM) fixes two problems:
 - OverviewPage.onCompleted: It got the wrong AuthorizationState if qml was loaded too fast because it wasn't initialized. (c++)
- The QML could have tried to open the InitializationPage "onCompleted". But the initial pageStack operation is a parent in its call stack,  so it is neither ready nor wants to accept "completeAnimation()". A zero interval Timer was added for this case.