### PR TITLE
Redesign sticker picker, show sticker sets, install/remove sticker sets

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -64,6 +64,7 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/components/ReplyMarkupButtons.qml \
     qml/components/StickerPicker.qml \
     qml/components/PhotoTextsListItem.qml \
+    qml/components/StickerSetOverlay.qml \
     qml/components/TDLibImage.qml \
     qml/components/TDLibMinithumbnail.qml \
     qml/components/TDLibPhoto.qml \

--- a/qml/components/StickerPicker.qml
+++ b/qml/components/StickerPicker.qml
@@ -142,7 +142,7 @@ Item {
 
                         TDLibThumbnail {
                             id: stickerSetThumbnail
-                            thumbnail: modelData.thumbnail
+                            thumbnail: modelData.thumbnail ? modelData.thumbnail : modelData.stickers[0].thumbnail
                             anchors.verticalCenter: parent.verticalCenter
                             width: Theme.itemSizeMedium
                             height: Theme.itemSizeMedium

--- a/qml/components/StickerSetOverlay.qml
+++ b/qml/components/StickerSetOverlay.qml
@@ -1,0 +1,170 @@
+/*
+    Copyright (C) 2020-21 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import "./messageContent"
+import "../js/functions.js" as Functions
+import "../js/twemoji.js" as Emoji
+import "../js/debug.js" as Debug
+
+Flickable {
+    id: stickerSetOverlayFlickable
+    anchors.fill: parent
+    boundsBehavior: Flickable.StopAtBounds
+    contentHeight: stickerSetContentColumn.height
+    clip: true
+
+    property string stickerSetId;
+    property var stickerSet;
+    property bool setLoaded: false;
+    signal requestClose;
+
+    Component.onCompleted: {
+        if (!stickerManager.hasStickerSet(stickerSetId)) {
+            tdLibWrapper.getStickerSet(stickerSetId);
+        } else {
+            stickerSet = stickerManager.getStickerSet(stickerSetId);
+        }
+    }
+
+    Connections {
+        target: tdLibWrapper
+        onStickerSetReceived: {
+            if (stickerSet.id === stickerSetOverlayFlickable.stickerSetId) {
+                stickerSetOverlayFlickable.stickerSet = stickerSet;
+            }
+        }
+    }
+
+    Timer {
+        id: stickerSetLoadedTimer
+        interval: 100
+        running: true
+        repeat: false
+        onTriggered: {
+            stickerSetOverlayFlickable.setLoaded = true;
+        }
+    }
+
+    Rectangle {
+        id: stickerSetContentBackground
+        color: Theme.overlayBackgroundColor
+        opacity: 0.7
+        anchors.fill: parent
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                stickerSetOverlayFlickable.requestClose();
+            }
+        }
+    }
+
+    Column {
+        id: stickerSetContentColumn
+        spacing: Theme.paddingMedium
+        width: parent.width
+        height: parent.height
+
+        Row {
+            id: stickerSetTitleRow
+            width: parent.width - ( 2 * Theme.horizontalPageMargin )
+            height: overlayStickerTitleText.height + ( 2 * Theme.paddingMedium )
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            Label {
+                id: overlayStickerTitleText
+
+                width: parent.width - ( installSetButton.visible ? installSetButton.width : 0 ) - closeSetButton.width
+                text: stickerSet.title
+                font.pixelSize: Theme.fontSizeExtraLarge
+                font.weight: Font.ExtraBold
+                maximumLineCount: 1
+                truncationMode: TruncationMode.Fade
+                textFormat: Text.StyledText
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            IconButton {
+                id: installSetButton
+                icon.source: "image://theme/icon-m-add"
+                anchors.verticalCenter: parent.verticalCenter
+                visible: !stickerSet.is_installed
+                onClicked: {
+                    tdLibWrapper.changeStickerSet(stickerSet.id, true);
+                }
+            }
+
+            IconButton {
+                id: closeSetButton
+                icon.source: "image://theme/icon-m-clear"
+                anchors.verticalCenter: parent.verticalCenter
+                onClicked: {
+                    stickerSetOverlayFlickable.requestClose();
+                }
+            }
+        }
+
+        SilicaGridView {
+            id: stickerSetGridView
+
+            width: parent.width - ( 2 * Theme.horizontalPageMargin )
+            height: parent.height - stickerSetTitleRow.height - Theme.paddingMedium
+            anchors.horizontalCenter: parent.horizontalCenter
+
+            cellWidth: chatPage.isLandscape ? (width / 5) : (width / 3);
+            cellHeight: cellWidth
+
+            visible: count > 0
+
+            clip: true
+
+            model: stickerSet.stickers
+            delegate: Item {
+                width: stickerSetGridView.cellWidth - Theme.paddingSmall
+                height: stickerSetGridView.cellHeight - Theme.paddingSmall
+
+                Image {
+                    id: singleStickerImage
+                    source: modelData.thumbnail.file.local.is_downloading_completed ? modelData.thumbnail.file.local.path : ""
+                    anchors.fill: parent
+                    visible: modelData.thumbnail.file.local.is_downloading_completed
+                    asynchronous: true
+                    onStatusChanged: {
+                        if (status === Image.Ready) {
+                            stickerSetLoadedTimer.restart();
+                        }
+                    }
+                }
+                Label {
+                    font.pixelSize: Theme.fontSizeHuge
+                    anchors.fill: parent
+                    maximumLineCount: 1
+                    truncationMode: TruncationMode.Fade
+                    text: Emoji.emojify(modelData.emoji, font.pixelSize)
+                    visible: !modelData.thumbnail.file.local.is_downloading_completed
+                }
+
+            }
+
+            VerticalScrollDecorator {}
+        }
+
+    }
+
+}

--- a/qml/components/messageContent/MessageSticker.qml
+++ b/qml/components/messageContent/MessageSticker.qml
@@ -1,5 +1,5 @@
 /*
-    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+    Copyright (C) 2020-21 Sebastian J. Wolf and other contributors
 
     This file is part of Fernschreiber.
 
@@ -95,6 +95,14 @@ MessageContentBase {
             active: opacity > 0
             opacity: !stickerVisible && !placeHolderDelayTimer.running ? 0.15 : 0
             Behavior on opacity { FadeAnimation {} }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                stickerSetOverlayLoader.stickerSetId = stickerData.set_id;
+                stickerSetOverlayLoader.active = true;
+            }
         }
     }
 

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -699,7 +699,7 @@ Page {
         contentWidth: width
 
         PullDownMenu {
-            visible: chatInformation.id !== chatPage.myUserId && !stickerPickerLoader.active && !voiceNoteOverlayLoader.active && !messageOverlayLoader.active
+            visible: chatInformation.id !== chatPage.myUserId && !stickerPickerLoader.active && !voiceNoteOverlayLoader.active && !messageOverlayLoader.active && !stickerSetOverlayLoader.active
             MenuItem {
                 id: closeSecretChatMenuItem
                 visible: chatPage.isSecretChat && chatPage.secretChatDetails.state["@type"] !== "secretChatStateClosed"
@@ -958,7 +958,7 @@ Page {
                     id: chatView
 
                     visible: !blurred
-                    property bool blurred: messageOverlayLoader.item || stickerPickerLoader.item || voiceNoteOverlayLoader.item || inlineQuery.hasOverlay
+                    property bool blurred: messageOverlayLoader.item || stickerPickerLoader.item || voiceNoteOverlayLoader.item || inlineQuery.hasOverlay || stickerSetOverlayLoader.item
 
                     anchors.fill: parent
                     opacity: chatPage.loading ? 0 : 1
@@ -1304,6 +1304,9 @@ Page {
                     }
 
                     onActiveChanged: {
+                        if (active) {
+                            attachmentOptionsFlickable.isNeeded = false;
+                        }
                     }
                 }
 
@@ -1773,7 +1776,7 @@ Page {
                         icon.source: "image://theme/icon-m-attach?" +  (attachmentOptionsFlickable.isNeeded ? Theme.highlightColor : Theme.primaryColor)
                         anchors.bottom: parent.bottom
                         anchors.bottomMargin: Theme.paddingSmall
-                        enabled: !attachmentPreviewRow.visible
+                        enabled: !attachmentPreviewRow.visible && !stickerSetOverlayLoader.item
                         visible: !inlineQuery.userNameIsValid
                         onClicked: {
                             if (attachmentOptionsFlickable.isNeeded) {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1285,6 +1285,28 @@ Page {
                     }
                 }
 
+                Loader {
+                    id: stickerSetOverlayLoader
+
+                    property string stickerSetId;
+
+                    active: false
+                    asynchronous: true
+                    width: parent.width
+                    height: active ? parent.height : 0
+                    sourceComponent: Component {
+                        StickerSetOverlay {
+                            stickerSetId: stickerSetOverlayLoader.stickerSetId
+                            onRequestClose: {
+                                stickerSetOverlayLoader.active = false;
+                            }
+                        }
+                    }
+
+                    onActiveChanged: {
+                    }
+                }
+
                 InlineQuery {
                     id: inlineQuery
                     textField: newMessageTextField

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1245,9 +1245,11 @@ Page {
                     target: stickerPickerLoader.item
                     onStickerPicked: {
                         Debug.log("Sticker picked: " + stickerId);
-                        tdLibWrapper.sendStickerMessage(chatInformation.id, stickerId);
+                        tdLibWrapper.sendStickerMessage(chatInformation.id, stickerId, newMessageColumn.replyToMessageId);
                         stickerPickerLoader.active = false;
                         attachmentOptionsFlickable.isNeeded = false;
+                        newMessageInReplyToRow.inReplyToMessage = null;
+                        newMessageColumn.editMessageId = "0";
                     }
                 }
 

--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -12,7 +12,7 @@ Name:       harbour-fernschreiber
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
 Version:    0.7.1
-Release:    1
+Release:    2
 Group:      Qt/Qt
 License:    LICENSE
 URL:        http://werkwolf.eu/

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -1,7 +1,7 @@
 Name: harbour-fernschreiber
 Summary: Fernschreiber is a Telegram client for Sailfish OS
 Version: 0.7.1
-Release: 1
+Release: 2
 # The contents of the Group field should be one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS
 Group: Qt/Qt

--- a/src/stickermanager.cpp
+++ b/src/stickermanager.cpp
@@ -129,7 +129,7 @@ void StickerManager::handleStickerSetsReceived(const QVariantList &stickerSets)
     this->stickerSetMap.clear();
     while (stickerSetIdIterator.hasNext()) {
         QString stickerSetId = stickerSetIdIterator.next().toString();
-        if (this->installedStickerSetIds.contains(stickerSetId)) {
+        if (this->stickerSets.contains(stickerSetId)) {
             this->installedStickerSets.append(this->stickerSets.value(stickerSetId));
             this->stickerSetMap.insert(stickerSetId, i);
             i++;

--- a/src/stickermanager.cpp
+++ b/src/stickermanager.cpp
@@ -60,6 +60,11 @@ bool StickerManager::hasStickerSet(const QString &stickerSetId)
     return this->stickerSets.contains(stickerSetId);
 }
 
+bool StickerManager::isStickerSetInstalled(const QString &stickerSetId)
+{
+    return this->installedStickerSetIds.contains(stickerSetId);
+}
+
 bool StickerManager::needsReload()
 {
     return this->reloadNeeded;
@@ -105,7 +110,15 @@ void StickerManager::handleStickerSetsReceived(const QVariantList &stickerSets)
     QListIterator<QVariant> stickerSetsIterator(stickerSets);
     while (stickerSetsIterator.hasNext()) {
         QVariantMap newStickerSet = stickerSetsIterator.next().toMap();
-        this->stickerSets.insert(newStickerSet.value("id").toString(), newStickerSet);
+        QString newSetId = newStickerSet.value("id").toString();
+        bool isInstalled = newStickerSet.value("is_installed").toBool();
+        if (isInstalled && !this->installedStickerSetIds.contains(newSetId)) {
+            this->installedStickerSetIds.append(newSetId);
+        }
+        if (!isInstalled && this->installedStickerSetIds.contains(newSetId)) {
+            this->installedStickerSetIds.removeAll(newSetId);
+        }
+        this->stickerSets.insert(newSetId, newStickerSet);
     }
 
     this->installedStickerSets.clear();

--- a/src/stickermanager.cpp
+++ b/src/stickermanager.cpp
@@ -118,7 +118,9 @@ void StickerManager::handleStickerSetsReceived(const QVariantList &stickerSets)
         if (!isInstalled && this->installedStickerSetIds.contains(newSetId)) {
             this->installedStickerSetIds.removeAll(newSetId);
         }
-        this->stickerSets.insert(newSetId, newStickerSet);
+        if (!this->stickerSets.contains(newSetId)) {
+            this->stickerSets.insert(newSetId, newStickerSet);
+        }
     }
 
     this->installedStickerSets.clear();
@@ -133,6 +135,7 @@ void StickerManager::handleStickerSetsReceived(const QVariantList &stickerSets)
             i++;
         }
     }
+    emit stickerSetsReceived();
 }
 
 void StickerManager::handleStickerSetReceived(const QVariantMap &stickerSet)

--- a/src/stickermanager.h
+++ b/src/stickermanager.h
@@ -42,6 +42,7 @@ public:
     Q_INVOKABLE void setNeedsReload(const bool &reloadNeeded);
 
 signals:
+    void stickerSetsReceived();
 
 private slots:
 

--- a/src/stickermanager.h
+++ b/src/stickermanager.h
@@ -35,6 +35,8 @@ public:
 
     Q_INVOKABLE QVariantList getRecentStickers();
     Q_INVOKABLE QVariantList getInstalledStickerSets();
+    Q_INVOKABLE QVariantMap getStickerSet(const QString &stickerSetId);
+    Q_INVOKABLE bool hasStickerSet(const QString &stickerSetId);
     Q_INVOKABLE bool needsReload();
     Q_INVOKABLE void setNeedsReload(const bool &reloadNeeded);
 

--- a/src/stickermanager.h
+++ b/src/stickermanager.h
@@ -37,6 +37,7 @@ public:
     Q_INVOKABLE QVariantList getInstalledStickerSets();
     Q_INVOKABLE QVariantMap getStickerSet(const QString &stickerSetId);
     Q_INVOKABLE bool hasStickerSet(const QString &stickerSetId);
+    Q_INVOKABLE bool isStickerSetInstalled(const QString &stickerSetId);
     Q_INVOKABLE bool needsReload();
     Q_INVOKABLE void setNeedsReload(const bool &reloadNeeded);
 

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -1326,6 +1326,18 @@ void TDLibWrapper::deleteProfilePhoto(const QString &profilePhotoId)
     this->sendRequest(requestObject);
 }
 
+void TDLibWrapper::changeStickerSet(const QString &stickerSetId, bool isInstalled)
+{
+    LOG("Change sticker set" << stickerSetId << isInstalled);
+
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "changeStickerSet");
+    requestObject.insert("set_id", stickerSetId);
+    requestObject.insert("is_installed", isInstalled);
+
+    this->sendRequest(requestObject);
+}
+
 void TDLibWrapper::searchEmoji(const QString &queryString)
 {
     LOG("Searching emoji" << queryString);

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -1332,6 +1332,7 @@ void TDLibWrapper::changeStickerSet(const QString &stickerSetId, bool isInstalle
 
     QVariantMap requestObject;
     requestObject.insert(_TYPE, "changeStickerSet");
+    requestObject.insert(_EXTRA, isInstalled ? "installStickerSet" : "removeStickerSet");
     requestObject.insert("set_id", stickerSetId);
     requestObject.insert("is_installed", isInstalled);
 

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -221,6 +221,7 @@ public:
     Q_INVOKABLE void getUserPrivacySettingRules(UserPrivacySetting setting);
     Q_INVOKABLE void setProfilePhoto(const QString &filePath);
     Q_INVOKABLE void deleteProfilePhoto(const QString &profilePhotoId);
+    Q_INVOKABLE void changeStickerSet(const QString &stickerSetId, bool isInstalled);
 
     // Others (candidates for extraction ;))
     Q_INVOKABLE void searchEmoji(const QString &queryString);

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -1666,8 +1666,23 @@
         <translation>Kürzlich verwendet</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Lade Sticker...</translation>
+        <source>Removing sticker set</source>
+        <translation>Entferne Sticker-Set</translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation>Sticker-Set erfolgreich entfernt!</translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation>Sticker-Set erfolgreich installiert!</translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation>Sticker-Set erfolgreich entfernt!</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -1668,8 +1668,23 @@ messages</numerusform>
         <translation>Recently used</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Loading stickers...</translation>
+        <source>Removing sticker set</source>
+        <translation>Removing sticker set</translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation>Sticker set successfully removed!</translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation>Sticker set successfully installed!</translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation>Sticker set successfully removed!</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -1666,8 +1666,23 @@
         <translation>Usado recientemente</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Cargando pegatinas...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -1667,8 +1667,23 @@
         <translation>Viimeksi käytetty</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Ladataan tarroja...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -1639,7 +1639,22 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -1666,8 +1666,23 @@
         <translation>Usati di recente</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Carica sticker...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -1693,8 +1693,23 @@
         <translation>Ostatnio użyty</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Ładowanie naklejek...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -1696,8 +1696,23 @@
         <translation>Недавно использованные</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Загрузка стикеров...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -1693,8 +1693,23 @@
         <translation>Nedávno použité</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Načítanie nálepiek...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -1666,8 +1666,23 @@
         <translation>Nyligen använt</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Läser in dekaler...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -1640,8 +1640,23 @@
         <translation>最近使用</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>正在加载表情贴图…</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -1666,8 +1666,23 @@
         <translation>Recently used</translation>
     </message>
     <message>
-        <source>Loading stickers...</source>
-        <translation>Loading stickers...</translation>
+        <source>Removing sticker set</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>StickerSetOverlay</name>
+    <message>
+        <source>Sticker set successfully installed!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Sticker set successfully removed!</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Just an attempt to redesign the sticker picker page and to add some minor new features with respect to stickers:
- Sticker picker now displays immediately, this fixes #286 
- But: Only the set's preview image is shown, all stickers of a set can be expanded by tapping on the title of the sticker set
- Sticker picker now offers to remove a set
- If you tap on a sticker, an overlay is shown with all stickers of the respective set. Moreover, you can install or remove a sticker set from there
- Stickers can now also be sent as replies