### PR TITLE
Improved chat message index handling

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -443,7 +443,6 @@ Page {
                 chatModel.initialize(chatInformation);
 
                 pageStack.pushAttached(Qt.resolvedUrl("ChatInformationPage.qml"), { "chatInformation" : chatInformation, "privateChatUserInformation": chatPartnerInformation, "groupInformation": chatGroupInformation, "chatOnlineMemberCount": chatOnlineMemberCount});
-                chatPage.isInitialized = true;
 
                 if(doSendBotStartMessage) {
                     tdLibWrapper.sendBotStartMessage(chatInformation.id, chatInformation.id, sendBotStartMessageParameter, "")
@@ -595,6 +594,9 @@ Page {
         onMessagesIncrementalUpdate: {
             Debug.log("Incremental update received. View now has ", chatView.count, " messages, view is on index ", modelIndex, ", own messages were read before index ", lastReadSentIndex);
             chatView.lastReadSentIndex = lastReadSentIndex;
+            if (!chatPage.isInitialized) {
+                chatView.scrollToIndex(modelIndex);
+            }
             chatViewCooldownTimer.restart();
         }
         onNotificationSettingsUpdated: {
@@ -925,6 +927,12 @@ Page {
                     onTriggered: {
                         Debug.log("[ChatPage] Cooldown completed...");
                         chatView.inCooldown = false;
+
+                        if (!chatPage.isInitialized) {
+                            Debug.log("Page is initialized!");
+                            chatPage.isInitialized = true;
+                            chatView.handleScrollPositionChanged();
+                        }
                     }
                 }
 

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -145,7 +145,7 @@ Page {
     function initializePage() {
         Debug.log("[ChatPage] Initializing chat page...");
         chatView.currentIndex = -1;
-        chatView.lastReadSentIndex = 0;
+        chatView.lastReadSentIndex = -1;
         var chatType = chatInformation.type['@type'];
         isPrivateChat = chatType === "chatTypePrivate";
         isSecretChat = chatType === "chatTypeSecret";
@@ -182,6 +182,7 @@ Page {
     }
 
     function getMessageStatusText(message, listItemIndex, lastReadSentIndex, useElapsed) {
+        Debug.log("Last read sent index: " + lastReadSentIndex);
         var messageStatusSuffix = "";
         if(!message) {
             return "";
@@ -597,6 +598,10 @@ Page {
             if (!chatPage.isInitialized) {
                 chatView.scrollToIndex(modelIndex);
             }
+            if (chatView.height > chatView.contentHeight) {
+                Debug.log("[ChatPage] Chat content quite small...");
+                viewMessageTimer.queueViewMessage(chatView.count - 1);
+            }
             chatViewCooldownTimer.restart();
         }
         onNotificationSettingsUpdated: {
@@ -800,7 +805,7 @@ Page {
 
                     Rectangle {
                         id: chatSecretBackground
-                        color: Theme.highlightBackgroundColor
+                        color: Theme.rgba(Theme.overlayBackgroundColor, Theme.opacityFaint)
                         width: chatPage.isPortrait ? Theme.fontSizeLarge : Theme.fontSizeMedium
                         height: width
                         anchors.left: parent.left
@@ -960,7 +965,7 @@ Page {
                     clip: true
                     highlightMoveDuration: 0
                     highlightResizeDuration: 0
-                    property int lastReadSentIndex: 0
+                    property int lastReadSentIndex: -1
                     property bool inCooldown: false
                     property bool manuallyScrolledToBottom
                     property QtObject precalculatedValues: QtObject {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -548,7 +548,7 @@ Page {
     Connections {
         target: chatModel
         onMessagesReceived: {
-            Debug.log("[ChatPage] Messages received, view has ", chatView.count, " messages, setting view to index ", modelIndex, ", own messages were read before index ", lastReadSentIndex);
+            Debug.log("[ChatPage] Messages received, view has ", chatView.count, " messages, last known message index ", modelIndex, ", own messages were read before index ", lastReadSentIndex);
             if (totalCount === 0) {
                 if (chatPage.iterativeInitialization) {
                     chatPage.iterativeInitialization = false;

--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -12,7 +12,7 @@ Name:       harbour-fernschreiber
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
 Version:    0.7
-Release:    1
+Release:    2
 Group:      Qt/Qt
 License:    LICENSE
 URL:        http://werkwolf.eu/

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -1,7 +1,7 @@
 Name: harbour-fernschreiber
 Summary: Fernschreiber is a Telegram client for Sailfish OS
 Version: 0.7
-Release: 1
+Release: 2
 # The contents of the Group field should be one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS
 Group: Qt/Qt

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -403,6 +403,7 @@ void ChatModel::handleMessagesReceived(const QVariantList &messages, int totalCo
         this->inReload = false;
         int listInboxPosition = this->calculateLastKnownMessageId();
         int listOutboxPosition = this->calculateLastReadSentMessageId();
+        listInboxPosition = this->calculateScrollPosition(listInboxPosition);
         if (this->inIncrementalUpdate) {
             this->inIncrementalUpdate = false;
             emit messagesIncrementalUpdate(listInboxPosition, listOutboxPosition);
@@ -443,6 +444,7 @@ void ChatModel::handleMessagesReceived(const QVariantList &messages, int totalCo
                 this->inReload = false;
                 int listInboxPosition = this->calculateLastKnownMessageId();
                 int listOutboxPosition = this->calculateLastReadSentMessageId();
+                listInboxPosition = this->calculateScrollPosition(listInboxPosition);
                 if (this->inIncrementalUpdate) {
                     this->inIncrementalUpdate = false;
                     emit messagesIncrementalUpdate(listInboxPosition, listOutboxPosition);
@@ -777,6 +779,16 @@ int ChatModel::calculateLastReadSentMessageId()
     const int listOutboxPosition = messageIndexMap.value(lastReadSentMessageId, messages.size() - 1);
     LOG("Last read sent message is at position" << listOutboxPosition);
     return listOutboxPosition;
+}
+
+int ChatModel::calculateScrollPosition(int listInboxPosition)
+{
+    LOG("Calculating new scroll position, current:" << listInboxPosition << ", list size:" << this->messages.size());
+    if ((this->messages.size() - 1) > listInboxPosition) {
+        return listInboxPosition + 1;
+    } else {
+        return listInboxPosition;
+    }
 }
 
 bool ChatModel::isMostRecentMessageLoaded()

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -755,12 +755,12 @@ int ChatModel::calculateLastKnownMessageId()
     LOG("contains last read ID?" << messageIndexMap.contains(lastKnownMessageId));
     LOG("contains last own ID?" << messageIndexMap.contains(lastOwnMessageId));
     int listInboxPosition = messageIndexMap.value(lastKnownMessageId, messages.size() - 1);
-    int listOwnPosition = messageIndexMap.value(lastOwnMessageId, messages.size() - 1);
+    int listOwnPosition = messageIndexMap.value(lastOwnMessageId, 0);
     if (listInboxPosition > this->messages.size() - 1 ) {
         listInboxPosition = this->messages.size() - 1;
     }
     if (listOwnPosition > this->messages.size() - 1 ) {
-        listOwnPosition = this->messages.size() - 1;
+        listOwnPosition = 0;
     }
     LOG("Last known message is at position" << listInboxPosition);
     LOG("Last own message is at position" << listOwnPosition);

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -757,12 +757,12 @@ int ChatModel::calculateLastKnownMessageId()
     LOG("contains last read ID?" << messageIndexMap.contains(lastKnownMessageId));
     LOG("contains last own ID?" << messageIndexMap.contains(lastOwnMessageId));
     int listInboxPosition = messageIndexMap.value(lastKnownMessageId, messages.size() - 1);
-    int listOwnPosition = messageIndexMap.value(lastOwnMessageId, 0);
+    int listOwnPosition = messageIndexMap.value(lastOwnMessageId, -1);
     if (listInboxPosition > this->messages.size() - 1 ) {
         listInboxPosition = this->messages.size() - 1;
     }
     if (listOwnPosition > this->messages.size() - 1 ) {
-        listOwnPosition = 0;
+        listOwnPosition = -1;
     }
     LOG("Last known message is at position" << listInboxPosition);
     LOG("Last own message is at position" << listOwnPosition);
@@ -776,8 +776,9 @@ int ChatModel::calculateLastReadSentMessageId()
     LOG("lastReadSentMessageId" << lastReadSentMessageId);
     LOG("size messageIndexMap" << messageIndexMap.size());
     LOG("contains ID?" << messageIndexMap.contains(lastReadSentMessageId));
-    const int listOutboxPosition = messageIndexMap.value(lastReadSentMessageId, messages.size() - 1);
+    const int listOutboxPosition = messageIndexMap.value(lastReadSentMessageId, -1);
     LOG("Last read sent message is at position" << listOutboxPosition);
+    emit lastReadSentMessageUpdated(listOutboxPosition);
     return listOutboxPosition;
 }
 

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -85,6 +85,7 @@ private:
     QVariantMap enhanceMessage(const QVariantMap &message);
     int calculateLastKnownMessageId();
     int calculateLastReadSentMessageId();
+    int calculateScrollPosition(int listInboxPosition);
     bool isMostRecentMessageLoaded();
 
 private:


### PR DESCRIPTION
This change tries to improve the chat message index handling, this one fixes #235, #243, #271 and #301 (hopefully):
The errors were:
- Unread count wasn't set to zero in case you sent out a new message without scrolling down to actually 'read' it actively (#235)
- Try to display the first unread message after opening a chat (#243)
- Own messages were marked as unread after receiving a new message (#271)
- Sent messages were marked as read though they haven't been read yet (#301)

Happy testing!