### PR TITLE
Explicitly set image-path notification hint to empty string

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -60,6 +60,7 @@ namespace {
     const QString HINT_CHAT_ID("x-fernschreiber.chat_id");          // qlonglong
     const QString HINT_TOTAL_COUNT("x-fernschreiber.total_count");  // int
 
+    const QString HINT_IMAGE_PATH("image-path");                    // QString
     const QString HINT_VIBRA("x-nemo-vibrate");                     // bool
     const QString HINT_SUPPRESS_SOUND("suppress-sound");            // bool
     const QString HINT_DISPLAY_ON("x-nemo-display-on");             // bool
@@ -362,6 +363,7 @@ void NotificationManager::publishNotification(const NotificationGroup *notificat
     nemoNotification->setBody(notificationBody);
     nemoNotification->setSummary(summary);
     nemoNotification->setHintValue(HINT_VIBRA, needFeedback);
+    nemoNotification->setHintValue(HINT_IMAGE_PATH, QString());
 
     // Don't show popup for the currently open chat
     if (!needFeedback || (chatModel->getChatId() == notificationGroup->chatId &&


### PR DESCRIPTION
This stops home screen (on a really really really fresh build of Sailfish OS) from using app icon as a default:

![Screenshot_20210201_001](https://user-images.githubusercontent.com/5909522/106402598-e7800000-6432-11eb-85a2-d4441cbb3b49.png)

This `image-path` thing (or `image-data`) may actually be used at some point (e.g. for passing minithumbnail if it's available) but for now let's just pass an empty string, it doesn't cost much. The same icon all over the place just looks silly and eats up horizontal space.

With an empty `image-path` the second icon disappears:

![Screenshot_20210201_002](https://user-images.githubusercontent.com/5909522/106402841-472adb00-6434-11eb-8dd5-267d9dbedbed.png)