### PR TITLE
'Fernschreiber' is not localizable

### DIFF
--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -124,7 +124,7 @@ Page {
             break;
         case TelegramAPI.ConnectionReady:
             pageStatus.color = "green";
-            pageHeader.title = qsTr("Fernschreiber");
+            pageHeader.title = Fernschreiber;
             break;
         case TelegramAPI.Updating:
             pageStatus.color = "lightblue";

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -260,7 +260,7 @@ Page {
 
         PageHeader {
             id: pageHeader
-            title: qsTr("Fernschreiber")
+            title: Fernschreiber
             leftMargin: Theme.itemSizeMedium
             visible: opacity > 0
             Behavior on opacity { FadeAnimation {} }


### PR DESCRIPTION
Fixed conflict with name.desktop
I really do not know what to do with apps with generic name.  For me these applications with generic names need to be translated as core-applications, but I don't know what the original author's wishes are.