### PR TITLE
Hardcode line break in "unread messages"

### DIFF
--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -483,8 +483,10 @@
     <message numerus="yes">
         <source>unread messages</source>
         <translation>
-            <numerusform>unread message</numerusform>
-            <numerusform>unread messages</numerusform>
+            <numerusform>unread
+message</numerusform>
+            <numerusform>unread
+messages</numerusform>
         </translation>
     </message>
 </context>


### PR DESCRIPTION
To avoid cover layout change when number of unread messages goes 9 => 10:

![Screenshot_20210207_006](https://user-images.githubusercontent.com/5909522/107148825-0bc16c80-695e-11eb-9162-ca75719e27d1.png)
![Screenshot_20210207_005](https://user-images.githubusercontent.com/5909522/107148831-10862080-695e-11eb-8d51-cb44f6f19ec4.png)

I like it better when there's line break even with a single digit:

![Screenshot_20210207_007](https://user-images.githubusercontent.com/5909522/107148888-5347f880-695e-11eb-8e8d-d707f3c55e9a.png)

What do you think?