### PR TITLE
Don't allow ContextMenu to be wider than its ComboBox

### DIFF
--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -324,6 +324,8 @@ Page {
                     label: qsTr("Allow chat invites")
                     description: qsTr("Privacy setting for managing whether you can be invited to chats.")
                     menu: ContextMenu {
+                        x: 0
+                        width: allowChatInvitesComboBox.width
 
                         MenuItem {
                             text: qsTr("Yes")
@@ -356,6 +358,8 @@ Page {
                     label: qsTr("Allow finding by phone number")
                     description: qsTr("Privacy setting for managing whether you can be found by your phone number.")
                     menu: ContextMenu {
+                        x: 0
+                        width: allowFindingByPhoneNumberComboBox.width
 
                         MenuItem {
                             text: qsTr("Yes")
@@ -382,6 +386,8 @@ Page {
                     label: qsTr("Show link in forwarded messages")
                     description: qsTr("Privacy setting for managing whether a link to your account is included in forwarded messages.")
                     menu: ContextMenu {
+                        x: 0
+                        width: showLinkInForwardedMessagesComboBox.width
 
                         MenuItem {
                             text: qsTr("Yes")
@@ -414,6 +420,8 @@ Page {
                     label: qsTr("Show phone number")
                     description: qsTr("Privacy setting for managing whether your phone number is visible.")
                     menu: ContextMenu {
+                        x: 0
+                        width: showPhoneNumberComboBox.width
 
                         MenuItem {
                             text: qsTr("Yes")
@@ -446,6 +454,8 @@ Page {
                     label: qsTr("Show profile photo")
                     description: qsTr("Privacy setting for managing whether your profile photo is visible.")
                     menu: ContextMenu {
+                        x: 0
+                        width: showProfilePhotoComboBox.width
 
                         MenuItem {
                             text: qsTr("Yes")
@@ -478,6 +488,8 @@ Page {
                     label: qsTr("Show status")
                     description: qsTr("Privacy setting for managing whether your online status is visible.")
                     menu: ContextMenu {
+                        x: 0
+                        width: showStatusComboBox.width
 
                         MenuItem {
                             text: qsTr("Yes")


### PR DESCRIPTION
That looks ridiculous:

![Screenshot_20210130_001](https://user-images.githubusercontent.com/5909522/106337168-309c4c80-6299-11eb-8818-4d93742eea8e.png)

and this I think is much better:

![Screenshot_20210130_002](https://user-images.githubusercontent.com/5909522/106337183-3db93b80-6299-11eb-83c7-2f70f1e0d354.png)

Honestly speaking, I feel the urge to redo this new User Profile section, but let's start with smaller and more obvious things.