### PR TITLE
Fixed long tap on an image

### DIFF
--- a/qml/components/ImagePreview.qml
+++ b/qml/components/ImagePreview.qml
@@ -32,6 +32,13 @@ Item {
     width: parent.width
     height: singleImage.visible ? Math.min(defaultHeight, singleImage.bestHeight + Theme.paddingSmall) : defaultHeight
 
+    function clicked() {
+        pageStack.push(Qt.resolvedUrl("../pages/ImagePage.qml"), {
+            "photoData" : imagePreviewItem.photoData,
+            "pictureFileInformation" : imageFile.fileInformation
+        })
+    }
+
     Component.onCompleted: {
         if (photoData) {
             // Check first which size fits best...
@@ -68,15 +75,6 @@ Item {
         visible: status === Image.Ready
         opacity: visible ? 1 : 0
         Behavior on opacity { FadeAnimation {} }
-        MouseArea {
-            anchors.fill: parent
-            onClicked: {
-                pageStack.push(Qt.resolvedUrl("../pages/ImagePage.qml"), {
-                    "photoData" : imagePreviewItem.photoData,
-                    "pictureFileInformation" : imageFile.fileInformation
-                })
-            }
-        }
     }
 
     BackgroundImage {

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -47,6 +47,15 @@ ListItem {
     onClicked: {
         if(messageListItem.precalculatedValues.pageIsSelecting) {
             page.toggleMessageSelection(myMessage);
+        } else {
+            // Allow extra context to react to click
+            var extraContent = extraContentLoader.item
+            if (extraContent && ("clicked" in extraContent) && (typeof extraContent.clicked === "function") &&
+                mouseX >= extraContentLoader.x && mouseY >= extraContentLoader.y &&
+                mouseX < (extraContentLoader.x + extraContentLoader.width) &&
+                mouseY < (extraContentLoader.y + extraContentLoader.height)) {
+                extraContent.clicked()
+            }
         }
     }
 


### PR DESCRIPTION
`MouseArea` filling the image was eating mouse events which should be handled by the list item. Handle them all at the list item level and forward the `"clicked"` event to the extra content items which declare the `clicked()` function.

This fixes context menu and background highlighting when image is long-tapped.