### PR TITLE
speed up overview page loading

### DIFF
--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -24,39 +24,57 @@ PhotoTextsListItem {
     isSecret: ( chat_type === TelegramAPI.ChatTypeSecret )
 
     openMenuOnPressAndHold: true//chat_id != overviewPage.ownUserId
-    menu: ContextMenu {
-        MenuItem {
-            visible: unread_count > 0
-            onClicked: {
-                tdLibWrapper.viewMessage(chat_id, display.last_message.id, true);
-            }
-            text: qsTr("Mark all messages as read")
-        }
 
-        MenuItem {
-            visible: chat_id != listItem.ownUserId
-            onClicked: {
-                var newNotificationSettings = display.notification_settings;
-                if (newNotificationSettings.mute_for > 0) {
-                    newNotificationSettings.mute_for = 0;
-                } else {
-                    newNotificationSettings.mute_for = 6666666;
-                }
-                newNotificationSettings.use_default_mute_for = false;
-                tdLibWrapper.setChatNotificationSettings(chat_id, newNotificationSettings);
-            }
-            text: display.notification_settings.mute_for > 0 ? qsTr("Unmute Chat") : qsTr("Mute Chat")
-        }
+    onPressAndHold: {
+        contextMenuLoader.active = true;
+    }
 
-        MenuItem {
-            onClicked: {
-                if(pageStack.depth > 2) {
-                    pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
+    Loader {
+        id: contextMenuLoader
+        active: false
+        asynchronous: true
+        onStatusChanged: {
+            if(status === Loader.Ready) {
+                listItem.menu = item;
+                listItem.openMenu();
+            }
+        }
+        sourceComponent: Component {
+            ContextMenu {
+                MenuItem {
+                    visible: unread_count > 0
+                    onClicked: {
+                        tdLibWrapper.viewMessage(chat_id, display.last_message.id, true);
+                    }
+                    text: qsTr("Mark all messages as read")
                 }
 
-                pageStack.push(Qt.resolvedUrl("../pages/ChatInformationPage.qml"), { "chatInformation" : display});
+                MenuItem {
+                    visible: chat_id != listItem.ownUserId
+                    onClicked: {
+                        var newNotificationSettings = display.notification_settings;
+                        if (newNotificationSettings.mute_for > 0) {
+                            newNotificationSettings.mute_for = 0;
+                        } else {
+                            newNotificationSettings.mute_for = 6666666;
+                        }
+                        newNotificationSettings.use_default_mute_for = false;
+                        tdLibWrapper.setChatNotificationSettings(chat_id, newNotificationSettings);
+                    }
+                    text: display.notification_settings.mute_for > 0 ? qsTr("Unmute Chat") : qsTr("Mute Chat")
+                }
+
+                MenuItem {
+                    onClicked: {
+                        if(pageStack.depth > 2) {
+                            pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
+                        }
+
+                        pageStack.push(Qt.resolvedUrl("../pages/ChatInformationPage.qml"), { "chatInformation" : display});
+                    }
+                    text: model.display.type['@type'] === "chatTypePrivate" ? qsTr("User Info") : qsTr("Group Info")
+                }
             }
-            text: model.display.type['@type'] === "chatTypePrivate" ? qsTr("User Info") : qsTr("Group Info")
         }
     }
 

--- a/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
@@ -154,15 +154,6 @@ ChatInformationTabItemBase {
                 pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
                 pageStack.push(Qt.resolvedUrl("../../pages/ChatPage.qml"), { "chatInformation" : display });
             }
-            Connections {
-                target: chatListModel
-                onChatChanged: {
-                    if (changedChatId === chat_id) {
-                        // Force update of some list item elements (currently only last message text seems to create problems). dataChanged() doesn't seem to trigger them all :(
-                        secondaryText.text = last_message_text ? Emoji.emojify(Functions.enhanceHtmlEntities(last_message_text), Theme.fontSizeExtraSmall) : qsTr("Unknown")
-                    }
-                }
-            }
         }
     }
 


### PR DESCRIPTION
contributes to #198

A few small changes to get the "time to chat list" pretty low:
 - put `ContextMenu` of `ChatListViewItem` into a `Loader` – the impact here isn't as heavy as on the `ChatPage`, but it saves a few ms on init and while scrolling.
 - radically reduced `interval` of `chatListCreatedTimer`. This just renders the list much, much sooner and seems to work pretty well.
 - put `tdLibWrapper.getRecentStickers()`,  `tdLibWrapper.getInstalledStickerSets()` and `tdLibWrapper.getContacts()` into a new Timer that is started when `chatListCreatedTimer` triggers. I don't think these are needed right at the start, so we can defer the needed time a bit.
 - removed `chatListModel.redrawModel()` when the chatList is created. In my tests, this workaround didn't seem needed anymore.
 - removed the `onChatChanged` `Connection` in every delegate.  In my tests, this workaround didn't seem needed anymore and even if it didn't do much, it got called a few thousand times on init in my setup, which added up. Also did this in `ChatInformationTabItemMembersGroups.qml`.
 - removed the main `Column`s. We basically only have a `PageHeader` (now containing the `GlassItem`) and the `chatListView` as layout items, so there's really no need for extra `Column`s calculating their own layouts. The loading indicator is now just anchored to the `chatListView`. 
 - Small layout change: I omitted the anchor `topMargin: Theme.paddingMedium` that would be needed on the `chatListView` to get the same layout as before. PageHeader has its own padding, so now the text seems better centered vertically.
 - replaced the `NumberAnimation`s with `FadeAnimation`s mainly because @monich likes that and I'm here to please.

~~One drawback~~ Two drawbacks I've noticed: 
- Sometimes I'm not able to read the loading text because it disappears too quickly. But I could get used to that.
- Updates/changes in the chat order may now be visible after initial load. I guess this is what the long interval was meant to hide, but I actually like it better this way – if you disagree, I'm happy to increase it again (maybe a bit lower than 300ms?).

As discussed quite a while ago, we'll have to test for a while if the two removed workarounds really aren't needed anymore or if I just got (un)lucky in the bug hunting lottery.