### PR TITLE
Don't display default and superlowres images at the same time

### DIFF
--- a/qml/components/TDLibMinithumbnail.qml
+++ b/qml/components/TDLibMinithumbnail.qml
@@ -26,14 +26,12 @@ Loader {
     property bool highlighted
     anchors.fill: parent
     active: !!minithumbnail
-    visible: active
     sourceComponent: Component {
         Item {
             Image {
                 id: minithumbnailImage
                 anchors.fill: parent
                 source: "data:image/jpg;base64,"+minithumbnail.data
-                asynchronous: true
                 fillMode: tdLibImage.fillMode
                 opacity: status === Image.Ready ? 1.0 : 0.0
                 cache: false

--- a/qml/components/TDLibPhoto.qml
+++ b/qml/components/TDLibPhoto.qml
@@ -54,7 +54,7 @@ Item {
     }
 
     BackgroundImage {
-        visible: tdLibImage.opacity < 1.0
+        visible: !tdLibImage.visible && !(minithumbnailLoader.item && minithumbnailLoader.item.visible)
     }
 
     TDLibImage {


### PR DESCRIPTION
It looked like this:

![a](https://user-images.githubusercontent.com/5909522/106346200-f09b9080-62bd-11eb-81a4-0aa90eb0a0a8.png)

Also, I don't think asynchronous loading mode makes sense for these minithumbnail images. That may actually introduce even greater overhead.