### PR TITLE
Fixed Emoji image positioning in multiline StyledText

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -51,6 +51,7 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/components/MessageListViewItem.qml \
     qml/components/MessageListViewItemSimple.qml \
     qml/components/MessageOverlayFlickable.qml \
+    qml/components/MultilineEmojiLabel.qml \
     qml/components/PinnedMessageItem.qml \
     qml/components/PollPreview.qml \
     qml/components/PressEffect.qml \

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -57,6 +57,8 @@ ListItem {
                 mouseX < (extraContentLoader.x + extraContentLoader.width) &&
                 mouseY < (extraContentLoader.y + extraContentLoader.height)) {
                 extraContent.clicked()
+            } else if (webPagePreviewLoader.item) {
+                webPagePreviewLoader.item.clicked()
             }
         }
     }
@@ -397,17 +399,10 @@ ListItem {
                     active: false
                     asynchronous: true
                     width: parent.width
-                    height: typeof myMessage.content.web_page !== "undefined" ? precalculatedValues.webPagePreviewHeight : 0
+                    height: (status === Loader.Ready) ? item.implicitHeight : myMessage.content.web_page ? precalculatedValues.webPagePreviewHeight : 0
 
                     sourceComponent: Component {
-                        id: webPagePreviewComponent
                         WebPagePreview {
-                            id: webPagePreview
-
-                            onImplicitHeightChanged: {
-                                webPagePreviewLoader.height = webPagePreview.implicitHeight;
-                            }
-
                             webPageData: myMessage.content.web_page
                             width: parent.width
                             highlighted: messageListItem.highlighted

--- a/qml/components/MultilineEmojiLabel.qml
+++ b/qml/components/MultilineEmojiLabel.qml
@@ -1,0 +1,78 @@
+/*
+    Copyright (C) 2020 Slava Monich and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import "../js/twemoji.js" as Emoji
+
+// Combination of maximumLineCount and TruncationMode.Elide (or Fade) breaks
+// Emoji image alignment, pushing the image down. This one aligns the image
+// correctly on its line.
+Label {
+    property string rawText
+    property int maxLineCount
+
+    wrapMode: Text.Wrap
+    textFormat: Text.StyledText
+    truncationMode: TruncationMode.Elide
+
+    // lineCount is unreliable for StyledText with images and line breaks
+    readonly property int fontSize: font.pixelSize
+    readonly property int actualLineHeight: (text === rawText) ? fontSize : (fontSize * 6 / 5)
+    readonly property int actualLineCount: Math.floor(implicitHeight/actualLineHeight)
+
+    Component.onCompleted: refitText()
+    onFontSizeChanged: refitText()
+    onWidthChanged: refitText()
+    onRawTextChanged: refitText()
+    onMaxLineCountChanged: refitText()
+
+    function emojify(str) {
+        return Emoji.emojify(str, fontSize)
+    }
+
+    function refitText() {
+        text = emojify(rawText)
+        if (maxLineCount > 0) {
+            var divisor = 1
+            var max = rawText.length
+            var min = max
+            while (actualLineCount > maxLineCount && divisor < rawText.length) {
+                max = min
+                divisor++
+                min = rawText.length/divisor
+                text = emojify(rawText.substr(0, min) + "…")
+            }
+            while (min < max) {
+                var mid = Math.floor((min + max)/2)
+                if (mid === min) {
+                    text = emojify(rawText.substr(0, min) + "…")
+                    break
+                } else {
+                    text = emojify(rawText.substr(0, mid) + "…")
+                    if (actualLineCount > maxLineCount) {
+                        max = mid
+                    } else {
+                        min = mid
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
The problem - combination of `maximumLineCount` and `TruncationMode.Elide` (or `Fade`) breaks Emoji image alignment, pushing the image down, like this:

![001](https://user-images.githubusercontent.com/5909522/103058681-8e0ef080-45ab-11eb-9f6b-e99b65e455f2.png)

Explicitly truncating the text fixes the problem, at expense of certain runtime overhead. The image stays where it's supposed to be:

![002](https://user-images.githubusercontent.com/5909522/103058706-a121c080-45ab-11eb-8fb9-fc81c96d62da.png)

Also, added the code to toggle full and truncated Web page preview on tap. For example, tapping the above two things expands them into full preview:

![003](https://user-images.githubusercontent.com/5909522/103058744-c9112400-45ab-11eb-95de-f50fdb7c8762.png)

Cool?