### PR TITLE
Initialize ChatModel::searchModeActive

### DIFF
--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -105,7 +105,8 @@ bool ChatModel::MessageData::lessThan(const MessageData *message1, const Message
 ChatModel::ChatModel(TDLibWrapper *tdLibWrapper) :
     chatId(0),
     inReload(false),
-    inIncrementalUpdate(false)
+    inIncrementalUpdate(false),
+    searchModeActive(false)
 {
     this->tdLibWrapper = tdLibWrapper;
     connect(this->tdLibWrapper, SIGNAL(messagesReceived(QVariantList, int)), this, SLOT(handleMessagesReceived(QVariantList, int)));


### PR DESCRIPTION
```
==7097== Conditional jump or move depends on uninitialised value(s)
==7097==    at 0x12BBAA: ChatModel::handleMessagesReceived(QList<QVariant> const&, int) (chatmodel.cpp:325)
==7097==    by 0x19035F: ChatModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_chatmodel.cpp:235)
==7097==    by 0x55E3257: QMetaObject::activate(QObject*, int, int, void**) (qobject.cpp:3730)
==7097==    by 0x19B013: messagesReceived (moc_tdlibwrapper.cpp:1764)
==7097==    by 0x19B013: TDLibWrapper::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_tdlibwrapper.cpp:983)
==7097==    by 0x55E371B: QObject::event(QEvent*) (qobject.cpp:1256)
==7097==    by 0x55C6C43: doNotify (qcoreapplication.cpp:1090)
==7097==    by 0x55C6C43: QCoreApplication::notify(QObject*, QEvent*) (qcoreapplication.cpp:1076)
==7097==    by 0x55C6D51: QCoreApplication::notifyInternal2(QObject*, QEvent*) (qcoreapplication.cpp:1015)
==7097==    by 0x55C8659: sendEvent (qcoreapplication.h:225)
==7097==    by 0x55C8659: QCoreApplicationPrivate::sendPostedEvents(QObject*, int, QThreadData*) (qcoreapplication.cpp:1650)
==7097==    by 0x55FF6BB: postEventSourceDispatch(_GSource*, int (*)(void*), void*) (qeventdispatcher_glib.cpp:275)
==7097==    by 0x6AC1A57: g_main_dispatch (gmain.c:3325)
==7097==    by 0x6AC1A57: g_main_context_dispatch (gmain.c:4016)
==7097==    by 0x6AC1BEF: g_main_context_iterate.isra.23 (gmain.c:4092)
==7097==    by 0x6AC1C47: g_main_context_iteration (gmain.c:4157)
==7097== 
==7097== Warning: invalid file descriptor -1 in syscall close()
==7097== Warning: invalid file descriptor -1 in syscall close()
==7097== Conditional jump or move depends on uninitialised value(s)
==7097==    at 0x128550: ChatModel::triggerLoadMoreFuture() (chatmodel.cpp:220)
==7097==    by 0x190263: ChatModel::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) (moc_chatmodel.cpp:251)
==7097==    by 0x1905DF: ChatModel::qt_metacall(QMetaObject::Call, int, void**) (moc_chatmodel.cpp:392)
==7097==    by 0x53053D5: QQmlObjectOrGadget::metacall(QMetaObject::Call, int, void**) const (qqmlpropertycache.cpp:1571)
==7097==    by 0x52AF84F: CallMethod(QQmlObjectOrGadget const&, int, int, int, int*, QV4::ExecutionEngine*, QV4::CallData*) (qv4qobjectwrapper.cpp:1156)
==7097==    by 0x52B0A4B: CallPrecise(QQmlObjectOrGadget const&, QQmlPropertyData const&, QV4::ExecutionEngine*, QV4::CallData*) (qv4qobjectwrapper.cpp:1393)
==7097==    by 0x52B0FB5: QV4::QObjectMethod::callInternal(QV4::CallData*) const (qv4qobjectwrapper.cpp:1871)
==7097==    by 0x52C1993: call (qv4object_p.h:334)
==7097==    by 0x52C1993: QV4::Runtime::callProperty(QV4::ExecutionEngine*, int, QV4::CallData*) (qv4runtime.cpp:998)
==7097==    by 0x13E58A69: ???
```