### PR TITLE
Display chat title in SimpleMessageDelegate if sender is chat

### DIFF
--- a/qml/components/MessageListViewItemSimple.qml
+++ b/qml/components/MessageListViewItemSimple.qml
@@ -24,8 +24,9 @@ import "../js/functions.js" as Functions
 Item {
     id: messageListItem
     property var myMessage: display
-    property var userInformation: tdLibWrapper.getUserInformation(myMessage.sender.user_id)
-    property bool isOwnMessage: chatPage.myUserId === myMessage.sender.user_id
+    property bool senderIsUser: myMessage.sender["@type"] === "messageSenderUser"
+    property var userInformation: senderIsUser ? tdLibWrapper.getUserInformation(myMessage.sender.user_id) : null
+    property bool isOwnMessage: senderIsUser && chatPage.myUserId === myMessage.sender.user_id
     height: backgroundRectangle.height + Theme.paddingMedium
 
     Rectangle {
@@ -43,7 +44,10 @@ Item {
         color: Theme.highlightColor
         horizontalAlignment: Text.AlignHCenter
         font.pixelSize: Theme.fontSizeExtraSmall
-        text: "<a style=\"text-decoration: none; font-weight: bold; color:"+Theme.primaryColor+"\" href=\"userId://" + messageListItem.userInformation.id + "\">" + (!messageListItem.isOwnMessage ? Emoji.emojify(Functions.getUserName(messageListItem.userInformation), font.pixelSize) : qsTr("You")) + "</a> " + Emoji.emojify(Functions.getMessageText(messageListItem.myMessage, false, chatPage.myUserId, false), font.pixelSize)
+        text: (messageListItem.senderIsUser
+               ? "<a style=\"text-decoration: none; font-weight: bold; color:"+Theme.primaryColor+"\" href=\"userId://" + messageListItem.userInformation.id + "\">" + (!messageListItem.isOwnMessage ? Emoji.emojify(Functions.getUserName(messageListItem.userInformation), font.pixelSize) : qsTr("You")) + "</a> "
+               :  "<a style=\"text-decoration: none; font-weight: bold; color:"+Theme.secondaryHighlightColor+"\">" +  Emoji.emojify(chatPage.chatInformation.title || "") + "</a> ")
+            + Emoji.emojify(Functions.getMessageText(messageListItem.myMessage, false, chatPage.myUserId, false), font.pixelSize)
         textFormat: Text.RichText
         wrapMode: Text.WrapAtWordBoundaryOrAnywhere
         onLinkActivated: {


### PR DESCRIPTION
On overviewPage an empty sender name for channels looks alright since the title is directly above it, anyway. 
But in the channel itself, the "simple messages" seemed wrong without a sender name.

The name link doesn't have a href in that case – this would only be useful for edge cases like someone sharing a "changed title" message to another chat with some inofficial client/bot that supports this. I did not consider that relevant enough. If other use cases arise, that can be added later.


![image](https://user-images.githubusercontent.com/99138/104571369-4c75e080-5653-11eb-87ff-43753c7c1952.png)
