### PR TITLE
Apply opacity to picture and badge as a group

### DIFF
--- a/qml/components/PhotoTextsListItem.qml
+++ b/qml/components/PhotoTextsListItem.qml
@@ -33,15 +33,14 @@ ListItem {
             height: contentColumn.height
             spacing: Theme.paddingMedium
 
-            Column {
-                id: pictureColumn
+            ShaderEffectSource {
+                id: pictureItem
                 width: contentColumn.height - Theme.paddingSmall
                 height: contentColumn.height - Theme.paddingSmall
                 anchors.verticalCenter: parent.verticalCenter
-
-                Item {
-                    width: parent.width
-                    height: parent.width
+                sourceItem:  Item {
+                    width: pictureItem.width
+                    height: pictureItem.width
 
                     ProfileThumbnail {
                         id: pictureThumbnail
@@ -93,7 +92,7 @@ ListItem {
 
             Column {
                 id: contentColumn
-                width: mainColumn.width - pictureColumn.width - mainRow.spacing
+                width: mainColumn.width - pictureItem.width - mainRow.spacing
                 spacing: Theme.paddingSmall
 
                 Row {


### PR DESCRIPTION
It matters when page is being dimmed. Before:

![before](https://user-images.githubusercontent.com/5909522/103416188-3fa2b880-4b8e-11eb-9222-a500df1c1a61.png)

and after this change:

![after](https://user-images.githubusercontent.com/5909522/103416194-47faf380-4b8e-11eb-906e-006c0974961d.png)

Better?