### PR TITLE
Don't show Reply menu item if the message can't be replied to

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -28,6 +28,7 @@ ListItem {
     property var chatId
     property var messageId
     property var myMessage
+    property bool canReplyToMessage
     readonly property var userInformation: tdLibWrapper.getUserInformation(myMessage.sender_user_id)
     property QtObject precalculatedValues: ListView.view.precalculatedValues
     readonly property color textColor: isOwnMessage ? Theme.highlightColor : Theme.primaryColor
@@ -41,6 +42,9 @@ ListItem {
 
     highlighted: (down || isSelected) && !menuOpen
     openMenuOnPressAndHold: !messageListItem.precalculatedValues.pageIsSelecting
+
+    signal replyToMessage()
+    signal editMessage()
 
     onClicked: {
         if(messageListItem.precalculatedValues.pageIsSelecting) {
@@ -88,20 +92,14 @@ ListItem {
                 }
 
                 MenuItem {
-                    onClicked: {
-                        newMessageInReplyToRow.inReplyToMessage = myMessage;
-                        newMessageTextField.focus = true;
-                    }
+                    visible: messageListItem.canReplyToMessage
+                    onClicked: messageListItem.replyToMessage()
                     text: qsTr("Reply to Message")
                 }
                 MenuItem {
-                    onClicked: {
-                        newMessageColumn.editMessageId = messageId;
-                        newMessageTextField.text = Functions.getMessageText(myMessage, false, false, true);
-                        newMessageTextField.focus = true;
-                    }
-                    text: qsTr("Edit Message")
                     visible: myMessage.can_be_edited
+                    onClicked: messageListItem.editMessage()
+                    text: qsTr("Edit Message")
                 }
                 MenuItem {
                     onClicked: {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -58,6 +58,8 @@ Page {
                                     )
     property var selectedMessages: []
     readonly property bool isSelecting: selectedMessages.length > 0
+    readonly property bool canSendMessages: hasSendPrivilege("can_send_messages")
+
     states: [
         State {
             name: "selectMessages"
@@ -77,6 +79,7 @@ Page {
         }
 
     ]
+
     function toggleMessageSelection(message) {
         var selectionArray = selectedMessages;
         var foundIndex = -1
@@ -923,6 +926,16 @@ Page {
                                 myMessage: model.display
                                 messageId: model.message_id
                                 extraContentComponentName: chatView.contentComponentNames[model.content_type]
+                                canReplyToMessage: chatPage.canSendMessages
+                                onReplyToMessage: {
+                                    newMessageInReplyToRow.inReplyToMessage = myMessage
+                                    newMessageTextField.focus = true
+                                }
+                                onEditMessage: {
+                                    newMessageColumn.editMessageId = messageId
+                                    newMessageTextField.text = Functions.getMessageText(myMessage, false, false, true)
+                                    newMessageTextField.focus = true
+                                }
                             }
                         }
                         Component {
@@ -1048,7 +1061,7 @@ Page {
                 height: isNeeded ? implicitHeight : 0
                 Behavior on height { SmoothedAnimation { duration: 200 } }
 
-                readonly property bool isNeeded: !chatPage.isSelecting && chatPage.hasSendPrivilege("can_send_messages")
+                readonly property bool isNeeded: !chatPage.isSelecting && chatPage.canSendMessages
                 property string replyToMessageId: "0";
                 property string editMessageId: "0";
 


### PR DESCRIPTION
Also moved the handling of the Edit action to the chat page where it's actually being handled.