### PR TITLE
Fix QML runtime warning in ChatInformationTabItemMembersGroups

### DIFF
--- a/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
@@ -72,7 +72,7 @@ ChatInformationTabItemBase {
         }
         delegate: PhotoTextsListItem {
             pictureThumbnail {
-                photoData: (typeof user.profile_photo !== "undefined") ? user.profile_photo.small : ""
+                photoData: user.profile_photo ? user.profile_photo.small : null
             }
             width: parent.width
 


### PR DESCRIPTION
When opening chat info page with member list:
```
[W] unknown:75 - file:///usr/share/harbour-fernschreiber/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml:75:28: Unable to assign QString to QVariantMap
```
This change makes that warning go away.