### PR TITLE
Implements Remove send new message button when "Send message by enter" is chosen

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1411,7 +1411,7 @@ Page {
 
                     TextArea {
                         id: newMessageTextField
-                        width: parent.width - attachmentIconButton.width - newMessageSendButton.width
+                        width: parent.width - attachmentIconButton.width - (appSettings.sendByEnter ? 0: newMessageSendButton.width)
                         height: Math.min(chatContainer.height / 3, implicitHeight)
                         anchors.verticalCenter: parent.verticalCenter
                         font.pixelSize: Theme.fontSizeSmall
@@ -1457,6 +1457,7 @@ Page {
                         icon.source: "image://theme/icon-m-chat"
                         anchors.bottom: parent.bottom
                         anchors.bottomMargin: Theme.paddingSmall
+                        visible: !appSettings.sendByEnter
                         enabled: false
                         onClicked: {
                             sendMessage();


### PR DESCRIPTION
[Implements 143](https://github.com/Wunderfitz/harbour-fernschreiber/issues/143). Send Message Icon button will now be hidden by default if "Send message by Enter" option is activated.