### PR TITLE
Show channel members on chat information page

### DIFF
--- a/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
@@ -162,7 +162,7 @@ ChatInformationTabItemBase {
         interval: 600
         property int fetchLimit: 50
         onTriggered: {
-            if(chatInformationPage.isSuperGroup && !chatInformationPage.isChannel && (chatInformationPage.groupInformation.member_count > membersView.count)) { //
+            if(chatInformationPage.isSuperGroup && (!chatInformationPage.isChannel || chatInformationPage.canGetMembers) && (chatInformationPage.groupInformation.member_count > membersView.count)) {
                 tabBase.loading = true
                 tdLibWrapper.getSupergroupMembers(chatInformationPage.chatPartnerGroupId, fetchLimit, pageContent.membersList.count);
                 fetchLimit = 200

--- a/qml/pages/ChatInformationPage.qml
+++ b/qml/pages/ChatInformationPage.qml
@@ -38,6 +38,7 @@ Page {
     property bool isBasicGroup: false
     property bool isSuperGroup: false
     property bool isChannel: false
+    readonly property bool canGetMembers: ("can_get_members" in groupFullInformation) && groupFullInformation.can_get_members
 
     property string chatPartnerGroupId
 
@@ -68,8 +69,6 @@ Page {
             break;
         }
     }
-
-
 
     Loader {
         id: mainContentLoader


### PR DESCRIPTION
You're allowed to get the list if you're channel's creator/admin. In that case you get `"can_get_members": true` in `"@type": "supergroupFullInfo"` message.