### PR TITLE
ChatListModel experiment

### DIFF
--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -92,7 +92,7 @@ PhotoTextsListItem {
                             pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
                         }
 
-                        pageStack.push(Qt.resolvedUrl("../pages/ChatInformationPage.qml"), { "chatInformation" : chatListModel.getById(chat_id)});
+                        pageStack.push(Qt.resolvedUrl("../pages/ChatInformationPage.qml"), { "chatInformation" : tdLibWrapper.getChat(chat_id)});
                     }
                     text: ( chat_type === TelegramAPI.ChatTypePrivate || isSecret ) ? qsTr("User Info") : qsTr("Group Info")
                 }

--- a/qml/components/ChatListViewItem.qml
+++ b/qml/components/ChatListViewItem.qml
@@ -27,7 +27,7 @@ PhotoTextsListItem {
     isSecret: ( chat_type === TelegramAPI.ChatTypeSecret )
     isMarkedAsUnread: is_marked_as_unread
     isPinned: is_pinned
-    isMuted: display.notification_settings.mute_for > 0
+    isMuted: notification_settings.mute_for > 0
 
     openMenuOnPressAndHold: true//chat_id != overviewPage.ownUserId
 
@@ -50,7 +50,7 @@ PhotoTextsListItem {
                 MenuItem {
                     visible: unread_count > 0
                     onClicked: {
-                        tdLibWrapper.viewMessage(chat_id, display.last_message.id, true);
+                        tdLibWrapper.viewMessage(chat_id, last_message_id, true);
                         tdLibWrapper.toggleChatIsMarkedAsUnread(chat_id, false);
                     }
                     text: qsTr("Mark all messages as read")
@@ -74,7 +74,7 @@ PhotoTextsListItem {
                 MenuItem {
                     visible: chat_id != listItem.ownUserId
                     onClicked: {
-                        var newNotificationSettings = display.notification_settings;
+                        var newNotificationSettings = notification_settings;
                         if (newNotificationSettings.mute_for > 0) {
                             newNotificationSettings.mute_for = 0;
                         } else {
@@ -83,7 +83,7 @@ PhotoTextsListItem {
                         newNotificationSettings.use_default_mute_for = false;
                         tdLibWrapper.setChatNotificationSettings(chat_id, newNotificationSettings);
                     }
-                    text: display.notification_settings.mute_for > 0 ? qsTr("Unmute chat") : qsTr("Mute chat")
+                    text: notification_settings.mute_for > 0 ? qsTr("Unmute chat") : qsTr("Mute chat")
                 }
 
                 MenuItem {
@@ -92,9 +92,9 @@ PhotoTextsListItem {
                             pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ), PageStackAction.Immediate);
                         }
 
-                        pageStack.push(Qt.resolvedUrl("../pages/ChatInformationPage.qml"), { "chatInformation" : display});
+                        pageStack.push(Qt.resolvedUrl("../pages/ChatInformationPage.qml"), { "chatInformation" : chatListModel.getById(chat_id)});
                     }
-                    text: model.display.type['@type'] === "chatTypePrivate" ? qsTr("User Info") : qsTr("Group Info")
+                    text: ( chat_type === TelegramAPI.ChatTypePrivate || isSecret ) ? qsTr("User Info") : qsTr("Group Info")
                 }
             }
         }

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -357,7 +357,7 @@ Page {
                 isVerified: is_verified
                 onClicked: {
                     pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), {
-                        chatInformation : display,
+                        chatInformation : chatListModel.getById(chat_id),
                         chatPicture: photo_small
                     })
                 }

--- a/qml/pages/OverviewPage.qml
+++ b/qml/pages/OverviewPage.qml
@@ -49,7 +49,7 @@ Page {
             Debug.log("[OverviewPage] Opening chat from external call...")
             if (chatListCreated) {
                 pageStack.pop(overviewPage, PageStackAction.Immediate)
-                pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : chatListModel.getById(chatId) }, PageStackAction.Immediate)
+                pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), { "chatInformation" : tdLibWrapper.getChat(chatId) }, PageStackAction.Immediate)
             }
         }
         onPleaseOpenUrl: {
@@ -357,7 +357,7 @@ Page {
                 isVerified: is_verified
                 onClicked: {
                     pageStack.push(Qt.resolvedUrl("../pages/ChatPage.qml"), {
-                        chatInformation : chatListModel.getById(chat_id),
+                        chatInformation : tdLibWrapper.getChat(chat_id),
                         chatPicture: photo_small
                     })
                 }

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -79,7 +79,6 @@ public:
     TDLibWrapper *tdLibWrapper;
 
 public:
-    QVariantMap chatData;
     qlonglong chatId;
     qlonglong order;
     qlonglong groupId;
@@ -104,7 +103,6 @@ public:
 
 ChatListModel::ChatData::ChatData(TDLibWrapper *tdLibWrapper, const QVariantMap &data) :
     tdLibWrapper(tdLibWrapper),
-    chatData(data),
     chatId(data.value(ID).toLongLong()),
     order(data.value(ORDER).toLongLong()),
     groupId(0),
@@ -580,7 +578,7 @@ void ChatListModel::updateSecretChatVisibility(const QVariantMap secretChatDetai
         if (chat->chatType != TDLibWrapper::ChatTypeSecret) {
             continue;
         }
-        if (chat->chatData.value(TYPE).toMap().value(SECRET_CHAT_ID).toLongLong() != secretChatDetails.value(ID).toLongLong()) {
+        if (tdLibWrapper->getChat(chat->chatId).value(TYPE).toMap().value(SECRET_CHAT_ID).toLongLong() != secretChatDetails.value(ID).toLongLong()) {
             continue;
         }
         const QVector<int> changedRoles(chat->updateSecretChat(secretChatDetails));

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -496,14 +496,6 @@ QVariantMap ChatListModel::get(int row)
     return res;
 }
 
-QVariantMap ChatListModel::getById(qlonglong chatId)
-{
-    if (chatIndexMap.contains(chatId)) {
-        return chatList.value(chatIndexMap.value(chatId))->chatData;
-    }
-    return QVariantMap();
-}
-
 int ChatListModel::updateChatOrder(int chatIndex)
 {
     ChatData *chat = chatList.at(chatIndex);

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -158,7 +158,7 @@ bool ChatListModel::ChatData::setOrder(const QString &newOrder)
 {
     if (!newOrder.isEmpty()) {
         order = newOrder.toLongLong();
-        tdLibWrapper->getChat(chatId).insert(ORDER, newOrder);
+        tdLibWrapper->updateCachedChatProperty(chatId, ORDER, newOrder);
         return true;
     }
     return false;
@@ -250,7 +250,7 @@ bool ChatListModel::ChatData::updateUnreadCount(int count)
 {
     const int prevUnreadCount(unreadCount);
     unreadCount = count;
-    tdLibWrapper->getChat(chatId).insert(UNREAD_COUNT, count);
+    tdLibWrapper->updateCachedChatProperty(chatId, UNREAD_COUNT, count);
     return prevUnreadCount != unreadCount;
 }
 
@@ -258,7 +258,7 @@ bool ChatListModel::ChatData::updateLastReadInboxMessageId(qlonglong messageId)
 {
     const qlonglong prevLastReadInboxMessageId(lastReadInboxMessageId);
     lastReadInboxMessageId = messageId;
-    tdLibWrapper->getChat(chatId).insert(LAST_READ_INBOX_MESSAGE_ID, messageId);
+    tdLibWrapper->updateCachedChatProperty(chatId, LAST_READ_INBOX_MESSAGE_ID, messageId);
     return prevLastReadInboxMessageId != messageId;
 }
 
@@ -271,7 +271,7 @@ QVector<int> ChatListModel::ChatData::updateLastMessage(const QVariantMap &messa
     const QString prevSenderMessageStatus(senderMessageStatus());
 
     lastMessage = message;
-    tdLibWrapper->getChat(chatId).insert(LAST_MESSAGE, lastMessage);
+    tdLibWrapper->updateCachedChatProperty(chatId, LAST_MESSAGE, lastMessage);
 
     QVector<int> changedRoles;
     if (prevSenderUserId != senderUserId()) {
@@ -665,7 +665,7 @@ void ChatListModel::handleChatLastMessageUpdated(const QString &id, const QStrin
                 LOG("Updating last message for hidden chat" << chatId << "new order" << order);
                 chat->setOrder(order);
                 chat->lastMessage = lastMessage;
-                tdLibWrapper->getChat(chatId).insert(LAST_MESSAGE, lastMessage);
+                tdLibWrapper->updateCachedChatProperty(chatId, LAST_MESSAGE, lastMessage);
             }
         }
     }
@@ -727,7 +727,7 @@ void ChatListModel::handleChatReadOutboxUpdated(const QString &id, const QString
 {
     bool ok;
     qlonglong chatId = id.toLongLong(&ok);
-    tdLibWrapper->getChat(chatId).insert(LAST_READ_OUTBOX_MESSAGE_ID, lastReadOutboxMessageId);
+    tdLibWrapper->updateCachedChatProperty(chatId, LAST_READ_OUTBOX_MESSAGE_ID, lastReadOutboxMessageId);
     if (ok) {
         if (chatIndexMap.contains(chatId)) {
             LOG("Updating last read message for" << chatId << "last ID" << lastReadOutboxMessageId);
@@ -747,7 +747,7 @@ void ChatListModel::handleChatReadOutboxUpdated(const QString &id, const QString
 
 void ChatListModel::handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &photo)
 {
-    tdLibWrapper->getChat(chatId).insert(PHOTO, photo);
+    tdLibWrapper->updateCachedChatProperty(chatId, PHOTO, photo);
     if (chatIndexMap.contains(chatId)) {
         LOG("Updating chat photo for" << chatId);
         const int chatIndex = chatIndexMap.value(chatId);
@@ -781,7 +781,7 @@ void ChatListModel::handleMessageSendSucceeded(qlonglong messageId, qlonglong ol
             if (chat) {
                 LOG("Updating last message for hidden chat" << chatId << ", as message was sent, old ID:" << oldMessageId << ", new ID:" << messageId);
                 chat->lastMessage = message;
-                tdLibWrapper->getChat(chatId).insert(LAST_MESSAGE, message);
+                tdLibWrapper->updateCachedChatProperty(chatId, LAST_MESSAGE, message);
             }
         }
     }
@@ -791,7 +791,7 @@ void ChatListModel::handleChatNotificationSettingsUpdated(const QString &id, con
 {
     bool ok;
     qlonglong chatId = id.toLongLong(&ok);
-    tdLibWrapper->getChat(chatId).insert(NOTIFICATION_SETTINGS, chatNotificationSettings);
+    tdLibWrapper->updateCachedChatProperty(chatId, NOTIFICATION_SETTINGS, chatNotificationSettings);
     if (ok) {
         if (chatIndexMap.contains(chatId)) {
             const int chatIndex = chatIndexMap.value(chatId);
@@ -825,7 +825,7 @@ void ChatListModel::handleSecretChatUpdated(qlonglong secretChatId, const QVaria
 void ChatListModel::handleChatTitleUpdated(const QString &chatId, const QString &title)
 {
     qlonglong chatIdLongLong = chatId.toLongLong();
-    tdLibWrapper->getChat(chatIdLongLong).insert(TITLE, title);
+    tdLibWrapper->updateCachedChatProperty(chatIdLongLong, TITLE, title);
     if (chatIndexMap.contains(chatIdLongLong)) {
         LOG("Updating title for" << chatId);
         const int chatIndex = chatIndexMap.value(chatIdLongLong);
@@ -846,7 +846,7 @@ void ChatListModel::handleChatTitleUpdated(const QString &chatId, const QString 
 
 void ChatListModel::handleChatPinnedUpdated(qlonglong chatId, bool chatIsPinned)
 {
-    tdLibWrapper->getChat(chatId).insert(IS_PINNED, chatIsPinned);
+    tdLibWrapper->updateCachedChatProperty(chatId, IS_PINNED, chatIsPinned);
     if (chatIndexMap.contains(chatId)) {
         LOG("Updating chat is pinned for" << chatId << chatIsPinned);
         const int chatIndex = chatIndexMap.value(chatId);
@@ -867,7 +867,7 @@ void ChatListModel::handleChatPinnedUpdated(qlonglong chatId, bool chatIsPinned)
 
 void ChatListModel::handleChatIsMarkedAsUnreadUpdated(qlonglong chatId, bool chatIsMarkedAsUnread)
 {
-    tdLibWrapper->getChat(chatId).insert(IS_MARKED_AS_UNREAD, chatIsMarkedAsUnread);
+    tdLibWrapper->updateCachedChatProperty(chatId, IS_MARKED_AS_UNREAD, chatIsMarkedAsUnread);
     if (chatIndexMap.contains(chatId)) {
         LOG("Updating chat is marked as unread for" << chatId << chatIsMarkedAsUnread);
         const int chatIndex = chatIndexMap.value(chatId);
@@ -888,7 +888,7 @@ void ChatListModel::handleChatIsMarkedAsUnreadUpdated(qlonglong chatId, bool cha
 
 void ChatListModel::handleChatDraftMessageUpdated(qlonglong chatId, const QVariantMap &draftMessage, const QString &order)
 {
-    tdLibWrapper->getChat(chatId).insert(DRAFT_MESSAGE, draftMessage);
+    tdLibWrapper->updateCachedChatProperty(chatId, DRAFT_MESSAGE, draftMessage);
     LOG("Updating draft message for" << chatId);
     if (chatIndexMap.contains(chatId)) {
         const int chatIndex = chatIndexMap.value(chatId);

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -337,7 +337,6 @@ ChatListModel::ChatListModel(TDLibWrapper *tdLibWrapper, AppSettings *appSetting
     connect(tdLibWrapper, SIGNAL(chatReadInboxUpdated(QString, QString, int)), this, SLOT(handleChatReadInboxUpdated(QString, QString, int)));
     connect(tdLibWrapper, SIGNAL(chatReadOutboxUpdated(QString, QString)), this, SLOT(handleChatReadOutboxUpdated(QString, QString)));
     connect(tdLibWrapper, SIGNAL(chatPhotoUpdated(qlonglong, QVariantMap)), this, SLOT(handleChatPhotoUpdated(qlonglong, QVariantMap)));
-    connect(tdLibWrapper, SIGNAL(chatPinnedMessageUpdated(qlonglong, qlonglong)), this, SLOT(handleChatPinnedMessageUpdated(qlonglong, qlonglong)));
     connect(tdLibWrapper, SIGNAL(messageSendSucceeded(qlonglong, qlonglong, QVariantMap)), this, SLOT(handleMessageSendSucceeded(qlonglong, qlonglong, QVariantMap)));
     connect(tdLibWrapper, SIGNAL(chatNotificationSettingsUpdated(QString, QVariantMap)), this, SLOT(handleChatNotificationSettingsUpdated(QString, QVariantMap)));
     connect(tdLibWrapper, SIGNAL(superGroupUpdated(qlonglong)), this, SLOT(handleGroupUpdated(qlonglong)));
@@ -618,7 +617,7 @@ void ChatListModel::setShowAllChats(bool showAll)
     }
 }
 
-void ChatListModel::handleChatDiscovered(qlonglong &, const QVariantMap &chatToBeAdded)
+void ChatListModel::handleChatDiscovered(qlonglong, const QVariantMap &chatToBeAdded)
 {
     ChatData *chat = new ChatData(tdLibWrapper, chatToBeAdded);
 
@@ -765,22 +764,6 @@ void ChatListModel::handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &
         if (chat) {
             LOG("Updating photo for hidden chat" << chatId);
             chat->photoSmall = photo.value(SMALL);
-        }
-    }
-}
-
-void ChatListModel::handleChatPinnedMessageUpdated(qlonglong chatId, qlonglong pinnedMessageId)
-{
-    if (chatIndexMap.contains(chatId)) {
-        LOG("Updating pinned message for" << chatId);
-        const int chatIndex = chatIndexMap.value(chatId);
-        ChatData *chat = chatList.at(chatIndex);
-        chat->chatData.insert(PINNED_MESSAGE_ID, pinnedMessageId);
-    } else {
-        ChatData *chat = hiddenChats.value(chatId);
-        if (chat) {
-            LOG("Updating pinned message for hidden chat" << chatId);
-            chat->chatData.insert(PINNED_MESSAGE_ID, pinnedMessageId);
         }
     }
 }

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -79,47 +79,47 @@ public:
     TDLibWrapper *tdLibWrapper;
 
 public:
+    bool verified;
+    bool isPinned;
+    bool isMarkedAsUnread;
+    bool isChannel;
     qlonglong chatId;
     qlonglong order;
     qlonglong groupId;
-    bool verified;
+    qlonglong lastReadInboxMessageId;
+    qlonglong lastReadOutboxMessageId;
+    qlonglong draftMessageDate;
     TDLibWrapper::ChatType chatType;
     TDLibWrapper::ChatMemberStatus memberStatus;
     TDLibWrapper::SecretChatState secretChatState;
     QVariantMap userInformation;
-    int unreadCount;
-    qlonglong lastReadInboxMessageId;
     QVariantMap lastMessage;
-    qlonglong lastReadOutboxMessageId;
-    QVariant photoSmall;
     QVariantMap notificationSettings;
+    QVariant photoSmall;
+    int unreadCount;
     QString title;
-    bool isPinned;
-    bool isMarkedAsUnread;
-    qlonglong draftMessageDate;
     QString draftMessageText;
-    bool isChannel;
 };
 
 ChatListModel::ChatData::ChatData(TDLibWrapper *tdLibWrapper, const QVariantMap &data) :
     tdLibWrapper(tdLibWrapper),
+    verified(false),
+    isPinned(data.value(IS_PINNED).toBool()),
+    isMarkedAsUnread(data.value(IS_MARKED_AS_UNREAD).toBool()),
+    isChannel(data.value(TYPE).toMap().value(IS_CHANNEL).toBool()),
     chatId(data.value(ID).toLongLong()),
     order(data.value(ORDER).toLongLong()),
     groupId(0),
-    verified(false),
+    lastReadInboxMessageId(data.value(LAST_READ_INBOX_MESSAGE_ID).toLongLong()),
+    lastReadOutboxMessageId(data.value(LAST_READ_OUTBOX_MESSAGE_ID).toLongLong()),
     memberStatus(TDLibWrapper::ChatMemberStatusUnknown),
     secretChatState(TDLibWrapper::SecretChatStateUnknown),
     userInformation(tdLibWrapper->getUserInformation()),
-    unreadCount(data.value(UNREAD_COUNT).toInt()),
-    lastReadInboxMessageId(data.value(LAST_READ_INBOX_MESSAGE_ID).toLongLong()),
     lastMessage(data.value(LAST_MESSAGE).toMap()),
-    lastReadOutboxMessageId(data.value(LAST_READ_OUTBOX_MESSAGE_ID).toLongLong()),
-    photoSmall(data.value(PHOTO).toMap().value(SMALL)),
     notificationSettings(data.value(NOTIFICATION_SETTINGS).toMap()),
-    title(data.value(TITLE).toString()),
-    isPinned(data.value(IS_PINNED).toBool()),
-    isMarkedAsUnread(data.value(IS_MARKED_AS_UNREAD).toBool()),
-    isChannel(data.value(TYPE).toMap().value(IS_CHANNEL).toBool())
+    photoSmall(data.value(PHOTO).toMap().value(SMALL)),
+    unreadCount(data.value(UNREAD_COUNT).toInt()),
+    title(data.value(TITLE).toString())
 {
     const QVariantMap type(data.value(TYPE).toMap());
     switch (chatType = TDLibWrapper::chatTypeFromString(type.value(_TYPE).toString())) {

--- a/src/chatlistmodel.cpp
+++ b/src/chatlistmodel.cpp
@@ -647,7 +647,7 @@ void ChatListModel::handleChatDiscovered(qlonglong, const QVariantMap &chatToBeA
 void ChatListModel::handleChatLastMessageUpdated(const QString &id, const QString &order, const QVariantMap &lastMessage)
 {
     bool ok;
-    qlonglong chatId = id.toLongLong(&ok);
+    const qlonglong chatId = id.toLongLong(&ok);
     if (ok) {
         if (chatIndexMap.contains(chatId)) {
             int chatIndex = chatIndexMap.value(chatId);
@@ -726,7 +726,7 @@ void ChatListModel::handleChatReadInboxUpdated(const QString &id, const QString 
 void ChatListModel::handleChatReadOutboxUpdated(const QString &id, const QString &lastReadOutboxMessageId)
 {
     bool ok;
-    qlonglong chatId = id.toLongLong(&ok);
+    const qlonglong chatId = id.toLongLong(&ok);
     tdLibWrapper->updateCachedChatProperty(chatId, LAST_READ_OUTBOX_MESSAGE_ID, lastReadOutboxMessageId);
     if (ok) {
         if (chatIndexMap.contains(chatId)) {
@@ -769,7 +769,7 @@ void ChatListModel::handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &
 void ChatListModel::handleMessageSendSucceeded(qlonglong messageId, qlonglong oldMessageId, const QVariantMap &message)
 {
     bool ok;
-    qlonglong chatId(message.value(CHAT_ID).toLongLong(&ok));
+    const qlonglong chatId(message.value(CHAT_ID).toLongLong(&ok));
     if (ok) {
         if (chatIndexMap.contains(chatId)) {
             const int chatIndex = chatIndexMap.value(chatId);
@@ -790,7 +790,7 @@ void ChatListModel::handleMessageSendSucceeded(qlonglong messageId, qlonglong ol
 void ChatListModel::handleChatNotificationSettingsUpdated(const QString &id, const QVariantMap &chatNotificationSettings)
 {
     bool ok;
-    qlonglong chatId = id.toLongLong(&ok);
+    const qlonglong chatId = id.toLongLong(&ok);
     tdLibWrapper->updateCachedChatProperty(chatId, NOTIFICATION_SETTINGS, chatNotificationSettings);
     if (ok) {
         if (chatIndexMap.contains(chatId)) {
@@ -824,7 +824,7 @@ void ChatListModel::handleSecretChatUpdated(qlonglong secretChatId, const QVaria
 
 void ChatListModel::handleChatTitleUpdated(const QString &chatId, const QString &title)
 {
-    qlonglong chatIdLongLong = chatId.toLongLong();
+    const qlonglong chatIdLongLong = chatId.toLongLong();
     tdLibWrapper->updateCachedChatProperty(chatIdLongLong, TITLE, title);
     if (chatIndexMap.contains(chatIdLongLong)) {
         LOG("Updating title for" << chatId);

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -64,7 +64,6 @@ public:
 
     Q_INVOKABLE void redrawModel();
     Q_INVOKABLE QVariantMap get(int row);
-    Q_INVOKABLE QVariantMap getById(qlonglong chatId);
     Q_INVOKABLE void reset();
 
     Q_INVOKABLE void calculateUnreadState();

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -72,7 +72,7 @@ public:
     void setShowAllChats(bool showAll);
 
 private slots:
-    void handleChatDiscovered(const QString &chatId, const QVariantMap &chatInformation);
+    void handleChatDiscovered(qlonglong &chatId, const QVariantMap &chatInformation);
     void handleChatLastMessageUpdated(const QString &chatId, const QString &order, const QVariantMap &lastMessage);
     void handleChatOrderUpdated(const QString &chatId, const QString &order);
     void handleChatReadInboxUpdated(const QString &chatId, const QString &lastReadInboxMessageId, int unreadCount);

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -32,13 +32,13 @@ class ChatListModel : public QAbstractListModel
 public:
 
     enum Role {
-        RoleDisplay = Qt::DisplayRole,
         RoleChatId,
         RoleChatType,
         RoleTitle,
         RolePhotoSmall,
         RoleUnreadCount,
         RoleLastReadInboxMessageId,
+        RoleLastMessageId,
         RoleLastMessageSenderId,
         RoleLastMessageDate,
         RoleLastMessageText,
@@ -48,6 +48,7 @@ public:
         RoleIsVerified,
         RoleIsChannel,
         RoleIsMarkedAsUnread,
+        RoleNotificationSettings,
         RoleIsPinned,
         RoleFilter,
         RoleDraftMessageText,

--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -72,13 +72,12 @@ public:
     void setShowAllChats(bool showAll);
 
 private slots:
-    void handleChatDiscovered(qlonglong &chatId, const QVariantMap &chatInformation);
+    void handleChatDiscovered(qlonglong chatId, const QVariantMap &chatInformation);
     void handleChatLastMessageUpdated(const QString &chatId, const QString &order, const QVariantMap &lastMessage);
     void handleChatOrderUpdated(const QString &chatId, const QString &order);
     void handleChatReadInboxUpdated(const QString &chatId, const QString &lastReadInboxMessageId, int unreadCount);
     void handleChatReadOutboxUpdated(const QString &chatId, const QString &lastReadOutboxMessageId);
     void handleChatPhotoUpdated(qlonglong chatId, const QVariantMap &photo);
-    void handleChatPinnedMessageUpdated(qlonglong chatId, qlonglong pinnedMessageId);
     void handleMessageSendSucceeded(qlonglong messageId, qlonglong oldMessageId, const QVariantMap &message);
     void handleChatNotificationSettingsUpdated(const QString &chatId, const QVariantMap &chatNotificationSettings);
     void handleGroupUpdated(qlonglong groupId);

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -44,7 +44,7 @@ public slots:
     void handleUpdateActiveNotifications(const QVariantList &notificationGroups);
     void handleUpdateNotificationGroup(const QVariantMap &notificationGroupUpdate);
     void handleUpdateNotification(const QVariantMap &updatedNotification);
-    void handleChatDiscovered(const QString &chatId, const QVariantMap &chatInformation);
+    void handleChatDiscovered(qlonglong chatId, const QVariantMap &chatInformation);
     void handleChatTitleUpdated(const QString &chatId, const QString &title);
 
 private:

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -1247,7 +1247,12 @@ QVariantMap TDLibWrapper::getSuperGroup(qlonglong groupId) const
     }
 }
 
-QVariantMap TDLibWrapper::getChat(qlonglong &chatId)
+QVariantMap TDLibWrapper::getChat(const QString &chatId)
+{
+    return this->getChat(chatId.toLongLong());
+}
+
+QVariantMap TDLibWrapper::getChat(qlonglong chatId)
 {
     LOG("Returning chat information for ID" << chatId);
     return this->chats.value(chatId).toMap();
@@ -1581,16 +1586,25 @@ void TDLibWrapper::handleMessageInformation(qlonglong chatId, qlonglong messageI
 {
     QString extraInformation = receivedInformation.value(_EXTRA).toString();
     if (extraInformation.startsWith("getChatPinnedMessage:")) {
+        this->getChat(chatId).insert("pinned_message_id", messageId);
         emit chatPinnedMessageUpdated(chatId, messageId);
     }
     emit receivedMessage(chatId, messageId, receivedInformation);
 }
 
+void TDLibWrapper::handleChatPinnedMessageUpdated(qlonglong chatId, qlonglong messageId)
+{
+    this->getChat(chatId).insert("pinned_message_id", messageId);
+    emit chatPinnedMessageUpdated(chatId, messageId);
+}
+
 void TDLibWrapper::handleMessageIsPinnedUpdated(qlonglong chatId, qlonglong messageId, bool isPinned)
 {
     if (isPinned) {
+        this->getChat(chatId).insert("pinned_message_id", messageId);
         emit chatPinnedMessageUpdated(chatId, messageId);
     } else {
+        this->getChat(chatId).insert("pinned_message_id", 0);
         emit chatPinnedMessageUpdated(chatId, 0);
         this->getChatPinnedMessage(chatId);
     }

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -1182,6 +1182,15 @@ void TDLibWrapper::deleteFile(int fileId)
     this->sendRequest(requestObject);
 }
 
+void TDLibWrapper::updateCachedChatProperty(qlonglong chatId, const QString &key, const QVariant &value)
+{
+    QVariantMap chatInformation = this->getChat(chatId);
+    if(!chatInformation.isEmpty()) {
+        chatInformation.insert(key, value);
+        this->chats.insert(chatId, chatInformation);
+    }
+}
+
 void TDLibWrapper::searchEmoji(const QString &queryString)
 {
     LOG("Searching emoji" << queryString);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -1247,11 +1247,6 @@ QVariantMap TDLibWrapper::getSuperGroup(qlonglong groupId) const
     }
 }
 
-QVariantMap TDLibWrapper::getChat(const QString &chatId)
-{
-    return this->getChat(chatId.toLongLong());
-}
-
 QVariantMap TDLibWrapper::getChat(qlonglong chatId)
 {
     LOG("Returning chat information for ID" << chatId);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -1247,7 +1247,7 @@ QVariantMap TDLibWrapper::getSuperGroup(qlonglong groupId) const
     }
 }
 
-QVariantMap TDLibWrapper::getChat(const QString &chatId)
+QVariantMap TDLibWrapper::getChat(qlonglong &chatId)
 {
     LOG("Returning chat information for ID" << chatId);
     return this->chats.value(chatId).toMap();
@@ -1464,7 +1464,7 @@ void TDLibWrapper::handleFileUpdated(const QVariantMap &fileInformation)
 
 void TDLibWrapper::handleNewChatDiscovered(const QVariantMap &chatInformation)
 {
-    QString chatId = chatInformation.value("id").toString();
+    qlonglong chatId = chatInformation.value("id").toLongLong();
     this->chats.insert(chatId, chatInformation);
     emit newChatDiscovered(chatId, chatInformation);
 }

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -198,6 +198,7 @@ public:
     Q_INVOKABLE void deleteFile(int fileId);
 
     // Others (candidates for extraction ;))
+    Q_INVOKABLE void updateCachedChatProperty(qlonglong chatId, const QString &key, const QVariant &value);
     Q_INVOKABLE void searchEmoji(const QString &queryString);
     Q_INVOKABLE void initializeOpenWith();
     Q_INVOKABLE void removeOpenWith();

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -110,7 +110,7 @@ public:
     Q_INVOKABLE QVariantMap getUnreadChatInformation();
     Q_INVOKABLE QVariantMap getBasicGroup(qlonglong groupId) const;
     Q_INVOKABLE QVariantMap getSuperGroup(qlonglong groupId) const;
-    Q_INVOKABLE QVariantMap getChat(const QString &chatId);
+    Q_INVOKABLE QVariantMap getChat(qlonglong &chatId);
     Q_INVOKABLE QVariantMap getSecretChatFromCache(qlonglong secretChatId);
     Q_INVOKABLE QString getOptionString(const QString &optionName);
     Q_INVOKABLE void copyFileToDownloads(const QString &filePath);
@@ -203,6 +203,7 @@ public:
     Q_INVOKABLE void removeOpenWith();
 
 public:
+    QMap<qlonglong, QVariant> chats;
     const Group* getGroup(qlonglong groupId) const;
     static ChatType chatTypeFromString(const QString &type);
     static ChatMemberStatus chatMemberStatusFromString(const QString &status);
@@ -215,7 +216,7 @@ signals:
     void optionUpdated(const QString &optionName, const QVariant &optionValue);
     void connectionStateChanged(const TDLibWrapper::ConnectionState &connectionState);
     void fileUpdated(int fileId, const QVariantMap &fileInformation);
-    void newChatDiscovered(const QString &chatId, const QVariantMap &chatInformation);
+    void newChatDiscovered(qlonglong chatId, const QVariantMap &chatInformation);
     void unreadMessageCountUpdated(const QVariantMap &messageCountInformation);
     void unreadChatCountUpdated(const QVariantMap &chatCountInformation);
     void chatLastMessageUpdated(const QString &chatId, const QString &order, const QVariantMap &lastMessage);
@@ -317,7 +318,6 @@ private:
     QVariantMap userInformation;
     QVariantMap allUsers;
     QVariantMap allUserNames;
-    QVariantMap chats;
     QMap<qlonglong, QVariantMap> secretChats;
     QVariantMap unreadMessageInformation;
     QVariantMap unreadChatInformation;

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -110,7 +110,7 @@ public:
     Q_INVOKABLE QVariantMap getUnreadChatInformation();
     Q_INVOKABLE QVariantMap getBasicGroup(qlonglong groupId) const;
     Q_INVOKABLE QVariantMap getSuperGroup(qlonglong groupId) const;
-    Q_INVOKABLE QVariantMap getChat(const QString &chatId);
+    Q_INVOKABLE QVariantMap getChat(qlonglong chatId);
     Q_INVOKABLE QVariantMap getSecretChatFromCache(qlonglong secretChatId);
     Q_INVOKABLE QString getOptionString(const QString &optionName);
     Q_INVOKABLE void copyFileToDownloads(const QString &filePath);
@@ -207,7 +207,6 @@ public:
     static ChatType chatTypeFromString(const QString &type);
     static ChatMemberStatus chatMemberStatusFromString(const QString &status);
     static SecretChatState secretChatStateFromString(const QString &state);
-    QVariantMap getChat(qlonglong chatId);
 
 signals:
     void versionDetected(const QString &version);

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -110,7 +110,7 @@ public:
     Q_INVOKABLE QVariantMap getUnreadChatInformation();
     Q_INVOKABLE QVariantMap getBasicGroup(qlonglong groupId) const;
     Q_INVOKABLE QVariantMap getSuperGroup(qlonglong groupId) const;
-    Q_INVOKABLE QVariantMap getChat(qlonglong &chatId);
+    Q_INVOKABLE QVariantMap getChat(const QString &chatId);
     Q_INVOKABLE QVariantMap getSecretChatFromCache(qlonglong secretChatId);
     Q_INVOKABLE QString getOptionString(const QString &optionName);
     Q_INVOKABLE void copyFileToDownloads(const QString &filePath);
@@ -203,11 +203,11 @@ public:
     Q_INVOKABLE void removeOpenWith();
 
 public:
-    QMap<qlonglong, QVariant> chats;
     const Group* getGroup(qlonglong groupId) const;
     static ChatType chatTypeFromString(const QString &type);
     static ChatMemberStatus chatMemberStatusFromString(const QString &status);
     static SecretChatState secretChatStateFromString(const QString &state);
+    QVariantMap getChat(qlonglong chatId);
 
 signals:
     void versionDetected(const QString &version);
@@ -294,6 +294,7 @@ public slots:
     void handleStorageOptimizerChanged();
     void handleErrorReceived(int code, const QString &message, const QString &extra);
     void handleMessageInformation(qlonglong chatId, qlonglong messageId, const QVariantMap &receivedInformation);
+    void handleChatPinnedMessageUpdated(qlonglong chatId, qlonglong messageId);
     void handleMessageIsPinnedUpdated(qlonglong chatId, qlonglong messageId, bool isPinned);
 
 private:
@@ -318,6 +319,7 @@ private:
     QVariantMap userInformation;
     QVariantMap allUsers;
     QVariantMap allUserNames;
+    QMap<qlonglong, QVariant> chats;
     QMap<qlonglong, QVariantMap> secretChats;
     QVariantMap unreadMessageInformation;
     QVariantMap unreadChatInformation;


### PR DESCRIPTION
**It may not be a good idea to merge this. It is mainly an "academic" testbed and an opportunity to both learn stuff and perhaps discuss this.** 
_If it turns out that these changes actually make sense, I'd be glad to be wrong, though. ;)_

There are a few things I learned and tried to adress. 
We:
 - basically have all known chats fully cached both in `ChatListModel` and `TDLibWrapper`. I don't know why. I've tried to use `TDLibWrapper::getChat()` for the `ChatPage`, for example, and that worked, as well. (Pinned message handling wasn't used outside that cache, as well, so it was moved to `TDLibWrapper`, also items in the `TDLibWrapper` cache get updated now.)
 - really don't need the `ChatData::chatData` in `ChatListModel` – we only need a few more dedicated variables instead of getter functions for the `QVariantMaps`.
 - may not even need the `hiddenChats` cache. Not sure, though, how those are actually used. It's still included in these changes.

You probably want to see some results. The memory footprint is a bit different but I wouldn't call it a night and day difference (I've mostly got ~1MB fewer allocations when comparing the maximum measurements).

Here's a somewhat average example of the five tests I did for before and after, both initializing and slowly scrolling the chat list down once:
![image](https://user-images.githubusercontent.com/99138/105644422-cbf68180-5e95-11eb-874b-2b61fa2577ba.png)
![image](https://user-images.githubusercontent.com/99138/105644451-eaf51380-5e95-11eb-8c8f-b9a26e022d8e.png)

Also I think these changes may result in a few less "Variant value conversion" function calls. On the first few glances, things still work, but… I may have broken some, nonetheless. _That is why there's that disclaimer on the top._ 

I know you guys most likely don't have much time to really review this in detail, but it is mostly what _I think_ @monich meant when he listed things to avoid with QVariantMap. 

So, what do you think? ;)