### PR TITLE
Apply press effect to profile thumbnail in chat list?

### DIFF
--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -9,6 +9,7 @@ PhotoTextsListItem {
     id: listItem
     pictureThumbnail {
         photoData: photo_small || ({})
+        highlighted: listItem.highlighted && !listItem.menuOpen
     }
     property int ownUserId
     property bool showDraft: !!draft_message_text && draft_message_date > last_message_date

--- a/qml/components/ProfileThumbnail.qml
+++ b/qml/components/ProfileThumbnail.qml
@@ -22,7 +22,6 @@ import Sailfish.Silica 1.0
 import WerkWolf.Fernschreiber 1.0
 
 Item {
-
     id: profileThumbnail
 
     property alias photoData: file.fileInformation
@@ -30,6 +29,10 @@ Item {
     property int radius: width / 2
     property int imageStatus: -1
     property bool optimizeImageSize: true
+    property bool highlighted
+
+    layer.enabled: highlighted
+    layer.effect: PressEffect { source: profileThumbnail }
 
     function getReplacementString() {
         if (replacementStringHint.length > 2) {


### PR DESCRIPTION
If this item is pressed:

![highlight-5](https://user-images.githubusercontent.com/5909522/104112889-aa759180-52fc-11eb-920d-fc15dc6272e0.png)

it currently looks like this:

![highlight-6](https://user-images.githubusercontent.com/5909522/104112838-58cd0700-52fc-11eb-9234-e7f9aa7792b8.png)

and after this change the profile image (or the replacement circle) looks pressed too:

![highlight-7](https://user-images.githubusercontent.com/5909522/104112854-671b2300-52fc-11eb-9e07-76e261dd3d89.png)