### PR TITLE
Fix occasional crashes on long-tapping poll items

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -31,6 +31,7 @@ SOURCES += src/harbour-fernschreiber.cpp \
     src/fernschreiberutils.cpp \
     src/knownusersmodel.cpp \
     src/mceinterface.cpp \
+    src/namedaction.cpp \
     src/notificationmanager.cpp \
     src/processlauncher.cpp \
     src/stickermanager.cpp \
@@ -159,6 +160,7 @@ HEADERS += \
     src/fernschreiberutils.h \
     src/knownusersmodel.h \
     src/mceinterface.h \
+    src/namedaction.h \
     src/notificationmanager.h \
     src/processlauncher.h \
     src/stickermanager.h \

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -20,7 +20,6 @@ import QtQuick 2.6
 import Sailfish.Silica 1.0
 import "../js/twemoji.js" as Emoji
 import "../js/functions.js" as Functions
-import QtQml.Models 2.3
 import "../js/debug.js" as Debug
 
 ListItem {
@@ -40,7 +39,6 @@ ListItem {
                                                && typeof chatView.contentComponentNames[myMessage.content['@type']]  !== "undefined" ?
                                                    chatView.contentComponentNames[myMessage.content['@type']] : ""
 
-    readonly property ObjectModel additionalContextItems: ObjectModel {}
     highlighted: (down || isSelected) && !menuOpen
     openMenuOnPressAndHold: !messageListItem.precalculatedValues.pageIsSelecting
 
@@ -80,7 +78,13 @@ ListItem {
         sourceComponent: Component {
             ContextMenu {
                 Repeater {
-                    model: messageListItem.additionalContextItems
+                    model: (extraContentLoader.item && ("extraContextMenuItems" in extraContentLoader.item)) ?
+                        extraContentLoader.item.extraContextMenuItems : 0
+                    delegate: MenuItem {
+                        visible: modelData.visible
+                        text: modelData.name
+                        onClicked: modelData.action()
+                    }
                 }
 
                 MenuItem {

--- a/qml/components/PollPreview.qml
+++ b/qml/components/PollPreview.qml
@@ -19,6 +19,7 @@
 
 import QtQuick 2.6
 import Sailfish.Silica 1.0
+import WerkWolf.Fernschreiber 1.0
 
 import "../js/functions.js" as Functions
 import "../js/twemoji.js" as Emoji
@@ -46,8 +47,19 @@ Item {
     property bool highlighted
     width: parent.width
     height: pollColumn.height
-    opacity: 0
-    Behavior on opacity { FadeAnimation {} }
+    property list<NamedAction> extraContextMenuItems: [
+        NamedAction {
+            visible: !pollData.is_closed && pollMessageComponent.canEdit
+            name: qsTr("Close Poll")
+            action: function () { tdLibWrapper.stopPoll(pollMessageComponent.chatId, pollMessageComponent.messageId) }
+        },
+        NamedAction {
+            visible: !pollData.is_closed && !pollMessageComponent.isQuiz && pollMessageComponent.hasAnswered
+            name: qsTr("Reset Answer")
+            action: function () { pollMessageComponent.resetChosen() }
+        }
+    ]
+
     function handleChoose(index) {
         if(!pollData.type.allow_multiple_answers) {
             chosenIndexes = [index];
@@ -280,36 +292,6 @@ Item {
                 horizontalAlignment: Text.AlignRight
                 color: pollMessageComponent.isOwnMessage || pollMessageComponent.highlighted ? Theme.secondaryHighlightColor : Theme.secondaryColor
             }
-        }
-    }
-
-    Component {
-        id: closePollMenuItemComponent
-        MenuItem {
-            visible: !pollData.is_closed && pollMessageComponent.canEdit
-            text: qsTr("Close Poll")
-            onClicked: {
-                tdLibWrapper.stopPoll(pollMessageComponent.chatId, pollMessageComponent.messageId);
-            }
-        }
-    }
-
-    Component {
-        id: resetAnswerMenuItemComponent
-        MenuItem {
-            visible: !pollData.is_closed && !pollMessageComponent.isQuiz && pollMessageComponent.hasAnswered
-            text: qsTr("Reset Answer")
-            onClicked: {
-                pollMessageComponent.resetChosen()
-            }
-        }
-    }
-
-    Component.onCompleted: {
-        opacity = 1;
-        if(messageListItem && messageListItem.additionalContextItems ) {
-            messageListItem.additionalContextItems.append(closePollMenuItemComponent.createObject());
-            messageListItem.additionalContextItems.append(resetAnswerMenuItemComponent.createObject());
         }
     }
 }

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -29,12 +29,14 @@
 #include <QQmlEngine>
 #include <QGuiApplication>
 #include <QLoggingCategory>
+
 #include "appsettings.h"
 #include "debuglogjs.h"
 #include "tdlibfile.h"
 #include "tdlibwrapper.h"
 #include "chatlistmodel.h"
 #include "chatmodel.h"
+#include "namedaction.h"
 #include "notificationmanager.h"
 #include "mceinterface.h"
 #include "dbusadaptor.h"
@@ -66,6 +68,7 @@ int main(int argc, char *argv[])
 
     const char *uri = "WerkWolf.Fernschreiber";
     qmlRegisterType<TDLibFile>(uri, 1, 0, "TDLibFile");
+    qmlRegisterType<NamedAction>(uri, 1, 0, "NamedAction");
     qmlRegisterSingletonType<DebugLogJS>(uri, 1, 0, "DebugLog", DebugLogJS::createSingleton);
 
     AppSettings *appSettings = new AppSettings(view.data());

--- a/src/namedaction.cpp
+++ b/src/namedaction.cpp
@@ -1,0 +1,65 @@
+/*
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "namedaction.h"
+
+// A workaroud for
+// ListElement: cannot use script for property value
+
+NamedAction::NamedAction(QObject *parent) :
+    QObject(parent),
+    visible(true),
+    action(QJSValue::UndefinedValue)
+{
+}
+
+bool NamedAction::getVisible() const
+{
+    return visible;
+}
+
+void NamedAction::setVisible(bool newVisible)
+{
+    if (visible != newVisible) {
+        visible = newVisible;
+        emit visibleChanged();
+    }
+}
+
+QString NamedAction::getName() const
+{
+    return name;
+}
+
+void NamedAction::setName(QString newName)
+{
+    if (name != newName) {
+        name = newName;
+        emit nameChanged();
+    }
+}
+
+QJSValue NamedAction::getAction() const
+{
+    return action;
+}
+
+void NamedAction::setAction(QJSValue newAction)
+{
+    action = newAction;
+    emit actionChanged();
+}

--- a/src/namedaction.h
+++ b/src/namedaction.h
@@ -1,0 +1,54 @@
+/*
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef NAMEDACTION_H
+#define NAMEDACTION_H
+
+#include <QObject>
+#include <QString>
+#include <QJSValue>
+
+class NamedAction : public QObject {
+    Q_OBJECT
+    Q_PROPERTY(bool visible READ getVisible WRITE setVisible NOTIFY visibleChanged)
+    Q_PROPERTY(QString name READ getName WRITE setName NOTIFY nameChanged)
+    Q_PROPERTY(QJSValue action READ getAction WRITE setAction NOTIFY actionChanged)
+
+public:
+    NamedAction(QObject *parent = Q_NULLPTR);
+
+    bool getVisible() const;
+    void setVisible(bool newVisible);
+
+    QString getName() const;
+    void setName(QString newName);
+
+    QJSValue getAction() const;
+    void setAction(QJSValue newAction);
+
+signals:
+    void visibleChanged();
+    void nameChanged();
+    void actionChanged();
+
+private:
+    bool visible;
+    QString name;
+    QJSValue action;
+};
+
+#endif // NAMEDACTION_H


### PR DESCRIPTION
Not every time, but quite often I was getting this crash when `Repeater` was adding context menu items instantiated by `PollPreview` to context menu owned by `MessageListViewItem`:

```
Thread 1 "harbour-fernsch" received signal SIGSEGV, Segmentation fault.
QQmlData::get (create=false, object=0xdbe008) at qqmldata_p.h:190
190	qqmldata_p.h: No such file or directory.
(gdb) bt
#0  QQmlData::get (create=false, object=0xdbe008) at qqmldata_p.h:190
#1  QQmlMetaObject::QQmlMetaObject (this=0xfffef040, o=0xdbe008) at qqmlpropertycache_p.h:564
#2  0xf6d11952 in qmlobject_cast<QQuickItem*> (object=0xdbe008) at qqmlglobal_p.h:163
#3  0xf6d6d8a2 in QQuickRepeater::initItem (this=0xdb5e50, index=0, object=0xdbe008) at qquickrepeater.cpp:411
#4  0xf6def36a in QQuickRepeater::qt_static_metacall (_o=0xdb5e50, _c=QMetaObject::InvokeMetaMethod, _id=6, _a=0xfffef1bc) at moc_qquickrepeater_p.cpp:137
#5  0xf6def624 in QQuickRepeater::qt_metacall (this=0xdb5e50, _c=QMetaObject::InvokeMetaMethod, _id=6, _a=0xfffef1bc) at moc_qquickrepeater_p.cpp:262
#6  0xf627c080 in QMetaObject::activate (sender=0xdf93b8, signalOffset=<optimized out>, local_signal_index=3, argv=0xfffef1bc) at qobject.cpp:3745
#7  0xf627c43a in QMetaObject::activate (sender=0xdf93b8, m=<optimized out>, local_signal_index=3, argv=0xfffef1bc) at qobject.cpp:3595
#8  0xf67467c0 in QQmlInstanceModel::initItem (this=0xdf93b8, _t1=<optimized out>, _t1@entry=0, _t2=<optimized out>) at moc_qqmlobjectmodel_p.cpp:234
#9  0xf673b03a in QQmlObjectModel::object (this=0xdf93b8, index=0) at qqmlobjectmodel.cpp:270
#10 0xf6d6cd5a in QQuickRepeaterPrivate::requestItems (this=0xf5c9b8) at atomic_base.h:390
#11 0xf6d6ce60 in QQuickRepeater::regenerate (this=0xdb5e50) at qquickrepeater.cpp:388
#12 0xf6d6e39a in QQuickRepeater::componentComplete (this=0xdb5e50) at qquickrepeater.cpp:341
#13 0xf670883e in QQmlObjectCreator::finalize (this=0xdb70b8, interrupt=...) at qqmlobjectcreator.cpp:1232
#14 0xf66bcef8 in QQmlIncubatorPrivate::incubate (this=0xee0e88, i=...) at qqmlincubator.cpp:348
#15 0xf66bd3f0 in QQmlIncubationController::incubateFor (this=0x7f6650, msecs=<optimized out>) at qintrusivelist_p.h:236
#16 0xf627c258 in QMetaObject::activate (sender=0x72e0f8, signalOffset=<optimized out>, local_signal_index=0, argv=0x0) at qobject.cpp:3730
#17 0xf627c43a in QMetaObject::activate (sender=0x72e0f8, m=<optimized out>, local_signal_index=0, argv=0x0) at qobject.cpp:3595
#18 0xf6de25aa in QSGRenderLoop::timeToIncubate (this=0x72e0f8) at moc_qsgrenderloop_p.cpp:125
#19 0xf6cf8700 in QSGThreadedRenderLoop::event (e=<optimized out>, this=0x72e0f8) at qsgthreadedrenderloop.cpp:1243
#20 QSGThreadedRenderLoop::event (this=0x72e0f8, e=<optimized out>) at qsgthreadedrenderloop.cpp:1234
#21 0xf625fc44 in doNotify (event=<optimized out>, receiver=<optimized out>) at qobject.h:137
#22 QCoreApplication::notify (this=<optimized out>, receiver=<optimized out>, event=<optimized out>) at qcoreapplication.cpp:1076
#23 0xf625fd52 in QCoreApplication::notifyInternal2 (receiver=0x72e0f8, event=0xfffef470) at qobject.h:137
#24 0xf6297db0 in QCoreApplication::sendEvent (event=0xfffef470, receiver=<optimized out>) at qcoreapplication.h:225
#25 QTimerInfoList::activateTimers (this=0x704124) at qtimerinfo_unix.cpp:637
#26 0xf6298138 in timerSourceDispatch (source=0x7040f0) at qeventdispatcher_glib.cpp:179
#27 0xf54d2a64 in g_main_dispatch (context=0x6f6bc0) at gmain.c:3325
#28 g_main_context_dispatch (context=0x6f6bc0) at gmain.c:4016
#29 0xf54d2bfc in g_main_context_iterate (context=0x6f6bc0, block=1, dispatch=1, self=<optimized out>) at gmain.c:4092
#30 0xf54d2c54 in g_main_context_iteration (context=0x6f6bc0, may_block=1) at gmain.c:4157
#31 0xf62989a2 in QEventDispatcherGlib::processEvents (this=0x6f6938, flags=...) at qeventdispatcher_glib.cpp:423
#32 0xf625e9ea in QEventLoop::exec (this=0xfffef5a0, flags=...) at qflags.h:131
#33 0xf62641e0 in QCoreApplication::exec () at qflags.h:111
#34 0x005331ce in main (argc=1, argv=0xfffef894) at harbour-fernschreiber.cpp:122
(gdb) 
```

I fixed it by instantiating those extra menu items inside context menu itself. Generic `ListElement` couldn't be used because it doesn't like functions as property values, hence this `NamedAction` thing.