### PR TITLE
Update webPage photo id when message gets updated

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -27,6 +27,7 @@ ListItem {
     contentHeight: messageBackground.height + Theme.paddingMedium
     property var chatId
     property var messageId
+    property int messageIndex
     property var myMessage
     property bool canReplyToMessage
     readonly property bool isAnonymous: myMessage.sender["@type"] === "messageSenderChat"
@@ -159,13 +160,6 @@ ListItem {
             Debug.log("[ChatModel] Messages in this chat were read, new last read: ", lastReadSentIndex, ", updating description for index ", index, ", status: ", (index <= lastReadSentIndex));
             messageDateText.text = getMessageStatusText(myMessage, index, lastReadSentIndex, messageDateText.useElapsed);
         }
-        onMessageUpdated: {
-            if (index === modelIndex) {
-                Debug.log("[ChatModel] This message was updated, index ", index, ", updating content...");
-                messageDateText.text = getMessageStatusText(myMessage, index, chatView.lastReadSentIndex, messageDateText.useElapsed);
-                messageText.text = Emoji.emojify(Functions.getMessageText(myMessage, false, page.myUserId, false), messageText.font.pixelSize);
-            }
-        }
     }
 
     Connections {
@@ -187,6 +181,15 @@ ListItem {
 
         if (myMessage.reply_to_message_id !== 0) {
             tdLibWrapper.getMessage(page.chatInformation.id, myMessage.reply_to_message_id);
+        }
+    }
+
+    onMyMessageChanged: {
+        Debug.log("[ChatModel] This message was updated, index", messageIndex, ", updating content...")
+        messageDateText.text = getMessageStatusText(myMessage, messageIndex, chatView.lastReadSentIndex, messageDateText.useElapsed)
+        messageText.text = Emoji.emojify(Functions.getMessageText(myMessage, false, page.myUserId, false), messageText.font.pixelSize)
+        if (webPagePreviewLoader.item) {
+            webPagePreviewLoader.item.webPageData = myMessage.content.web_page
         }
     }
 

--- a/qml/components/WebPagePreview.qml
+++ b/qml/components/WebPagePreview.qml
@@ -33,7 +33,11 @@ Column {
 
     spacing: Theme.paddingSmall
 
-    Component.onCompleted: {
+    Component.onCompleted: updatePhoto()
+
+    onWebPageDataChanged: updatePhoto()
+
+    function updatePhoto() {
         if (webPageData) {
             if (webPageData.photo) {
                 // Check first which size fits best...
@@ -134,9 +138,10 @@ Column {
         }
 
         BackgroundImage {
+            id: backgroundImage
             visible: hasImage && singleImage.status !== Image.Ready
             layer.enabled: webPagePreviewColumn.highlighted
-            layer.effect: PressEffect { source: singleImage }
+            layer.effect: PressEffect { source: backgroundImage }
         }
     }
 

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1029,6 +1029,7 @@ Page {
                                 chatId: chatModel.chatId
                                 myMessage: model.display
                                 messageId: model.message_id
+                                messageIndex: model.index
                                 extraContentComponentName: chatView.contentComponentNames[model.content_type] || ""
                                 canReplyToMessage: chatPage.canSendMessages
                                 onReplyToMessage: {

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -54,8 +54,10 @@ public:
     MessageData(const QVariantMap &data, qlonglong msgid);
 
     static bool lessThan(const MessageData *message1, const MessageData *message2);
-    void setContent(const QVariantMap &content);
-    void setReplyMarkup(const QVariantMap &replyMarkup);
+    QVector<int> diff(const MessageData *message) const;
+    QVector<int> setMessageData(const QVariantMap &data);
+    QVector<int> setContent(const QVariantMap &content);
+    QVector<int> setReplyMarkup(const QVariantMap &replyMarkup);
     int senderUserId() const;
     qlonglong senderChatId() const;
     bool senderIsChat() const;
@@ -63,7 +65,7 @@ public:
 public:
     QVariantMap messageData;
     const qlonglong messageId;
-    const QString messageContentType;
+    QString messageContentType;
 };
 
 ChatModel::MessageData::MessageData(const QVariantMap &data, qlonglong msgid) :
@@ -88,13 +90,48 @@ bool ChatModel::MessageData::senderIsChat() const
     return messageData.value(SENDER).toMap().value(_TYPE).toString() == "messageSenderChat";
 }
 
-void ChatModel::MessageData::setContent(const QVariantMap &content)
+QVector<int> ChatModel::MessageData::diff(const MessageData *message) const
 {
-    messageData.insert(CONTENT, content);
+    QVector<int> roles;
+    if (message != this) {
+        roles.append(RoleDisplay);
+        if (message->messageId != messageId) {
+            roles.append(RoleMessageId);
+        }
+        if (message->messageContentType != messageContentType) {
+            roles.append(RoleMessageContentType);
+        }
+    }
+    return roles;
 }
-void ChatModel::MessageData::setReplyMarkup(const QVariantMap &replyMarkup)
+
+QVector<int> ChatModel::MessageData::setMessageData(const QVariantMap &data)
+{
+    messageData = data;
+    QVector<int> changedRoles;
+    changedRoles.append(RoleDisplay);
+    return changedRoles;
+}
+
+QVector<int> ChatModel::MessageData::setContent(const QVariantMap &content)
+{
+    const QString oldContentType(messageContentType);
+    messageData.insert(CONTENT, content);
+    messageContentType = content.value(_TYPE).toString();
+    QVector<int> changedRoles;
+    if (oldContentType != messageContentType) {
+        changedRoles.append(RoleMessageContentType);
+    }
+    changedRoles.append(RoleDisplay);
+    return changedRoles;
+}
+
+QVector<int> ChatModel::MessageData::setReplyMarkup(const QVariantMap &replyMarkup)
 {
     messageData.insert(REPLY_MARKUP, replyMarkup);
+    QVector<int> changedRoles;
+    changedRoles.append(RoleDisplay);
+    return changedRoles;
 }
 
 bool ChatModel::MessageData::lessThan(const MessageData *message1, const MessageData *message2)
@@ -370,11 +407,10 @@ void ChatModel::handleMessageReceived(qlonglong chatId, qlonglong messageId, con
     if (chatId == this->chatId && messageIndexMap.contains(messageId)) {
         LOG("Received a message that we already know, let's update it!");
         const int position = messageIndexMap.value(messageId);
-        MessageData *messageData = messages.at(position);
-        messageData->messageData = message;
+        const QVector<int> changedRoles(messages.at(position)->setMessageData(message));
         LOG("Message was updated at index" << position);
         const QModelIndex messageIndex(index(position));
-        emit dataChanged(messageIndex, messageIndex);
+        emit dataChanged(messageIndex, messageIndex, changedRoles);
     }
 }
 
@@ -405,11 +441,14 @@ void ChatModel::handleMessageSendSucceeded(qlonglong messageId, qlonglong oldMes
     if (this->messageIndexMap.contains(oldMessageId)) {
         LOG("Message was successfully sent" << oldMessageId);
         const int pos = messageIndexMap.take(oldMessageId);
-        delete messages.at(pos);
-        messages.replace(pos, new MessageData(message, messageId));
+        MessageData* oldMessage = messages.at(pos);
+        MessageData* newMessage = new MessageData(message, messageId);
+        messages.replace(pos, newMessage);
+        const QVector<int> changedRoles(newMessage->diff(oldMessage));
+        delete oldMessage;
         LOG("Message was replaced at index" << pos);
         const QModelIndex messageIndex(index(pos));
-        emit dataChanged(messageIndex, messageIndex);
+        emit dataChanged(messageIndex, messageIndex, changedRoles);
         emit lastReadSentMessageUpdated(calculateLastReadSentMessageId());
     }
 }
@@ -448,10 +487,10 @@ void ChatModel::handleMessageContentUpdated(qlonglong chatId, qlonglong messageI
         LOG("We know the message that was updated" << messageId);
         const int pos = messageIndexMap.value(messageId, -1);
         if (pos >= 0) {
-            messages.at(pos)->setContent(newContent);
-            LOG("Message was replaced at index" << pos);
+            const QVector<int> changedRoles(messages.at(pos)->setContent(newContent));
+            LOG("Message was updated at index" << pos);
             const QModelIndex messageIndex(index(pos));
-            emit dataChanged(messageIndex, messageIndex);
+            emit dataChanged(messageIndex, messageIndex, changedRoles);
             emit messageUpdated(pos);
         }
     }
@@ -464,10 +503,10 @@ void ChatModel::handleMessageEditedUpdated(qlonglong chatId, qlonglong messageId
         LOG("We know the message that was updated" << messageId);
         const int pos = messageIndexMap.value(messageId, -1);
         if (pos >= 0) {
-            messages.at(pos)->setReplyMarkup(replyMarkup);
+            const QVector<int> changedRoles(messages.at(pos)->setReplyMarkup(replyMarkup));
             LOG("Message was edited at index" << pos);
             const QModelIndex messageIndex(index(pos));
-            emit dataChanged(messageIndex, messageIndex);
+            emit dataChanged(messageIndex, messageIndex, changedRoles);
             emit messageUpdated(pos);
         }
     }


### PR DESCRIPTION
This only takes care of  `webPage`, something similar needs to be done for other components which download files.

Additionally, this fixes the problem with `ChatModel` roles not being updated. One needs to pass the list of changed roles to  `dataChanged` signal, then it works nicely. `ChatModel::messageUpdated`  signal is probably not needed anymore.