### PR TITLE
Fix click signal forwarding for extra content items

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -56,10 +56,7 @@ ListItem {
         } else {
             // Allow extra context to react to click
             var extraContent = extraContentLoader.item
-            if (extraContent && ("clicked" in extraContent) && (typeof extraContent.clicked === "function") &&
-                mouseX >= extraContentLoader.x && mouseY >= extraContentLoader.y &&
-                mouseX < (extraContentLoader.x + extraContentLoader.width) &&
-                mouseY < (extraContentLoader.y + extraContentLoader.height)) {
+            if (extraContent && extraContentLoader.contains(mapToItem(extraContentLoader, mouse.x, mouse.y))) {
                 extraContent.clicked()
             } else if (webPagePreviewLoader.item) {
                 webPagePreviewLoader.item.clicked()


### PR DESCRIPTION
From the dev chat in Telegram:
> I guess its an already known thing that: when trying to display full screen a picture only clicking left side of it opens it?

I think it wasn't. ;)