### PR TITLE
Use different badge colors for muted chats

### DIFF
--- a/qml/components/PhotoTextsListItem.qml
+++ b/qml/components/PhotoTextsListItem.qml
@@ -84,7 +84,7 @@ ListItem {
 
             Rectangle {
                 id: chatUnreadMessagesCountBackground
-                color: Theme.highlightBackgroundColor
+                color: isMuted ? ((Theme.colorScheme === Theme.DarkOnLight) ? "lightgray" : "dimgray") : Theme.highlightBackgroundColor
                 width: Theme.fontSizeLarge
                 height: Theme.fontSizeLarge
                 anchors.right: parent.right
@@ -100,6 +100,7 @@ ListItem {
                 color: Theme.primaryColor
                 anchors.centerIn: chatUnreadMessagesCountBackground
                 visible: chatListViewItem.unreadCount > 0
+                opacity: isMuted ? Theme.opacityHigh : 1.0
                 text: chatListViewItem.unreadCount > 99 ? "99+" : chatListViewItem.unreadCount
             }
         }


### PR DESCRIPTION
Unmuted:

![Screenshot_20210207_001](https://user-images.githubusercontent.com/5909522/107133005-bf8a1400-68ec-11eb-882f-bc7f83c27025.png)

![Screenshot_20210207_003](https://user-images.githubusercontent.com/5909522/107133010-c57ff500-68ec-11eb-8cd4-259d26f620c7.png)

Muted:

![Screenshot_20210207_002](https://user-images.githubusercontent.com/5909522/107133012-cadd3f80-68ec-11eb-9e06-9740368194e9.png)

![Screenshot_20210207_004](https://user-images.githubusercontent.com/5909522/107133014-cfa1f380-68ec-11eb-99da-8f6855075d41.png)

Linux desktop client is doing something like that too. What do you think?
