### PR TITLE
Fernschreiber learns filtering and searching

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -84,6 +84,7 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/pages/AboutPage.qml \
     qml/pages/PollCreationPage.qml \
     qml/pages/PollResultsPage.qml \
+    qml/pages/SearchChatsPage.qml \
     qml/pages/SettingsPage.qml \
     qml/pages/VideoPage.qml \
     rpm/harbour-fernschreiber.changes \

--- a/qml/components/AudioPreview.qml
+++ b/qml/components/AudioPreview.qml
@@ -64,9 +64,9 @@ Item {
             audioType = ( audioData['@type'] === "voiceNote" ) ? "voice" : "audio";
             audioFileId = audioData[audioType].id;
             if (typeof audioData.album_cover_thumbnail !== "undefined") {
-                previewFileId = audioData.album_cover_thumbnail.photo.id;
-                if (audioData.album_cover_thumbnail.photo.local.is_downloading_completed) {
-                    placeholderImage.source = audioData.album_cover_thumbnail.photo.local.path;
+                previewFileId = audioData.album_cover_thumbnail.file.id;
+                if (audioData.album_cover_thumbnail.file.local.is_downloading_completed) {
+                    placeholderImage.source = audioData.album_cover_thumbnail.file.local.path;
                 } else {
                     tdLibWrapper.downloadFile(previewFileId);
                 }
@@ -94,7 +94,7 @@ Item {
             if (typeof audioData === "object") {
                 if (fileInformation.local.is_downloading_completed) {
                     if (fileId === previewFileId) {
-                        audioData.thumbnail.photo = fileInformation;
+                        audioData.album_cover_thumbnail.file = fileInformation;
                         placeholderImage.source = fileInformation.local.path;
                     }
                     if (fileId === audioFileId) {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -779,7 +779,6 @@ Page {
                         id: searchInChatField
                         visible: false
                         width: visible ? parent.width : 0
-                        height: parent.height
                         placeholderText: qsTr("Search in chat...")
                         active: searchInChatItem.visible
                         canHide: text === ""

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -907,7 +907,6 @@ Page {
                     }
 
                     onContentYChanged: {
-                        Debug.log("In Cooldown: " + chatView.inCooldown);
                         if (!chatPage.loading && !chatView.inCooldown) {
                             if (chatView.indexAt(chatView.contentX, chatView.contentY) < 10) {
                                 Debug.log("[ChatPage] Trying to get older history items...");

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -65,7 +65,6 @@ Page {
         onTriggered: {
             overviewPage.chatListCreated = true;
             chatListModel.redrawModel();
-            chatListView.model = chatListProxyModel;
         }
     }
 
@@ -312,7 +311,7 @@ Page {
                     opacity: overviewPage.chatListCreated ? 1 : 0
                     Behavior on opacity { NumberAnimation {} }
 
-                    model: chatListModel
+                    model: chatSearchField.text !== "" ? chatListProxyModel : chatListModel
                     delegate: ChatListViewItem {
                         ownUserId: overviewPage.ownUserId
                         isVerified: is_verified

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -156,11 +156,13 @@ Page {
     }
 
     function resetFocus() {
+        if (chatSearchField.text === "") {
+            chatSearchField.visible = false;
+            pageHeader.visible = true;
+            searchChatButton.visible = overviewPage.connectionState === TelegramAPI.ConnectionReady;
+        }
         chatSearchField.focus = false;
         overviewPage.focus = true;
-        chatSearchField.visible = false;
-        pageHeader.visible = true;
-        searchChatButton.visible = overviewPage.connectionState === TelegramAPI.ConnectionReady;
     }
 
     Connections {
@@ -282,11 +284,16 @@ Page {
                 Behavior on opacity { FadeAnimation {} }
                 width: visible ? ( parent.width - pageStatus.width ) : 0
                 height: pageHeader.height
-                placeholderText: qsTr("Search a chat...")
+                placeholderText: qsTr("Filter your chats...")
                 active: searchHeaderItem.visible
+                canHide: text === ""
 
                 onTextChanged: {
                     searchChatTimer.restart();
+                }
+
+                onHideClicked: {
+                    resetFocus();
                 }
 
                 EnterKey.iconSource: "image://theme/icon-m-enter-close"

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -231,6 +231,10 @@ Page {
                 onClicked: pageStack.push(Qt.resolvedUrl("../pages/SettingsPage.qml"))
             }
             MenuItem {
+                text: qsTr("Search Chats")
+                onClicked: pageStack.push(Qt.resolvedUrl("../pages/SearchChatsPage.qml"))
+            }
+            MenuItem {
                 text: qsTr("New Chat")
                 onClicked: pageStack.push(Qt.resolvedUrl("../pages/NewChatPage.qml"))
             }
@@ -285,7 +289,6 @@ Page {
                 width: visible ? ( parent.width - pageStatus.width ) : 0
                 height: pageHeader.height
                 placeholderText: qsTr("Filter your chats...")
-                active: searchHeaderItem.visible
                 canHide: text === ""
 
                 onTextChanged: {

--- a/qml/pages/SearchChatsPage.qml
+++ b/qml/pages/SearchChatsPage.qml
@@ -52,6 +52,10 @@ Page {
             Debug.log(JSON.stringify(chats));
             chatsFound = chats;
         }
+        onErrorReceived: {
+            searchChatsPage.isLoading = false;
+            Functions.handleErrorMessage(code, message);
+        }
     }
 
     property bool isLoading: false;

--- a/qml/pages/SearchChatsPage.qml
+++ b/qml/pages/SearchChatsPage.qml
@@ -1,0 +1,258 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import WerkWolf.Fernschreiber 1.0
+import "../components"
+import "../js/debug.js" as Debug
+import "../js/twemoji.js" as Emoji
+import "../js/functions.js" as Functions
+
+Page {
+    id: searchChatsPage
+    allowedOrientations: Orientation.All
+
+    function resetFocus() {
+        publicChatsSearchField.focus = false;
+        searchChatsPage.focus = true;
+    }
+
+    Timer {
+        id: searchPublicChatsTimer
+        interval: 800
+        running: false
+        repeat: false
+        onTriggered: {
+            Debug.log("Searching for '" + publicChatsSearchField.text + "'");
+            tdLibWrapper.searchPublicChats(publicChatsSearchField.text);
+            searchChatsPage.isLoading = true;
+        }
+    }
+
+    Connections {
+        target: tdLibWrapper
+        onChatsReceived: {
+            searchChatsPage.isLoading = false;
+            Debug.log(JSON.stringify(chats));
+            chatsFound = chats;
+        }
+    }
+
+    property bool isLoading: false;
+    property var chatsFound;
+    readonly property var ownUserId: tdLibWrapper.getUserInformation().id;
+
+    SilicaFlickable {
+        id: searchChatsContainer
+        contentHeight: searchChatsPage.height
+        anchors.fill: parent
+
+        Column {
+            id: searchChatsPageColumn
+            width: searchChatsPage.width
+            height: searchChatsPage.height
+
+            PageHeader {
+                id: searchChatsPageHeader
+                title: qsTr("Search Chats")
+            }
+
+            Item {
+                id: publicChatsItem
+
+                width: searchChatsPageColumn.width
+                height: searchChatsPageColumn.height - searchChatsPageHeader.height
+
+                Column {
+
+                    width: parent.width
+                    height: parent.height
+
+                    SearchField {
+                        id: publicChatsSearchField
+                        width: parent.width
+                        placeholderText: qsTr("Search a chat...")
+                        focus: true
+
+                        onTextChanged: {
+                            searchPublicChatsTimer.restart();
+                        }
+
+                        EnterKey.iconSource: "image://theme/icon-m-enter-close"
+                        EnterKey.onClicked: {
+                            resetFocus();
+                        }
+
+                    }
+
+                    SilicaListView {
+                        id: searchChatsListView
+                        clip: true
+                        width: parent.width
+                        height: parent.height - publicChatsSearchField.height
+                        visible: !searchChatsPage.isLoading
+                        opacity: visible ? 1 : 0
+                        Behavior on opacity { FadeAnimation {} }
+                        model: searchChatsPage.chatsFound.chat_ids
+
+                        ViewPlaceholder {
+                            y: Theme.paddingLarge
+                            enabled: searchChatsListView.count === 0
+                            text: publicChatsSearchField.text.length < 5 ? qsTr("Enter your query to start searching (at least 5 characters needed)") : qsTr("No chats found.")
+                        }
+
+                        delegate: Item {
+                            id: foundChatListDelegate
+                            width: parent.width
+                            height: foundChatListItem.height
+
+                            property var foundChatInformation: tdLibWrapper.getChat(modelData);
+                            property var relatedInformation;
+                            property bool isPrivateChat: false;
+                            property bool isBasicGroup: false;
+                            property bool isSupergroup: false;
+
+                            Component.onCompleted: {
+                                switch (foundChatInformation.type["@type"]) {
+                                case "chatTypePrivate":
+                                    relatedInformation = tdLibWrapper.getUserInformation(foundChatInformation.type.user_id);
+                                    foundChatListItem.prologSecondaryText.text = qsTr("Private Chat");
+                                    foundChatListItem.secondaryText.text = "@" + ( relatedInformation.username !== "" ? relatedInformation.username : relatedInformation.user_id );
+                                    tdLibWrapper.getUserFullInfo(foundChatInformation.type.user_id);
+                                    isPrivateChat = true;
+                                    break;
+                                case "chatTypeBasicGroup":
+                                    relatedInformation = tdLibWrapper.getBasicGroup(foundChatInformation.type.basic_group_id);
+                                    foundChatListItem.prologSecondaryText.text = qsTr("Group");
+                                    tdLibWrapper.getGroupFullInfo(foundChatInformation.type.basic_group_id, false);
+                                    isBasicGroup = true;
+                                    break;
+                                case "chatTypeSupergroup":
+                                    relatedInformation = tdLibWrapper.getSuperGroup(foundChatInformation.type.supergroup_id);
+                                    if (relatedInformation.is_channel) {
+                                        foundChatListItem.prologSecondaryText.text = qsTr("Channel");
+                                    } else {
+                                        foundChatListItem.prologSecondaryText.text = qsTr("Group");
+                                    }
+                                    tdLibWrapper.getGroupFullInfo(foundChatInformation.type.supergroup_id, true);
+                                    isSupergroup = true;
+                                    break;
+                                }
+                            }
+
+                            Connections {
+                                target: tdLibWrapper
+                                onUserFullInfoUpdated: {
+                                    if (foundChatListDelegate.isPrivateChat && userId.toString() === foundChatListDelegate.foundChatInformation.type.user_id.toString()) {
+                                        foundChatListItem.tertiaryText.text = Emoji.emojify(userFullInfo.bio, foundChatListItem.tertiaryText.font.pixelSize, "../js/emoji/");
+                                    }
+                                }
+                                onUserFullInfoReceived: {
+                                    if (foundChatListDelegate.isPrivateChat && userFullInfo["@extra"].toString() === foundChatListDelegate.foundChatInformation.type.user_id.toString()) {
+                                        foundChatListItem.tertiaryText.text = Emoji.emojify(userFullInfo.bio, foundChatListItem.tertiaryText.font.pixelSize, "../js/emoji/");
+                                    }
+                                }
+
+                                onBasicGroupFullInfoUpdated: {
+                                    if (foundChatListDelegate.isBasicGroup && groupId.toString() === foundChatListDelegate.foundChatInformation.type.basic_group_id.toString()) {
+                                        foundChatListItem.secondaryText.text = qsTr("%1 members").arg(Number(groupFullInfo.members.length).toLocaleString(Qt.locale(), "f", 0));
+                                        foundChatListItem.tertiaryText.text = Emoji.emojify(groupFullInfo.description, foundChatListItem.tertiaryText.font.pixelSize, "../js/emoji/");
+                                    }
+                                }
+                                onBasicGroupFullInfoReceived: {
+                                    if (foundChatListDelegate.isBasicGroup && groupId.toString() === foundChatListDelegate.foundChatInformation.type.basic_group_id.toString()) {
+                                        foundChatListItem.secondaryText.text = qsTr("%1 members").arg(Number(groupFullInfo.members.length).toLocaleString(Qt.locale(), "f", 0));
+                                        foundChatListItem.tertiaryText.text = Emoji.emojify(groupFullInfo.description, foundChatListItem.tertiaryText.font.pixelSize, "../js/emoji/");
+                                    }
+                                }
+
+                                onSupergroupFullInfoUpdated: {
+                                    if (foundChatListDelegate.isSupergroup && groupId.toString() === foundChatListDelegate.foundChatInformation.type.supergroup_id.toString()) {
+                                        if (foundChatListDelegate.relatedInformation.is_channel) {
+                                            foundChatListItem.secondaryText.text = qsTr("%1 subscribers").arg(Number(groupFullInfo.member_count).toLocaleString(Qt.locale(), "f", 0));
+                                        } else {
+                                            foundChatListItem.secondaryText.text = qsTr("%1 members").arg(Number(groupFullInfo.member_count).toLocaleString(Qt.locale(), "f", 0));
+                                        }
+                                        foundChatListItem.tertiaryText.text = Emoji.emojify(groupFullInfo.description, foundChatListItem.tertiaryText.font.pixelSize, "../js/emoji/");
+                                    }
+                                }
+                                onSupergroupFullInfoReceived: {
+                                    if (foundChatListDelegate.isSupergroup && groupId.toString() === foundChatListDelegate.foundChatInformation.type.supergroup_id.toString()) {
+                                        if (foundChatListDelegate.relatedInformation.is_channel) {
+                                            foundChatListItem.secondaryText.text = qsTr("%1 subscribers").arg(Number(groupFullInfo.member_count).toLocaleString(Qt.locale(), "f", 0));
+                                        } else {
+                                            foundChatListItem.secondaryText.text = qsTr("%1 members").arg(Number(groupFullInfo.member_count).toLocaleString(Qt.locale(), "f", 0));
+                                        }
+                                        foundChatListItem.tertiaryText.text = Emoji.emojify(groupFullInfo.description, foundChatListItem.tertiaryText.font.pixelSize, "../js/emoji/");
+                                    }
+                                }
+                            }
+
+                            PhotoTextsListItem {
+                                id: foundChatListItem
+
+                                pictureThumbnail {
+                                    photoData: typeof foundChatInformation.photo.small !== "undefined" ? foundChatInformation.photo.small : {}
+                                }
+                                width: parent.width
+
+                                primaryText.text: Emoji.emojify(foundChatInformation.title, primaryText.font.pixelSize, "../js/emoji/")
+                                tertiaryText.maximumLineCount: 1
+
+                                onClicked: {
+                                    pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : foundChatInformation });
+                                }
+                            }
+                        }
+
+                        VerticalScrollDecorator {}
+                    }
+
+                }
+
+                Column {
+
+                    opacity: visible ? 1 : 0
+                    Behavior on opacity { FadeAnimation {} }
+                    visible: searchChatsPage.isLoading
+                    width: parent.width
+                    height: loadingLabel.height + loadingBusyIndicator.height + Theme.paddingMedium
+
+                    spacing: Theme.paddingMedium
+
+                    anchors.verticalCenter: parent.verticalCenter
+
+                    InfoLabel {
+                        id: loadingLabel
+                        text: qsTr("Searching chats...")
+                    }
+
+                    BusyIndicator {
+                        id: loadingBusyIndicator
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        running: searchChatsPage.isLoading
+                        size: BusyIndicatorSize.Large
+                    }
+                }
+
+            }
+
+        }
+    }
+}

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -54,23 +54,6 @@ namespace {
 class ChatListModel::ChatData
 {
 public:
-    enum Role {
-        RoleDisplay = Qt::DisplayRole,
-        RoleChatId,
-        RoleChatType,
-        RoleTitle,
-        RolePhotoSmall,
-        RoleUnreadCount,
-        RoleLastReadInboxMessageId,
-        RoleLastMessageSenderId,
-        RoleLastMessageDate,
-        RoleLastMessageText,
-        RoleLastMessageStatus,
-        RoleChatMemberStatus,
-        RoleSecretChatState,
-        RoleIsVerified,
-        RoleIsChannel
-    };
 
     ChatData(const QVariantMap &data, const QVariantMap &userInformation);
 
@@ -368,21 +351,22 @@ ChatListModel::~ChatListModel()
 QHash<int,QByteArray> ChatListModel::roleNames() const
 {
     QHash<int,QByteArray> roles;
-    roles.insert(ChatData::RoleDisplay, "display");
-    roles.insert(ChatData::RoleChatId, "chat_id");
-    roles.insert(ChatData::RoleChatType, "chat_type");
-    roles.insert(ChatData::RoleTitle, "title");
-    roles.insert(ChatData::RolePhotoSmall, "photo_small");
-    roles.insert(ChatData::RoleUnreadCount, "unread_count");
-    roles.insert(ChatData::RoleLastReadInboxMessageId, "last_read_inbox_message_id");
-    roles.insert(ChatData::RoleLastMessageSenderId, "last_message_sender_id");
-    roles.insert(ChatData::RoleLastMessageDate, "last_message_date");
-    roles.insert(ChatData::RoleLastMessageText, "last_message_text");
-    roles.insert(ChatData::RoleLastMessageStatus, "last_message_status");
-    roles.insert(ChatData::RoleChatMemberStatus, "chat_member_status");
-    roles.insert(ChatData::RoleSecretChatState, "secret_chat_state");
-    roles.insert(ChatData::RoleIsVerified, "is_verified");
-    roles.insert(ChatData::RoleIsChannel, "is_channel");
+    roles.insert(ChatListModel::RoleDisplay, "display");
+    roles.insert(ChatListModel::RoleChatId, "chat_id");
+    roles.insert(ChatListModel::RoleChatType, "chat_type");
+    roles.insert(ChatListModel::RoleTitle, "title");
+    roles.insert(ChatListModel::RolePhotoSmall, "photo_small");
+    roles.insert(ChatListModel::RoleUnreadCount, "unread_count");
+    roles.insert(ChatListModel::RoleLastReadInboxMessageId, "last_read_inbox_message_id");
+    roles.insert(ChatListModel::RoleLastMessageSenderId, "last_message_sender_id");
+    roles.insert(ChatListModel::RoleLastMessageDate, "last_message_date");
+    roles.insert(ChatListModel::RoleLastMessageText, "last_message_text");
+    roles.insert(ChatListModel::RoleLastMessageStatus, "last_message_status");
+    roles.insert(ChatListModel::RoleChatMemberStatus, "chat_member_status");
+    roles.insert(ChatListModel::RoleSecretChatState, "secret_chat_state");
+    roles.insert(ChatListModel::RoleIsVerified, "is_verified");
+    roles.insert(ChatListModel::RoleIsChannel, "is_channel");
+    roles.insert(ChatListModel::RoleFilter, "filter");
     return roles;
 }
 
@@ -396,22 +380,23 @@ QVariant ChatListModel::data(const QModelIndex &index, int role) const
     const int row = index.row();
     if (row >= 0 && row < chatList.size()) {
         const ChatData *data = chatList.at(row);
-        switch ((ChatData::Role)role) {
-        case ChatData::RoleDisplay: return data->chatData;
-        case ChatData::RoleChatId: return data->chatId;
-        case ChatData::RoleChatType: return data->chatType;
-        case ChatData::RoleTitle: return data->title();
-        case ChatData::RolePhotoSmall: return data->photoSmall();
-        case ChatData::RoleUnreadCount: return data->unreadCount();
-        case ChatData::RoleLastReadInboxMessageId: return data->lastReadInboxMessageId();
-        case ChatData::RoleLastMessageSenderId: return data->senderUserId();
-        case ChatData::RoleLastMessageText: return data->senderMessageText();
-        case ChatData::RoleLastMessageDate: return data->senderMessageDate();
-        case ChatData::RoleLastMessageStatus: return data->senderMessageStatus();
-        case ChatData::RoleChatMemberStatus: return data->memberStatus;
-        case ChatData::RoleSecretChatState: return data->secretChatState;
-        case ChatData::RoleIsVerified: return data->verified;
-        case ChatData::RoleIsChannel: return data->isChannel();
+        switch ((ChatListModel::Role)role) {
+        case ChatListModel::RoleDisplay: return data->chatData;
+        case ChatListModel::RoleChatId: return data->chatId;
+        case ChatListModel::RoleChatType: return data->chatType;
+        case ChatListModel::RoleTitle: return data->title();
+        case ChatListModel::RolePhotoSmall: return data->photoSmall();
+        case ChatListModel::RoleUnreadCount: return data->unreadCount();
+        case ChatListModel::RoleLastReadInboxMessageId: return data->lastReadInboxMessageId();
+        case ChatListModel::RoleLastMessageSenderId: return data->senderUserId();
+        case ChatListModel::RoleLastMessageText: return data->senderMessageText();
+        case ChatListModel::RoleLastMessageDate: return data->senderMessageDate();
+        case ChatListModel::RoleLastMessageStatus: return data->senderMessageStatus();
+        case ChatListModel::RoleChatMemberStatus: return data->memberStatus;
+        case ChatListModel::RoleSecretChatState: return data->secretChatState;
+        case ChatListModel::RoleIsVerified: return data->verified;
+        case ChatListModel::RoleIsChannel: return data->isChannel();
+        case ChatListModel::RoleFilter: return QString(data->title() + " " + data->senderMessageText()).trimmed();
         }
     }
     return QVariant();
@@ -677,12 +662,12 @@ void ChatListModel::handleChatReadInboxUpdated(const QString &id, const QString 
             const int chatIndex = chatIndexMap.value(chatId);
             ChatData *chat = chatList.at(chatIndex);
             QVector<int> changedRoles;
-            changedRoles.append(ChatData::RoleDisplay);
+            changedRoles.append(ChatListModel::RoleDisplay);
             if (chat->updateUnreadCount(unreadCount)) {
-                changedRoles.append(ChatData::RoleUnreadCount);
+                changedRoles.append(ChatListModel::RoleUnreadCount);
             }
             if (chat->updateLastReadInboxMessageId(messageId)) {
-                changedRoles.append(ChatData::RoleLastReadInboxMessageId);
+                changedRoles.append(ChatListModel::RoleLastReadInboxMessageId);
             }
             const QModelIndex modelIndex(index(chatIndex));
             emit dataChanged(modelIndex, modelIndex, changedRoles);
@@ -726,7 +711,7 @@ void ChatListModel::handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &
         ChatData *chat = chatList.at(chatIndex);
         chat->chatData.insert(PHOTO, photo);
         QVector<int> changedRoles;
-        changedRoles.append(ChatData::RolePhotoSmall);
+        changedRoles.append(ChatListModel::RolePhotoSmall);
         const QModelIndex modelIndex(index(chatIndex));
         emit dataChanged(modelIndex, modelIndex, changedRoles);
     } else {
@@ -815,7 +800,7 @@ void ChatListModel::handleChatTitleUpdated(const QString &chatId, const QString 
         ChatData *chat = chatList.at(chatIndex);
         chat->chatData.insert(TITLE, title);
         QVector<int> changedRoles;
-        changedRoles.append(ChatData::RoleTitle);
+        changedRoles.append(ChatListModel::RoleTitle);
         const QModelIndex modelIndex(index(chatIndex));
         emit dataChanged(modelIndex, modelIndex, changedRoles);
     } else {
@@ -831,6 +816,6 @@ void ChatListModel::handleRelativeTimeRefreshTimer()
 {
     LOG("Refreshing timestamps");
     QVector<int> roles;
-    roles.append(ChatData::RoleLastMessageDate);
+    roles.append(ChatListModel::RoleLastMessageDate);
     emit dataChanged(index(0), index(chatList.size() - 1), roles);
 }

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -29,6 +29,26 @@ class ChatListModel : public QAbstractListModel
     Q_PROPERTY(bool showAllChats READ showAllChats WRITE setShowAllChats NOTIFY showAllChatsChanged)
 
 public:
+
+    enum Role {
+        RoleDisplay = Qt::DisplayRole,
+        RoleChatId,
+        RoleChatType,
+        RoleTitle,
+        RolePhotoSmall,
+        RoleUnreadCount,
+        RoleLastReadInboxMessageId,
+        RoleLastMessageSenderId,
+        RoleLastMessageDate,
+        RoleLastMessageText,
+        RoleLastMessageStatus,
+        RoleChatMemberStatus,
+        RoleSecretChatState,
+        RoleIsVerified,
+        RoleIsChannel,
+        RoleFilter
+    };
+
     ChatListModel(TDLibWrapper *tdLibWrapper);
     ~ChatListModel() override;
 

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -353,7 +353,7 @@ void ChatModel::handleNewMessageReceived(qlonglong chatId, const QVariantMap &me
 {
     const qlonglong messageId = message.value(ID).toLongLong();
     if (chatId == this->chatId && !messageIndexMap.contains(messageId)) {
-        if (this->isMostRecentMessageLoaded()) {
+        if (this->isMostRecentMessageLoaded() && !this->searchModeActive) {
             LOG("New message received for this chat");
             QList<MessageData*> messagesToBeAdded;
             messagesToBeAdded.append(new MessageData(message, messageId));

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -37,13 +37,14 @@ public:
     virtual int rowCount(const QModelIndex&) const override;
     virtual QVariant data(const QModelIndex &index, int role) const override;
 
-    Q_INVOKABLE void clear();
+    Q_INVOKABLE void clear(bool contentOnly = false);
     Q_INVOKABLE void initialize(const QVariantMap &chatInformation);
     Q_INVOKABLE void triggerLoadMoreHistory();
     Q_INVOKABLE void triggerLoadMoreFuture();
     Q_INVOKABLE QVariantMap getChatInformation();
     Q_INVOKABLE QVariantMap getMessage(int index);
     Q_INVOKABLE int getLastReadMessageIndex();
+    Q_INVOKABLE void setSearchQuery(const QString newSearchQuery);
 
     QVariantMap smallPhoto() const;
     qlonglong getChatId() const;
@@ -92,6 +93,8 @@ private:
     qlonglong chatId;
     bool inReload;
     bool inIncrementalUpdate;
+    bool searchModeActive;
+    QString searchQuery;
 };
 
 #endif // CHATMODEL_H

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -88,6 +88,11 @@ int main(int argc, char *argv[])
 
     ChatListModel chatListModel(tdLibWrapper);
     context->setContextProperty("chatListModel", &chatListModel);
+    QSortFilterProxyModel chatListProxyModel(view.data());
+    chatListProxyModel.setSourceModel(&chatListModel);
+    chatListProxyModel.setFilterRole(ChatListModel::RoleFilter);
+    chatListProxyModel.setFilterCaseSensitivity(Qt::CaseInsensitive);
+    context->setContextProperty("chatListProxyModel", &chatListProxyModel);
 
     ChatModel chatModel(tdLibWrapper);
     context->setContextProperty("chatModel", &chatModel);

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -74,7 +74,7 @@ signals:
     void stickerSet(const QVariantMap &stickerSet);
     void chatMembers(const QString &extra, const QVariantList &members, int totalMembers);
     void userFullInfo(const QVariantMap &userFullInfo);
-    void userFullInfoUpdated(const QString &userId,const QVariantMap &userFullInfo);
+    void userFullInfoUpdated(const QString &userId, const QVariantMap &userFullInfo);
     void basicGroupFullInfo(const QString &groupId, const QVariantMap &groupFullInfo);
     void basicGroupFullInfoUpdated(const QString &groupId, const QVariantMap &groupFullInfo);
     void supergroupFullInfo(const QString &groupId, const QVariantMap &groupFullInfo);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -925,6 +925,20 @@ void TDLibWrapper::importContacts(const QVariantList &contacts)
     this->sendRequest(requestObject);
 }
 
+void TDLibWrapper::searchChatMessages(const qlonglong &chatId, const QString &query, const qlonglong fromMessageId)
+{
+    LOG("Searching for messages" << chatId << query);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "searchChatMessages");
+    requestObject.insert("chat_id", chatId);
+    requestObject.insert("query", query);
+    requestObject.insert("from_message_id", fromMessageId);
+    requestObject.insert("offset", 0);
+    requestObject.insert("limit", 100);
+    requestObject.insert(_EXTRA, "searchChatMessages");
+    this->sendRequest(requestObject);
+}
+
 void TDLibWrapper::searchEmoji(const QString &queryString)
 {
     LOG("Searching emoji" << queryString);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -958,6 +958,7 @@ void TDLibWrapper::searchPublicChats(const QString &query)
     requestObject.insert(_TYPE, "searchPublicChats");
     requestObject.insert("query", query);
     requestObject.insert(_EXTRA, "searchPublicChats");
+    this->sendRequest(requestObject);
 }
 
 void TDLibWrapper::readAllChatMentions(qlonglong chatId)

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -951,6 +951,16 @@ void TDLibWrapper::searchChatMessages(const qlonglong &chatId, const QString &qu
     this->sendRequest(requestObject);
 }
 
+void TDLibWrapper::searchPublicChats(const QString &query)
+{
+    LOG("Searching public chats" << query);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "searchPublicChats");
+    requestObject.insert("query", query);
+    requestObject.insert(_EXTRA, "searchPublicChats");
+    this->sendRequest(requestObject);
+}
+
 void TDLibWrapper::searchEmoji(const QString &queryString)
 {
     LOG("Searching emoji" << queryString);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -939,14 +939,14 @@ void TDLibWrapper::importContacts(const QVariantList &contacts)
 
 void TDLibWrapper::searchChatMessages(const qlonglong &chatId, const QString &query, const qlonglong fromMessageId)
 {
-    LOG("Searching for messages" << chatId << query);
+    LOG("Searching for messages" << chatId << query << fromMessageId);
     QVariantMap requestObject;
     requestObject.insert(_TYPE, "searchChatMessages");
     requestObject.insert("chat_id", chatId);
     requestObject.insert("query", query);
     requestObject.insert("from_message_id", fromMessageId);
     requestObject.insert("offset", 0);
-    requestObject.insert("limit", 100);
+    requestObject.insert("limit", 50);
     requestObject.insert(_EXTRA, "searchChatMessages");
     this->sendRequest(requestObject);
 }

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -178,6 +178,7 @@ public:
     Q_INVOKABLE void getSecretChat(qlonglong secretChatId);
     Q_INVOKABLE void closeSecretChat(qlonglong secretChatId);
     Q_INVOKABLE void importContacts(const QVariantList &contacts);
+    Q_INVOKABLE void searchChatMessages(const qlonglong &chatId, const QString &query, const qlonglong fromMessageId = 0);
 
     // Others (candidates for extraction ;))
     Q_INVOKABLE void searchEmoji(const QString &queryString);

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -180,6 +180,7 @@ public:
     Q_INVOKABLE void closeSecretChat(qlonglong secretChatId);
     Q_INVOKABLE void importContacts(const QVariantList &contacts);
     Q_INVOKABLE void searchChatMessages(const qlonglong &chatId, const QString &query, const qlonglong fromMessageId = 0);
+    Q_INVOKABLE void searchPublicChats(const QString &query);
 
     // Others (candidates for extraction ;))
     Q_INVOKABLE void searchEmoji(const QString &queryString);

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -1026,6 +1026,10 @@
         <source>New Chat</source>
         <translation>Neuer Chat</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation>Einen Chat suchen...</translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -1038,6 +1038,10 @@
         <source>Filter your chats...</source>
         <translation>Ihre Chats filtern...</translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation>Chats suchen</translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1230,6 +1234,49 @@
             <numerusform>%Ln Antwort inklusive Ihrer</numerusform>
             <numerusform>%Ln Antworten inklusive Ihrer</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation>Keine Chats gefunden.</translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation>Suche Chats...</translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation>Privater Chat</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Gruppe</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation>Kanal</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 Mitglied</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 Abonnent</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation>Chats suchen</translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation>Einen Chat suchen...</translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation>Geben Sie Ihre Anfrage ein, um die Suche zu starten (mindestens 5 Zeichen benötigt)</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -391,6 +391,14 @@
         <source>Close Chat</source>
         <translation>Chat schließen</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation>Im Chat suchen</translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation>Im Chat suchen...</translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1027,8 +1035,8 @@
         <translation>Neuer Chat</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
-        <translation>Einen Chat suchen...</translation>
+        <source>Filter your chats...</source>
+        <translation>Ihre Chats filtern...</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -1038,6 +1038,10 @@
         <source>Filter your chats...</source>
         <translation>Filter your chats...</translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation>Search Chats</translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1230,6 +1234,49 @@
             <numerusform>%Ln vote including yours</numerusform>
             <numerusform>%Ln votes including yours</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation>No chats found.</translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation>Searching chats...</translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation>Private Chat</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation>Group</translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation>Channel</translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 member</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 subscriber</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation>Search Chats</translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation>Search a chat...</translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation>Enter your query to start searching (at least 5 characters needed)</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -1026,6 +1026,10 @@
         <source>New Chat</source>
         <translation>New Chat</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -391,6 +391,14 @@
         <source>Close Chat</source>
         <translation>Close Chat</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation>Search in Chat</translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation>Search in chat...</translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1027,8 +1035,8 @@
         <translation>New Chat</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
-        <translation type="unfinished"></translation>
+        <source>Filter your chats...</source>
+        <translation>Filter your chats...</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -1015,6 +1015,10 @@
         <source>New Chat</source>
         <translation>Nueva charla</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -381,6 +381,14 @@
         <source>Close Chat</source>
         <translation>Cerrar charla</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1016,7 +1024,7 @@
         <translation>Nueva charla</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -1027,6 +1027,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1211,6 +1215,49 @@
         <translation>
             <numerusform>%Ln votos incluyendo el suyo</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished">Privado</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 miembros</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 suscriptores</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -391,6 +391,14 @@
         <source>Close Chat</source>
         <translation>Sulje keskustelu</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1028,7 +1036,7 @@
         <translation>Uusi keskustelu</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -1027,6 +1027,10 @@
         <source>New Chat</source>
         <translation>Uusi keskustelu</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -1039,6 +1039,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1231,6 +1235,49 @@
             <numerusform>%Ln ääni (sinun)</numerusform>
             <numerusform>%Ln ääntä (mukaan lukien sinun)</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished">Yksityinen keskustelu</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 jäsen</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 tilaaja</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -381,6 +381,14 @@
         <source>Close Chat</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1016,7 +1024,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -1027,6 +1027,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1211,6 +1215,49 @@
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 tag</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 feliratkozott</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -1015,6 +1015,10 @@
         <source>New Chat</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -391,6 +391,14 @@
         <source>Close Chat</source>
         <translation>Chiudi chat</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1027,7 +1035,7 @@
         <translation>Nuova chat</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -1038,6 +1038,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1230,6 +1234,49 @@
             <numerusform>%Ln voto incluso il tuo</numerusform>
             <numerusform>%Ln voti incluso il tuo</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished">Chat privata</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 membro</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 abbonato</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -1026,6 +1026,10 @@
         <source>New Chat</source>
         <translation>Nuova chat</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -1049,6 +1049,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1249,6 +1253,49 @@
             <numerusform>%Ln głosy, w tym twój</numerusform>
             <numerusform>%Ln głosów, w tym twój</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished">Prywatny czat</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 członek</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 subskrybent</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -1037,6 +1037,10 @@
         <source>New Chat</source>
         <translation>Nowy czat</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -401,6 +401,14 @@
         <source>Close Chat</source>
         <translation>Zamknij czat</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1038,7 +1046,7 @@
         <translation>Nowy czat</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -1037,6 +1037,10 @@
         <source>New Chat</source>
         <translation>Новый Чат</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -1049,6 +1049,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1249,6 +1253,49 @@
             <numerusform></numerusform>
             <numerusform></numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished">Приватный Чат</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 участников</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 подписчиков</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -401,6 +401,14 @@
         <source>Close Chat</source>
         <translation>Закрыть чат</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1038,7 +1046,7 @@
         <translation>Новый Чат</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -1038,6 +1038,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1230,6 +1234,49 @@
         <source>Chosen by:</source>
         <comment>This answer has been chosen by the following users</comment>
         <translation>Valt av:</translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished">Privat chatt</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 medlem</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 prenumerant</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -391,6 +391,14 @@
         <source>Close Chat</source>
         <translation>Stäng chatten</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1027,7 +1035,7 @@
         <translation>Ny chatt</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -1026,6 +1026,10 @@
         <source>New Chat</source>
         <translation>Ny chatt</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -381,6 +381,14 @@
         <source>Close Chat</source>
         <translation>关闭对话</translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1016,7 +1024,7 @@
         <translation>新对话</translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -1015,6 +1015,10 @@
         <source>New Chat</source>
         <translation>新对话</translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -1027,6 +1027,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1211,6 +1215,49 @@
         <translation>
             <numerusform>%Ln 次投票，包括你</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished">个人对话</translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 位成员</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 位订阅者</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -1026,6 +1026,10 @@
         <source>New Chat</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -1038,6 +1038,10 @@
         <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>PinnedMessageItem</name>
@@ -1230,6 +1234,49 @@
             <numerusform>%Ln vote including yours</numerusform>
             <numerusform>%Ln votes including yours</numerusform>
         </translation>
+    </message>
+</context>
+<context>
+    <name>SearchChatsPage</name>
+    <message>
+        <source>No chats found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Searching chats...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Private Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Channel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>%1 members</source>
+        <translation type="unfinished">%1 member</translation>
+    </message>
+    <message>
+        <source>%1 subscribers</source>
+        <translation type="unfinished">%1 subscriber</translation>
+    </message>
+    <message>
+        <source>Search Chats</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search a chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Enter your query to start searching (at least 5 characters needed)</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -391,6 +391,14 @@
         <source>Close Chat</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Search in Chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Search in chat...</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1027,7 +1035,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Search a chat...</source>
+        <source>Filter your chats...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
These changes will fix #9. With this we will get:
- Filter capabilities for the chat list (use the magnifying glass next to the 'Fernschreiber' title
- Search messages in a chat (use the new pulley menu entry on chat page)
- Search public chats (use the new pulley menu entry on chat list page)

While implementing the features, I came across a few bugs which I fixed with this PR as well (I wanted to implement them directly on master, but I mixed up the branches...):
- Fernschreiber crashed when message deletion updates were received (there was an error in handling deletion ranges)
- Audio files didn't show album cover thumbnails properly (this is a leftover from the TDLib 1.7 migration)