### PR TITLE
implement message drafts

### DIFF
--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -11,15 +11,17 @@ PhotoTextsListItem {
         photoData: photo_small || ({})
     }
     property int ownUserId
+    property bool showDraft: !!draft_message_text && draft_message_date > last_message_date
+    property string previewText: showDraft ? draft_message_text : last_message_text
 
     // chat title
     primaryText.text: title ? Emoji.emojify(title + ( display.notification_settings.mute_for > 0 ? " 🔇" : "" ), Theme.fontSizeMedium) : qsTr("Unknown")
     // last user
-    prologSecondaryText.text: is_channel ? "" : ( last_message_sender_id ? ( last_message_sender_id !== ownUserId ? Emoji.emojify(Functions.getUserName(tdLibWrapper.getUserInformation(last_message_sender_id)), primaryText.font.pixelSize) : qsTr("You") ) : "" )
+    prologSecondaryText.text: showDraft ? "<i>"+qsTr("Draft")+"</i>" : (is_channel ? "" : ( last_message_sender_id ? ( last_message_sender_id !== ownUserId ? Emoji.emojify(Functions.getUserName(tdLibWrapper.getUserInformation(last_message_sender_id)), primaryText.font.pixelSize) : qsTr("You") ) : "" ))
     // last message
-    secondaryText.text: last_message_text ? Emoji.emojify(Functions.enhanceHtmlEntities(last_message_text), Theme.fontSizeExtraSmall) : "<i>" + qsTr("No message in this chat.") + "</i>"
+    secondaryText.text: previewText ? Emoji.emojify(Functions.enhanceHtmlEntities(previewText), Theme.fontSizeExtraSmall) : "<i>" + qsTr("No message in this chat.") + "</i>"
     // message date
-    tertiaryText.text: ( last_message_date ? ( last_message_date.length === 0 ? "" : Functions.getDateTimeElapsed(last_message_date) + Emoji.emojify(last_message_status, tertiaryText.font.pixelSize) ) : "" )
+    tertiaryText.text: showDraft ? Functions.getDateTimeElapsed(draft_message_date) : ( last_message_date ? ( last_message_date.length === 0 ? "" : Functions.getDateTimeElapsed(last_message_date) + Emoji.emojify(last_message_status, tertiaryText.font.pixelSize) ) : "" )
     unreadCount: unread_count
     isSecret: ( chat_type === TelegramAPI.ChatTypeSecret )
     isMarkedAsUnread: is_marked_as_unread

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -373,6 +373,7 @@ Page {
     }
 
     Component.onDestruction: {
+        tdLibWrapper.setChatDraftMessage(chatInformation.id, 0, newMessageColumn.replyToMessageId, newMessageTextField.text);
         tdLibWrapper.closeChat(chatInformation.id);
     }
 
@@ -387,6 +388,15 @@ Page {
 
                 pageStack.pushAttached(Qt.resolvedUrl("ChatInformationPage.qml"), { "chatInformation" : chatInformation, "privateChatUserInformation": chatPartnerInformation, "groupInformation": chatGroupInformation, "chatOnlineMemberCount": chatOnlineMemberCount});
                 chatPage.isInitialized = true;
+
+                if(chatInformation.draft_message) {
+                    if(chatInformation.draft_message && chatInformation.draft_message.input_message_text) {
+                        newMessageTextField.text = chatInformation.draft_message.input_message_text.text.text;
+                        if(chatInformation.draft_message.reply_to_message_id) {
+                            tdLibWrapper.getMessage(chatInformation.id, chatInformation.draft_message.reply_to_message_id);
+                        }
+                    }
+                }
             }
             break;
         case PageStatus.Inactive:
@@ -442,6 +452,9 @@ Page {
             if (message.is_pinned) {
                 Debug.log("[ChatPage] Received pinned message");
                 pinnedMessageItem.pinnedMessage = message;
+            }
+            if (messageId === chatInformation.draft_message.reply_to_message_id) {
+                newMessageInReplyToRow.inReplyToMessage = message;
             }
         }
         onSecretChatReceived: {

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -47,7 +47,9 @@ public:
         RoleIsVerified,
         RoleIsChannel,
         RoleIsMarkedAsUnread,
-        RoleFilter
+        RoleFilter,
+        RoleDraftMessageText,
+        RoleDraftMessageDate
     };
 
     ChatListModel(TDLibWrapper *tdLibWrapper);
@@ -78,6 +80,7 @@ private slots:
     void handleSecretChatUpdated(qlonglong secretChatId, const QVariantMap &secretChat);
     void handleChatTitleUpdated(const QString &chatId, const QString &title);
     void handleChatIsMarkedAsUnreadUpdated(qlonglong chatId, bool chatIsMarkedAsUnread);
+    void handleChatDraftMessageUpdated(qlonglong chatId, const QVariantMap &draftMessage, const QString &order);
     void handleRelativeTimeRefreshTimer();
 
 signals:

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -43,6 +43,7 @@ namespace {
     const QString LAST_MESSAGE("last_message");
     const QString TOTAL_COUNT("total_count");
     const QString UNREAD_COUNT("unread_count");
+    const QString TEXT("text");
     const QString LAST_READ_INBOX_MESSAGE_ID("last_read_inbox_message_id");
     const QString LAST_READ_OUTBOX_MESSAGE_ID("last_read_outbox_message_id");
     const QString SECRET_CHAT("secret_chat");
@@ -134,6 +135,7 @@ TDLibReceiver::TDLibReceiver(void *tdLibClient, QObject *parent) : QThread(paren
     handlers.insert("importedContacts", &TDLibReceiver::processImportedContacts);
     handlers.insert("updateMessageEdited", &TDLibReceiver::processUpdateMessageEdited);
     handlers.insert("updateChatIsMarkedAsUnread", &TDLibReceiver::processUpdateChatIsMarkedAsUnread);
+    handlers.insert("updateChatDraftMessage", &TDLibReceiver::processUpdateChatDraftMessage);
 }
 
 void TDLibReceiver::setActive(bool active)
@@ -575,4 +577,10 @@ void TDLibReceiver::processUpdateChatIsMarkedAsUnread(const QVariantMap &receive
 {
     LOG("The unread state of a chat was updated");
     emit chatIsMarkedAsUnreadUpdated(receivedInformation.value(CHAT_ID).toLongLong(), receivedInformation.value("is_marked_as_unread").toBool());
+}
+
+void TDLibReceiver::processUpdateChatDraftMessage(const QVariantMap &receivedInformation)
+{
+    LOG("Draft message was updated");
+    emit chatDraftMessageUpdated(receivedInformation.value(CHAT_ID).toLongLong(), receivedInformation.value("draft_message").toMap(), findChatPositionOrder(receivedInformation.value(POSITIONS).toList()));
 }

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -91,6 +91,7 @@ signals:
     void secretChatUpdated(qlonglong secretChatId, const QVariantMap &secretChat);
     void contactsImported(const QVariantList &importerCount, const QVariantList &userIds);
     void chatIsMarkedAsUnreadUpdated(qlonglong chatId, bool chatIsMarkedAsUnread);
+    void chatDraftMessageUpdated(qlonglong chatId, const QVariantMap &draftMessage, const QString &order);
 
 private:
     typedef void (TDLibReceiver::*Handler)(const QVariantMap &);
@@ -157,6 +158,7 @@ private:
     void processUpdateMessageEdited(const QVariantMap &receivedInformation);
     void processImportedContacts(const QVariantMap &receivedInformation);
     void processUpdateChatIsMarkedAsUnread(const QVariantMap &receivedInformation);
+    void processUpdateChatDraftMessage(const QVariantMap &receivedInformation);
 };
 
 #endif // TDLIBRECEIVER_H

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -45,6 +45,7 @@ namespace {
     const QString LAST_NAME("last_name");
     const QString FIRST_NAME("first_name");
     const QString USERNAME("username");
+    const QString THREAD_ID("thread_id");
     const QString VALUE("value");
     const QString _TYPE("@type");
     const QString _EXTRA("@extra");
@@ -126,6 +127,7 @@ TDLibWrapper::TDLibWrapper(AppSettings *appSettings, MceInterface *mceInterface,
     connect(this->tdLibReceiver, SIGNAL(contactsImported(QVariantList, QVariantList)), this, SIGNAL(contactsImported(QVariantList, QVariantList)));
     connect(this->tdLibReceiver, SIGNAL(messageEditedUpdated(qlonglong, qlonglong, QVariantMap)), this, SIGNAL(messageEditedUpdated(qlonglong, qlonglong, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(chatIsMarkedAsUnreadUpdated(qlonglong, bool)), this, SIGNAL(chatIsMarkedAsUnreadUpdated(qlonglong, bool)));
+    connect(this->tdLibReceiver, SIGNAL(chatDraftMessageUpdated(qlonglong, QVariantMap, QString)), this, SIGNAL(chatDraftMessageUpdated(qlonglong, QVariantMap, QString)));
 
     connect(&emojiSearchWorker, SIGNAL(searchCompleted(QString, QVariantList)), this, SLOT(handleEmojiSearchCompleted(QString, QVariantList)));
 
@@ -979,6 +981,30 @@ void TDLibWrapper::toggleChatIsMarkedAsUnread(qlonglong chatId, bool isMarkedAsU
     requestObject.insert(_TYPE, "toggleChatIsMarkedAsUnread");
     requestObject.insert(CHAT_ID, chatId);
     requestObject.insert("is_marked_as_unread", isMarkedAsUnread);
+    this->sendRequest(requestObject);
+}
+
+void TDLibWrapper::setChatDraftMessage(qlonglong chatId, qlonglong threadId, qlonglong replyToMessageId, const QString &draft)
+{
+    LOG("Set Draft Message" << chatId);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "setChatDraftMessage");
+    requestObject.insert(CHAT_ID, chatId);
+    requestObject.insert(THREAD_ID, threadId);
+    QVariantMap draftMessage;
+    QVariantMap inputMessageContent;
+    QVariantMap formattedText;
+
+    formattedText.insert("text", draft);
+    formattedText.insert("clear_draft", draft.isEmpty());
+    formattedText.insert(_TYPE, "formattedText");
+    inputMessageContent.insert(_TYPE, "inputMessageText");
+    inputMessageContent.insert("text", formattedText);
+    draftMessage.insert(_TYPE, "draftMessage");
+    draftMessage.insert("reply_to_message_id", replyToMessageId);
+    draftMessage.insert("input_message_text", inputMessageContent);
+
+    requestObject.insert("draft_message", draftMessage);
     this->sendRequest(requestObject);
 }
 

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -183,6 +183,7 @@ public:
     Q_INVOKABLE void searchPublicChats(const QString &query);
     Q_INVOKABLE void readAllChatMentions(qlonglong chatId);
     Q_INVOKABLE void toggleChatIsMarkedAsUnread(qlonglong chatId, bool isMarkedAsUnread);
+    Q_INVOKABLE void setChatDraftMessage(qlonglong chatId, qlonglong threadId, qlonglong replyToMessageId, const QString &draft);
 
     // Others (candidates for extraction ;))
     Q_INVOKABLE void searchEmoji(const QString &queryString);
@@ -253,6 +254,7 @@ signals:
     void contactsImported(const QVariantList &importerCount, const QVariantList &userIds);
     void messageNotFound(qlonglong chatId, qlonglong messageId);
     void chatIsMarkedAsUnreadUpdated(qlonglong chatId, bool chatIsMarkedAsUnread);
+    void chatDraftMessageUpdated(qlonglong chatId, const QVariantMap &draftMessage, const QString &order);
 
 public slots:
     void handleVersionDetected(const QString &version);

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -272,6 +272,10 @@
         <source>Mark chat as read</source>
         <translation>Chat als gelesen markieren</translation>
     </message>
+    <message>
+        <source>Draft</source>
+        <translation>Entwurf</translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -272,6 +272,10 @@
         <source>Mark chat as read</source>
         <translation>Mark chat as read</translation>
     </message>
+    <message>
+        <source>Draft</source>
+        <translation>Draft</translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -266,6 +266,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -269,6 +269,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -266,6 +266,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -269,6 +269,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -272,6 +272,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -272,6 +272,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -269,6 +269,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -266,6 +266,10 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -272,6 +272,10 @@
         <source>Mark chat as read</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Draft</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatPage</name>


### PR DESCRIPTION
- Drafts are only saved (or removed) when the ChatPage is destroyed.
- When the draft is a reply, that is also saved.
- The chat order gets updated when a draft is changed.
- The draft message gets displayed on the OverviewPage and gets prefilled on the ChatPage.
- Note: The implementation does not actually create a real formatted text including entities, it just shoves the current text "in there".

I've had some issues with the ChatListModel not updating sometimes, but with doing the order update last, this seems to work.
Quite possibly I did some (c++) part horribly wrong and/or ineffective, so please do judge me – I'd love to understand more. ;)


cheers!