### PR TITLE
Introduce message options drawer

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -43,8 +43,9 @@ ListItem {
     });
     readonly property bool isOwnMessage: page.myUserId === myMessage.sender.user_id
     property bool hasContentComponent
+    property bool additionalOptionsOpened
 
-    highlighted: (down || isSelected) && !menuOpen
+    highlighted: (down || isSelected || additionalOptionsOpened) && !menuOpen
     openMenuOnPressAndHold: !messageListItem.precalculatedValues.pageIsSelecting
 
     signal replyToMessage()
@@ -81,7 +82,7 @@ ListItem {
     Connections {
         target: messageOptionsDrawer
         onCloseRequested: {
-            messageListItem.highlighted = false;
+            messageListItem.additionalOptionsOpened = false;
         }
     }
 
@@ -119,7 +120,7 @@ ListItem {
                         messageOptionsDrawer.userInformation = userInformation;
                         messageOptionsDrawer.sourceItem = messageListItem
                         messageOptionsDrawer.additionalItemsModel = (extraContentLoader.item && ("extraContextMenuItems" in extraContentLoader.item)) ? extraContentLoader.item.extraContextMenuItems : 0;
-                        messageListItem.highlighted = true;
+                        messageListItem.additionalOptionsOpened = true;
                         messageOptionsDrawer.open = true;
                     }
                     text: qsTr("More Options...")

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -78,6 +78,13 @@ ListItem {
         chatView.manuallyScrolledToBottom = false;
     }
 
+    Connections {
+        target: messageOptionsDrawer
+        onCloseRequested: {
+            messageListItem.highlighted = false;
+        }
+    }
+
     Loader {
         id: contextMenuLoader
         active: false
@@ -112,15 +119,18 @@ ListItem {
                 }
                 MenuItem {
                     onClicked: {
-                        Clipboard.text = Functions.getMessageText(myMessage, true, userInformation.id, true);
-                    }
-                    text: qsTr("Copy Message to Clipboard")
-                }
-                MenuItem {
-                    onClicked: {
                         page.toggleMessageSelection(myMessage);
                     }
                     text: qsTr("Select Message")
+                }
+                MenuItem {
+                    onClicked: {
+                        messageOptionsDrawer.myMessage = myMessage;
+                        messageOptionsDrawer.userInformation = userInformation;
+                        messageListItem.highlighted = true;
+                        messageOptionsDrawer.open = true;
+                    }
+                    text: qsTr("More Options...")
                 }
                 MenuItem {
                     onClicked: {

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -97,16 +97,6 @@ ListItem {
         }
         sourceComponent: Component {
             ContextMenu {
-                Repeater {
-                    model: (extraContentLoader.item && ("extraContextMenuItems" in extraContentLoader.item)) ?
-                        extraContentLoader.item.extraContextMenuItems : 0
-                    delegate: MenuItem {
-                        visible: modelData.visible
-                        text: modelData.name
-                        onClicked: modelData.action()
-                    }
-                }
-
                 MenuItem {
                     visible: messageListItem.canReplyToMessage
                     onClicked: messageListItem.replyToMessage()
@@ -127,31 +117,12 @@ ListItem {
                     onClicked: {
                         messageOptionsDrawer.myMessage = myMessage;
                         messageOptionsDrawer.userInformation = userInformation;
+                        messageOptionsDrawer.sourceItem = messageListItem
+                        messageOptionsDrawer.additionalItemsModel = (extraContentLoader.item && ("extraContextMenuItems" in extraContentLoader.item)) ? extraContentLoader.item.extraContextMenuItems : 0;
                         messageListItem.highlighted = true;
                         messageOptionsDrawer.open = true;
                     }
                     text: qsTr("More Options...")
-                }
-                MenuItem {
-                    onClicked: {
-                        if (myMessage.is_pinned) {
-                            Remorse.popupAction(page, qsTr("Message unpinned"), function() { tdLibWrapper.unpinMessage(page.chatInformation.id, messageId);
-                                                                                             pinnedMessageItem.requestCloseMessage(); } );
-                        } else {
-                            tdLibWrapper.pinMessage(page.chatInformation.id, messageId);
-                        }
-                    }
-                    text: myMessage.is_pinned ? qsTr("Unpin Message") : qsTr("Pin Message")
-                    visible: canPinMessages()
-                }
-                MenuItem {
-                    onClicked: {
-                        var chatId = page.chatInformation.id;
-                        var messageId = messageListItem.messageId;
-                        Remorse.itemAction(messageListItem, qsTr("Message deleted"), function() { tdLibWrapper.deleteMessages(chatId, [ messageId]);  })
-                    }
-                    text: qsTr("Delete Message")
-                    visible: myMessage.can_be_deleted_for_all_users || (myMessage.can_be_deleted_only_for_self && myMessage.chat_id === page.myUserId)
                 }
             }
         }

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -335,6 +335,18 @@ Page {
 
     }
 
+    function startForwardingMessages(messages) {
+        var ids = Functions.getMessagesArrayIds(messages);
+        var neededPermissions = Functions.getMessagesNeededForwardPermissions(messages);
+        var chatId = chatInformation.id;
+        pageStack.push(Qt.resolvedUrl("../pages/ChatSelectionPage.qml"), {
+            myUserId: chatPage.myUserId,
+            headerDescription: qsTr("Forward %Ln messages", "dialog header", ids.length),
+            payload: {fromChatId: chatId, messageIds:ids, neededPermissions: neededPermissions},
+            state: "forwardMessages"
+        });
+    }
+
     function forwardMessages(fromChatId, messageIds) {
         forwardMessagesTimer.fromChatId = fromChatId;
         forwardMessagesTimer.messageIds = messageIds;
@@ -696,6 +708,14 @@ Page {
                 visible: true
                 name: qsTr("Copy Message to Clipboard")
                 action: function () { Clipboard.text = Functions.getMessageText(messageOptionsDrawer.myMessage, true, messageOptionsDrawer.userInformation.id, true); }
+            },
+            NamedAction {
+                visible: messageOptionsDrawer.myMessage.can_be_forwarded
+                name: qsTr("Forward Message")
+                action: function () {
+                    var messagesToForward = [ messageOptionsDrawer.myMessage ];
+                    startForwardingMessages(messagesToForward);
+                }
             },
             NamedAction {
                 visible: canPinMessages()
@@ -2029,15 +2049,7 @@ Page {
                         icon.sourceSize: Qt.size(Theme.iconSizeMedium, Theme.iconSizeMedium)
                         icon.source: "image://theme/icon-m-forward"
                         onClicked: {
-                            var ids = Functions.getMessagesArrayIds(chatPage.selectedMessages)
-                            var neededPermissions = Functions.getMessagesNeededForwardPermissions(chatPage.selectedMessages)
-                            var chatId = chatInformation.id
-                            pageStack.push(Qt.resolvedUrl("../pages/ChatSelectionPage.qml"), {
-                                myUserId: chatPage.myUserId,
-                                headerDescription: qsTr("Forward %Ln messages", "dialog header", ids.length),
-                                payload: {fromChatId: chatId, messageIds:ids, neededPermissions: neededPermissions},
-                                state: "forwardMessages"
-                            })
+                            startForwardingMessages(chatPage.selectedMessages);
                         }
 
                     }

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -698,7 +698,7 @@ Page {
 
         anchors.fill: parent
         dock: chatPage.isPortrait ? Dock.Bottom : Dock.Right
-        backgroundSize: dock == Dock.Left || dock == Dock.Right ? width / 2 : height / 3
+        backgroundSize: chatPage.isPortrait ? height / 3 : width / 2
 
         background: Column {
             anchors.fill: parent

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -681,1081 +681,1213 @@ Page {
         }
     }
 
-    SilicaFlickable {
-        id: chatContainer
+    Drawer {
+        id: messageOptionsDrawer
 
-        onContentYChanged: {
-            // For some strange reason contentY sometimes is > 0 which doesn't make sense without a PushUpMenu (?)
-            // That leads to the problem that the whole flickable is moved slightly (or sometimes considerably) up
-            // which creates UX issues... As a workaround we are setting it to 0 in such cases.
-            // Better solutions are highly appreciated, contributions always welcome! ;)
-            if (contentY > 0) {
-                contentY = 0;
-            }
-        }
+        property var myMessage: ({})
+        property var userInformation: ({})
+
+        signal closeRequested();
 
         anchors.fill: parent
-        contentHeight: height
-        contentWidth: width
+        dock: chatPage.isPortrait ? Dock.Top : Dock.Right
 
-        PullDownMenu {
-            visible: chatInformation.id !== chatPage.myUserId && !stickerPickerLoader.active && !voiceNoteOverlayLoader.active && !messageOverlayLoader.active && !stickerSetOverlayLoader.active
-            MenuItem {
-                id: closeSecretChatMenuItem
-                visible: chatPage.isSecretChat && chatPage.secretChatDetails.state["@type"] !== "secretChatStateClosed"
-                onClicked: {
-                    var secretChatId = chatPage.secretChatDetails.id;
-                    Remorse.popupAction(chatPage, qsTr("Closing chat"), function() { tdLibWrapper.closeSecretChat(secretChatId) });
-                }
-                text: qsTr("Close Chat")
-            }
-
-            MenuItem {
-                id: joinLeaveChatMenuItem
-                visible: (chatPage.isSuperGroup || chatPage.isBasicGroup) && chatGroupInformation && chatGroupInformation.status["@type"] !== "chatMemberStatusBanned"
-                onClicked: {
-                    if (chatPage.userIsMember) {
-                        var chatId = chatInformation.id;
-                        Remorse.popupAction(chatPage, qsTr("Leaving chat"), function() {
-                            tdLibWrapper.leaveChat(chatId);
-                            // this does not care about the response (ideally type "ok" without further reference) for now
-                            pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ));
-                        });
-                    } else {
-                        tdLibWrapper.joinChat(chatInformation.id);
+        background: SilicaListView {
+            anchors.fill: parent
+            model: ListModel {
+                id: myListModel
+                property var actions: {
+                    "copyToClipboard": function() { Clipboard.text = Functions.getMessageText(messageOptionsDrawer.myMessage, true, messageOptionsDrawer.userInformation.id, true) },
+                    "pinMessage": function() {
+                        if (messageOptionsDrawer.myMessage.is_pinned) {
+                            Remorse.popupAction(page, qsTr("Message unpinned"), function() { tdLibWrapper.unpinMessage(chatPage.chatInformation.id, messageOptionsDrawer.myMessage.id);
+                                                                                             pinnedMessageItem.requestCloseMessage(); } );
+                        } else {
+                            tdLibWrapper.pinMessage(chatPage.chatInformation.id, messageOptionsDrawer.myMessage.id);
+                        }
                     }
                 }
-                text: chatPage.userIsMember ? qsTr("Leave Chat") : qsTr("Join Chat")
-            }
-
-            MenuItem {
-                id: muteChatMenuItem
-                visible: chatPage.userIsMember
-                onClicked: {
-                    var newNotificationSettings = chatInformation.notification_settings;
-                    if (newNotificationSettings.mute_for > 0) {
-                        newNotificationSettings.mute_for = 0;
-                    } else {
-                        newNotificationSettings.mute_for = 6666666;
-                    }
-                    newNotificationSettings.use_default_mute_for = false;
-                    tdLibWrapper.setChatNotificationSettings(chatInformation.id, newNotificationSettings);
+                property var conditions: {
+                    "copyToClipboard": function() { return true; },
+                    "pinMessage": function() { return canPinMessages(); }
                 }
-                text: chatInformation.notification_settings.mute_for > 0 ? qsTr("Unmute Chat") : qsTr("Mute Chat")
-            }
 
-            MenuItem {
-                id: searchInChatMenuItem
-                visible: !chatPage.isSecretChat && chatOverviewItem.visible
-                onClicked: {
-                    // This automatically shows the search field as well
-                    chatOverviewItem.visible = false;
-                    searchInChatField.focus = true;
+                property var texts: {
+                    "copyToClipboard": function() { return qsTr("Copy Message to Clipboard"); },
+                    "pinMessage": function() { return messageOptionsDrawer.myMessage.is_pinned ? qsTr("Unpin Message") : qsTr("Pin Message"); }
                 }
-                text: qsTr("Search in Chat")
-            }
-        }
 
-        BackgroundItem {
-            id: headerMouseArea
-            height: headerRow.height
-            width: parent.width
-            onClicked: {
-                if (chatPage.isSelecting) {
-                    chatPage.selectedMessages = [];
-                } else {
-                    pageStack.navigateForward();
+                ListElement {
+                    elementActionName: "copyToClipboard"
+                }
+
+                ListElement {
+                    elementActionName: "pinMessage"
                 }
             }
-        }
 
-        Column {
-            id: chatColumn
-            width: parent.width
-            height: parent.height
-
-            Row {
-                id: headerRow
-                width: parent.width - (3 * Theme.horizontalPageMargin)
-                height: chatOverviewItem.height + ( chatPage.isPortrait ? (2 * Theme.paddingMedium) : (2 * Theme.paddingSmall) )
+            header: Row {
+                width: parent.width - ( 4 * Theme.horizontalPageMargin)
+                height: messageOptionsLabel.height + Theme.paddingLarge + ( chatPage.isPortrait ? ( 2 * Theme.paddingSmall ) : 0 )
                 anchors.horizontalCenter: parent.horizontalCenter
                 spacing: Theme.paddingMedium
-
-                Item {
-                    width: chatOverviewItem.height
-                    height: chatOverviewItem.height
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: chatPage.isPortrait ? Theme.paddingMedium : Theme.paddingSmall
-
-                    ProfileThumbnail {
-                        id: chatPictureThumbnail
-                        replacementStringHint: chatNameText.text
-                        width: parent.height
-                        height: parent.height
-
-                        // Setting it directly may cause an stale state for the thumbnail in case the chat page
-                        // was previously loaded with a picture and now it doesn't have one. Instead setting it
-                        // when the ChatModel indicates a change. This also avoids flickering when the page is loaded...
-                        Connections {
-                            target: chatModel
-                            onSmallPhotoChanged: {
-                                chatPictureThumbnail.photoData = chatModel.smallPhoto;
-                            }
-                        }
-                    }
-
-                    Rectangle {
-                        id: chatSecretBackground
-                        color: Theme.rgba(Theme.overlayBackgroundColor, Theme.opacityFaint)
-                        width: chatPage.isPortrait ? Theme.fontSizeLarge : Theme.fontSizeMedium
-                        height: width
-                        anchors.left: parent.left
-                        anchors.bottom: parent.bottom
-                        radius: parent.width / 2
-                        visible: chatPage.isSecretChat
-                    }
-
-                    Image {
-                        source: "image://theme/icon-s-secure"
-                        width: chatPage.isPortrait ? Theme.fontSizeSmall : Theme.fontSizeExtraSmall
-                        height: width
-                        anchors.centerIn: chatSecretBackground
-                        visible: chatPage.isSecretChat
-                    }
-
-                }
-
-                Item {
-                    id: chatOverviewItem
-                    opacity: visible ? 1 : 0
-                    Behavior on opacity { FadeAnimation {} }
-                    width: parent.width - chatPictureThumbnail.width - Theme.paddingMedium
-                    height: chatNameText.height + chatStatusText.height
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: chatPage.isPortrait ? Theme.paddingMedium : Theme.paddingSmall
-                    Label {
-                        id: chatNameText
-                        width: Math.min(implicitWidth, parent.width)
-                        anchors.right: parent.right
-                        text: chatInformation.title !== "" ? Emoji.emojify(chatInformation.title, font.pixelSize) : qsTr("Unknown")
-                        textFormat: Text.StyledText
-                        font.pixelSize: chatPage.isPortrait ? Theme.fontSizeLarge : Theme.fontSizeMedium
-                        font.family: Theme.fontFamilyHeading
-                        color: Theme.highlightColor
-                        truncationMode: TruncationMode.Fade
-                        maximumLineCount: 1
-                    }
-                    Label {
-                        id: chatStatusText
-                        width: Math.min(implicitWidth, parent.width)
-                        anchors {
-                            right: parent.right
-                            bottom: parent.bottom
-                        }
-                        text: ""
-                        textFormat: Text.StyledText
-                        font.pixelSize: chatPage.isPortrait ? Theme.fontSizeExtraSmall : Theme.fontSizeTiny
-                        font.family: Theme.fontFamilyHeading
-                        color: headerMouseArea.pressed ? Theme.secondaryHighlightColor : Theme.secondaryColor
-                        truncationMode: TruncationMode.Fade
-                        maximumLineCount: 1
-                    }
-                }
-
-                Item {
-                    id: searchInChatItem
-                    visible: !chatOverviewItem.visible
-                    opacity: visible ? 1 : 0
-                    Behavior on opacity { FadeAnimation {} }
-                    width: parent.width - chatPictureThumbnail.width - Theme.paddingMedium
-                    height: searchInChatField.height
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: chatPage.isPortrait ? Theme.paddingSmall : 0
-
-                    SearchField {
-                        id: searchInChatField
-                        visible: false
-                        width: visible ? parent.width : 0
-                        placeholderText: qsTr("Search in chat...")
-                        active: searchInChatItem.visible
-                        canHide: text === ""
-
-                        onTextChanged: {
-                            searchInChatTimer.restart();
-                        }
-
-                        onHideClicked: {
-                            resetFocus();
-                        }
-
-                        EnterKey.iconSource: "image://theme/icon-m-enter-close"
-                        EnterKey.onClicked: {
-                            resetFocus();
-                        }
-                    }
-                }
-            }
-
-            PinnedMessageItem {
-                id: pinnedMessageItem
-                onRequestShowMessage: {
-                    messageOverlayLoader.overlayMessage = pinnedMessageItem.pinnedMessage;
-                    messageOverlayLoader.active = true;
-                }
-                onRequestCloseMessage: {
-                    messageOverlayLoader.overlayMessage = undefined;
-                    messageOverlayLoader.active = false;
-                }
-            }
-
-            Item {
-                id: chatViewItem
-                width: parent.width
-                height: parent.height - headerRow.height - pinnedMessageItem.height - newMessageColumn.height - selectedMessagesActions.height
-
-                property int previousHeight;
-
-                Component.onCompleted: {
-                    previousHeight = height;
-                }
-
-                onHeightChanged: {
-                    var deltaHeight = previousHeight - height;
-                    chatView.contentY = chatView.contentY + deltaHeight;
-                    previousHeight = height;
-                }
-
-                Timer {
-                    id: chatViewCooldownTimer
-                    interval: 2000
-                    repeat: false
-                    running: false
-                    onTriggered: {
-                        Debug.log("[ChatPage] Cooldown completed...");
-                        chatView.inCooldown = false;
-
-                        if (!chatPage.isInitialized) {
-                            Debug.log("Page is initialized!");
-                            chatPage.isInitialized = true;
-                            chatView.handleScrollPositionChanged();
-                        }
-                    }
-                }
-
-                Loader {
-                    asynchronous: true
-                    active: chatView.blurred
-                    anchors.fill: chatView
-                    sourceComponent: Component {
-                        FastBlur {
-                            source: chatView
-                            radius: Theme.paddingLarge
-                        }
-                    }
-                }
-
-                SilicaListView {
-                    id: chatView
-
-                    visible: !blurred
-                    property bool blurred: messageOverlayLoader.item || stickerPickerLoader.item || voiceNoteOverlayLoader.item || inlineQuery.hasOverlay || stickerSetOverlayLoader.item
-
-                    anchors.fill: parent
-                    opacity: chatPage.loading ? 0 : 1
-                    Behavior on opacity { FadeAnimation {} }
-                    clip: true
-                    highlightMoveDuration: 0
-                    highlightResizeDuration: 0
-                    property int lastReadSentIndex: -1
-                    property bool inCooldown: false
-                    property bool manuallyScrolledToBottom
-                    property QtObject precalculatedValues: QtObject {
-                        readonly property alias page: chatPage
-                        readonly property bool showUserInfo: page.isBasicGroup || ( page.isSuperGroup && !page.isChannel)
-                        readonly property int profileThumbnailDimensions: showUserInfo ? Theme.itemSizeSmall : 0
-                        readonly property int pageMarginDouble: 2 * Theme.horizontalPageMargin
-                        readonly property int paddingMediumDouble: 2 * Theme.paddingMedium
-                        readonly property int entryWidth: chatView.width - pageMarginDouble
-                        readonly property int textItemWidth: entryWidth - profileThumbnailDimensions - Theme.paddingSmall
-                        readonly property int backgroundWidth: page.isChannel ? textItemWidth : textItemWidth - pageMarginDouble
-                        readonly property int backgroundRadius: textItemWidth/50
-                        readonly property int textColumnWidth: backgroundWidth - Theme.horizontalPageMargin
-                        readonly property int messageInReplyToHeight: Theme.fontSizeExtraSmall * 2.571428571 + Theme.paddingSmall;
-                        readonly property int webPagePreviewHeight: ( (textColumnWidth * 2 / 3) + (6 * Theme.fontSizeExtraSmall) + ( 7 * Theme.paddingSmall) )
-                        readonly property bool pageIsSelecting: chatPage.isSelecting
-
-                    }
-
-                    function handleScrollPositionChanged() {
-                        Debug.log("Current position: ", chatView.contentY);
-                        if (chatOverviewItem.visible && chatInformation.unread_count > 0) {
-                            var bottomIndex = chatView.indexAt(chatView.contentX, ( chatView.contentY + chatView.height - Theme.horizontalPageMargin ));
-                            if (bottomIndex > -1) {
-                                viewMessageTimer.queueViewMessage(bottomIndex)
-                            }
-                        } else {
-                            tdLibWrapper.readAllChatMentions(chatInformation.id);
-                        }
-                        manuallyScrolledToBottom = chatView.atYEnd
-                    }
-
-                    function scrollToIndex(index) {
-                        if(index > 0 && index < chatView.count) {
-                            positionViewAtIndex(index, ListView.Contain)
-//                            currentIndex = index;
-                            if(index === chatView.count - 1) {
-                                manuallyScrolledToBottom = true;
-                            }
-                        }
-                    }
-
-                    onContentYChanged: {
-                        if (!chatPage.loading && !chatView.inCooldown) {
-                            if (chatView.indexAt(chatView.contentX, chatView.contentY) < 10) {
-                                Debug.log("[ChatPage] Trying to get older history items...");
-                                chatView.inCooldown = true;
-                                chatModel.triggerLoadMoreHistory();
-                            } else if (chatOverviewItem.visible && chatView.indexAt(chatView.contentX, chatView.contentY) > ( count - 10)) {
-                                Debug.log("[ChatPage] Trying to get newer history items...");
-                                chatView.inCooldown = true;
-                                chatModel.triggerLoadMoreFuture();
-                            }
-                        }
-                    }
-
-                    onMovementEnded: {
-                        handleScrollPositionChanged();
-                    }
-
-                    onQuickScrollAnimatingChanged: {
-                        if (!quickScrollAnimating) {
-                            handleScrollPositionChanged();
-                            if(atYEnd) { // handle some false guesses from quick scroll
-                                chatView.scrollToIndex(chatView.count - 2)
-                                chatView.scrollToIndex(chatView.count - 1)
-                            }
-                        }
-                    }
-
-                    model: chatModel
-                    header: Component {
-                        Loader {
-                            active: !!chatPage.botInformation
-                                    && !!chatPage.botInformation.bot_info && chatPage.botInformation.bot_info.description.length > 0
-                            asynchronous: true
-                            width: chatView.width
-                            sourceComponent: Component {
-                                Label {
-                                    id: botInfoLabel
-                                    topPadding: Theme.paddingLarge
-                                    bottomPadding: Theme.paddingLarge
-                                    leftPadding: Theme.horizontalPageMargin
-                                    rightPadding: Theme.horizontalPageMargin
-                                    text: Emoji.emojify(chatPage.botInformation.bot_info.description, font.pixelSize)
-                                    font.pixelSize: Theme.fontSizeSmall
-                                    color: Theme.highlightColor
-                                    wrapMode: Text.Wrap
-                                    textFormat: Text.StyledText
-                                    horizontalAlignment: Text.AlignHCenter
-                                    onLinkActivated: {
-                                        var chatCommand = Functions.handleLink(link);
-                                        if(chatCommand) {
-                                            tdLibWrapper.sendTextMessage(chatInformation.id, chatCommand);
-                                        }
-                                    }
-                                    linkColor: Theme.primaryColor
-                                    visible: (text !== "")
-                                }
-                            }
-                        }
-                    }
-
-                    function getContentComponentHeight(contentType, content, parentWidth) {
-                        switch(contentType) {
-                        case "messageAnimation":
-                            return Functions.getVideoHeight(parentWidth, content.animation);
-                        case "messageAudio":
-                        case "messageVoiceNote":
-                        case "messageDocument":
-                            return Theme.itemSizeLarge;
-                        case "messageGame":
-                            return parentWidth * 0.66666666 + Theme.itemSizeLarge; // 2 / 3;
-                        case "messageLocation":
-                        case "messageVenue":
-                            return parentWidth * 0.66666666; // 2 / 3;
-                        case "messagePhoto":
-                            var biggest = content.photo.sizes[content.photo.sizes.length - 1];
-                            var aspectRatio = biggest.width/biggest.height;
-                            return Math.max(Theme.itemSizeExtraSmall, Math.min(parentWidth * 0.66666666, parentWidth / aspectRatio));
-                        case "messagePoll":
-                            return Theme.itemSizeSmall * (4 + content.poll.options);
-                        case "messageSticker":
-                            return content.sticker.height;
-                        case "messageVideo":
-                            return Functions.getVideoHeight(parentWidth, content.video);
-                        case "messageVideoNote":
-                            return parentWidth
-                        }
-                    }
-
-                    readonly property var delegateMessagesContent: [
-                        "messageAnimation",
-                        "messageAudio",
-                        // "messageContact",
-                        // "messageDice"
-                        "messageDocument",
-                        "messageGame",
-                        // "messageInvoice",
-                        "messageLocation",
-                        // "messagePassportDataSent",
-                        // "messagePaymentSuccessful",
-                        "messagePhoto",
-                        "messagePoll",
-                        // "messageProximityAlertTriggered",
-                        "messageSticker",
-                        "messageVenue",
-                        "messageVideo",
-                        "messageVideoNote",
-                        "messageVoiceNote"
-                    ]
-
-                    readonly property var simpleDelegateMessages: ["messageBasicGroupChatCreate",
-                                                                   "messageChatAddMembers",
-                                                                   "messageChatChangePhoto",
-                                                                   "messageChatChangeTitle",
-                                                                   "messageChatDeleteMember",
-                                                                   "messageChatDeletePhoto",
-                                                                   "messageChatJoinByLink",
-                                                                   "messageChatSetTtl",
-                                                                   "messageChatUpgradeFrom",
-                                                                   // "messageContactRegistered","messageExpiredPhoto", "messageExpiredVideo","messageWebsiteConnected"
-                                                                   "messageGameScore",
-                                                                   "messageChatUpgradeTo",
-                                                                   "messageCustomServiceAction",
-                                                                   "messagePinMessage",
-                                                                   "messageScreenshotTaken",
-                                                                   "messageSupergroupChatCreate",
-                                                                   "messageUnsupported"]
-                    delegate: Loader {
-                        width: chatView.width
-                        Component {
-                            id: messageListViewItemComponent
-                            MessageListViewItem {
-                                precalculatedValues: chatView.precalculatedValues
-                                chatId: chatModel.chatId
-                                myMessage: model.display
-                                messageId: model.message_id
-                                messageViewCount: model.view_count
-                                messageIndex: model.index
-                                hasContentComponent: !!myMessage.content && chatView.delegateMessagesContent.indexOf(model.content_type) > -1
-                                canReplyToMessage: chatPage.canSendMessages
-                                onReplyToMessage: {
-                                    newMessageInReplyToRow.inReplyToMessage = myMessage
-                                    newMessageTextField.focus = true
-                                }
-                                onEditMessage: {
-                                    newMessageColumn.editMessageId = messageId
-                                    newMessageTextField.text = Functions.getMessageText(myMessage, false, chatPage.myUserId, true)
-                                    newMessageTextField.focus = true
-                                }
-                            }
-                        }
-                        Component {
-                            id: messageListViewItemSimpleComponent
-                            MessageListViewItemSimple {}
-                        }
-                        sourceComponent: chatView.simpleDelegateMessages.indexOf(model.content_type) > -1 ? messageListViewItemSimpleComponent : messageListViewItemComponent
-                    }
-                    VerticalScrollDecorator {}
-
-                    ViewPlaceholder {
-                        id: chatViewPlaceholder
-                        enabled: chatView.count === 0
-                        text: (chatPage.isSecretChat && !chatPage.isSecretChatReady) ? qsTr("This secret chat is not yet ready. Your chat partner needs to go online first.") : qsTr("This chat is empty.")
-                    }
-                }
-
-                Column {
-                    width: parent.width
-                    height: loadingLabel.height + loadingBusyIndicator.height + Theme.paddingMedium
-                    spacing: Theme.paddingMedium
+                Label {
+                    id: messageOptionsLabel
+                    text: qsTr("Message Options")
+                    color: Theme.highlightColor
+                    font.pixelSize: Theme.fontSizeLarge
+                    width: parent.width - closeMessageOptionsButton.width - Theme.paddingMedium
                     anchors.verticalCenter: parent.verticalCenter
+                    horizontalAlignment: Text.AlignRight
 
-                    opacity: chatPage.loading ? 1 : 0
-                    Behavior on opacity { FadeAnimation {} }
-                    visible: chatPage.loading
-
-                    InfoLabel {
-                        id: loadingLabel
-                        text: qsTr("Loading messages...")
-                    }
-
-                    BusyIndicator {
-                        id: loadingBusyIndicator
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        running: chatPage.loading
-                        size: BusyIndicatorSize.Large
+                }
+                IconButton {
+                    id: closeMessageOptionsButton
+                    icon.source: "image://theme/icon-m-clear"
+                    anchors.verticalCenter: parent.verticalCenter
+                    onClicked: {
+                        messageOptionsDrawer.closeRequested();
+                        messageOptionsDrawer.open = false;
                     }
                 }
+            }
 
-                Item {
-                    id: chatUnreadMessagesItem
-                    width: Theme.fontSizeHuge
-                    height: Theme.fontSizeHuge
-                    anchors.right: parent.right
-                    anchors.rightMargin: Theme.paddingMedium
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: Theme.paddingMedium
-                    visible: !chatPage.loading && chatInformation.unread_count > 0 && chatOverviewItem.visible
-                    Rectangle {
-                        id: chatUnreadMessagesCountBackground
-                        color: Theme.highlightBackgroundColor
-                        anchors.fill: parent
-                        radius: width / 2
-                        visible: chatUnreadMessagesItem.visible
-                    }
+            delegate: ListItem {
+                width: parent.width
+                visible: myListModel.actions[conditions]()
+                onClicked: {
+                    myListModel.actions[elementActionName]();
+                }
+                Label {
+                    width: parent.width - ( 2 * Theme.horizontalPageMargin )
+                    text: myListModel.texts[elementActionName]();
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    horizontalAlignment: Text.AlignHCenter
+                }
+            }
 
-                    Text {
-                        id: chatUnreadMessagesCount
-                        font.pixelSize: Theme.fontSizeMedium
-                        font.bold: true
-                        color: Theme.primaryColor
-                        anchors.centerIn: chatUnreadMessagesCountBackground
-                        visible: chatUnreadMessagesItem.visible
-                        text: chatInformation.unread_count > 99 ? "99+" : chatInformation.unread_count
+            VerticalScrollDecorator {}
+        }
+
+        SilicaFlickable {
+            id: chatContainer
+
+            onContentYChanged: {
+                // For some strange reason contentY sometimes is > 0 which doesn't make sense without a PushUpMenu (?)
+                // That leads to the problem that the whole flickable is moved slightly (or sometimes considerably) up
+                // which creates UX issues... As a workaround we are setting it to 0 in such cases.
+                // Better solutions are highly appreciated, contributions always welcome! ;)
+                if (contentY > 0) {
+                    contentY = 0;
+                }
+            }
+
+            anchors.fill: parent
+            contentHeight: height
+            contentWidth: width
+
+            PullDownMenu {
+                visible: chatInformation.id !== chatPage.myUserId && !stickerPickerLoader.active && !voiceNoteOverlayLoader.active && !messageOverlayLoader.active && !stickerSetOverlayLoader.active
+                MenuItem {
+                    id: closeSecretChatMenuItem
+                    visible: chatPage.isSecretChat && chatPage.secretChatDetails.state["@type"] !== "secretChatStateClosed"
+                    onClicked: {
+                        var secretChatId = chatPage.secretChatDetails.id;
+                        Remorse.popupAction(chatPage, qsTr("Closing chat"), function() { tdLibWrapper.closeSecretChat(secretChatId) });
                     }
-                    MouseArea {
-                        anchors.fill: parent
-                        onClicked: {
-                            chatView.scrollToIndex(chatView.count - 1 - chatInformation.unread_count)
+                    text: qsTr("Close Chat")
+                }
+
+                MenuItem {
+                    id: joinLeaveChatMenuItem
+                    visible: (chatPage.isSuperGroup || chatPage.isBasicGroup) && chatGroupInformation && chatGroupInformation.status["@type"] !== "chatMemberStatusBanned"
+                    onClicked: {
+                        if (chatPage.userIsMember) {
+                            var chatId = chatInformation.id;
+                            Remorse.popupAction(chatPage, qsTr("Leaving chat"), function() {
+                                tdLibWrapper.leaveChat(chatId);
+                                // this does not care about the response (ideally type "ok" without further reference) for now
+                                pageStack.pop(pageStack.find( function(page){ return(page._depth === 0)} ));
+                            });
+                        } else {
+                            tdLibWrapper.joinChat(chatInformation.id);
                         }
                     }
+                    text: chatPage.userIsMember ? qsTr("Leave Chat") : qsTr("Join Chat")
                 }
 
-                Loader {
-                    id: stickerPickerLoader
-                    active: false
-                    asynchronous: true
-                    width: parent.width
-                    height: active ? parent.height : 0
-                    source: "../components/StickerPicker.qml"
-                }
-
-                Connections {
-                    target: stickerPickerLoader.item
-                    onStickerPicked: {
-                        Debug.log("Sticker picked: " + stickerId);
-                        tdLibWrapper.sendStickerMessage(chatInformation.id, stickerId, newMessageColumn.replyToMessageId);
-                        stickerPickerLoader.active = false;
-                        attachmentOptionsFlickable.isNeeded = false;
-                        newMessageInReplyToRow.inReplyToMessage = null;
-                        newMessageColumn.editMessageId = "0";
-                    }
-                }
-
-                Loader {
-                    id: messageOverlayLoader
-
-                    property var overlayMessage;
-
-                    active: false
-                    asynchronous: true
-                    width: parent.width
-                    height: active ? parent.height : 0
-                    sourceComponent: Component {
-                        MessageOverlayFlickable {
-                            overlayMessage: messageOverlayLoader.overlayMessage
-                            showHeader: !chatPage.isChannel
-                            onRequestClose: {
-                                messageOverlayLoader.active = false;
-                            }
+                MenuItem {
+                    id: muteChatMenuItem
+                    visible: chatPage.userIsMember
+                    onClicked: {
+                        var newNotificationSettings = chatInformation.notification_settings;
+                        if (newNotificationSettings.mute_for > 0) {
+                            newNotificationSettings.mute_for = 0;
+                        } else {
+                            newNotificationSettings.mute_for = 6666666;
                         }
+                        newNotificationSettings.use_default_mute_for = false;
+                        tdLibWrapper.setChatNotificationSettings(chatInformation.id, newNotificationSettings);
                     }
+                    text: chatInformation.notification_settings.mute_for > 0 ? qsTr("Unmute Chat") : qsTr("Mute Chat")
                 }
 
-                Loader {
-                    id: voiceNoteOverlayLoader
-                    active: false
-                    asynchronous: true
-                    width: parent.width
-                    height: active ? parent.height : 0
-                    source: "../components/VoiceNoteOverlay.qml"
-                    onActiveChanged: {
-                        if (!active) {
-                            fernschreiberUtils.stopRecordingVoiceNote();
-                        }
+                MenuItem {
+                    id: searchInChatMenuItem
+                    visible: !chatPage.isSecretChat && chatOverviewItem.visible
+                    onClicked: {
+                        // This automatically shows the search field as well
+                        chatOverviewItem.visible = false;
+                        searchInChatField.focus = true;
                     }
+                    text: qsTr("Search in Chat")
                 }
+            }
 
-                Loader {
-                    id: stickerSetOverlayLoader
-
-                    property string stickerSetId;
-
-                    active: false
-                    asynchronous: true
-                    width: parent.width
-                    height: active ? parent.height : 0
-                    sourceComponent: Component {
-                        StickerSetOverlay {
-                            stickerSetId: stickerSetOverlayLoader.stickerSetId
-                            onRequestClose: {
-                                stickerSetOverlayLoader.active = false;
-                            }
-                        }
+            BackgroundItem {
+                id: headerMouseArea
+                height: headerRow.height
+                width: parent.width
+                onClicked: {
+                    if (chatPage.isSelecting) {
+                        chatPage.selectedMessages = [];
+                    } else {
+                        pageStack.navigateForward();
                     }
-
-                    onActiveChanged: {
-                        if (active) {
-                            attachmentOptionsFlickable.isNeeded = false;
-                        }
-                    }
-                }
-
-                InlineQuery {
-                    id: inlineQuery
-                    textField: newMessageTextField
-                    chatId: chatInformation.id
                 }
             }
 
             Column {
-                id: newMessageColumn
-                spacing: Theme.paddingSmall
-                topPadding: Theme.paddingSmall + inlineQuery.buttonPadding
-                anchors.horizontalCenter: parent.horizontalCenter
-                visible: height > 0
-                width: parent.width - ( 2 * Theme.horizontalPageMargin )
-                height: isNeeded ? implicitHeight : 0
-                Behavior on height { SmoothedAnimation { duration: 200 } }
+                id: chatColumn
+                width: parent.width
+                height: parent.height
 
-                readonly property bool isNeeded: !chatPage.isSelecting && chatPage.canSendMessages
-                property string replyToMessageId: "0";
-                property string editMessageId: "0";
+                Row {
+                    id: headerRow
+                    width: parent.width - (3 * Theme.horizontalPageMargin)
+                    height: chatOverviewItem.height + ( chatPage.isPortrait ? (2 * Theme.paddingMedium) : (2 * Theme.paddingSmall) )
+                    anchors.horizontalCenter: parent.horizontalCenter
+                    spacing: Theme.paddingMedium
 
-                InReplyToRow {
-                    onInReplyToMessageChanged: {
-                        if (inReplyToMessage) {
-                            newMessageColumn.replyToMessageId = newMessageInReplyToRow.inReplyToMessage.id.toString()
-                            newMessageInReplyToRow.visible = true;
-                        } else {
-                            newMessageInReplyToRow.visible = false;
-                            newMessageColumn.replyToMessageId = "0";
+                    Item {
+                        width: chatOverviewItem.height
+                        height: chatOverviewItem.height
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: chatPage.isPortrait ? Theme.paddingMedium : Theme.paddingSmall
+
+                        ProfileThumbnail {
+                            id: chatPictureThumbnail
+                            replacementStringHint: chatNameText.text
+                            width: parent.height
+                            height: parent.height
+
+                            // Setting it directly may cause an stale state for the thumbnail in case the chat page
+                            // was previously loaded with a picture and now it doesn't have one. Instead setting it
+                            // when the ChatModel indicates a change. This also avoids flickering when the page is loaded...
+                            Connections {
+                                target: chatModel
+                                onSmallPhotoChanged: {
+                                    chatPictureThumbnail.photoData = chatModel.smallPhoto;
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            id: chatSecretBackground
+                            color: Theme.rgba(Theme.overlayBackgroundColor, Theme.opacityFaint)
+                            width: chatPage.isPortrait ? Theme.fontSizeLarge : Theme.fontSizeMedium
+                            height: width
+                            anchors.left: parent.left
+                            anchors.bottom: parent.bottom
+                            radius: parent.width / 2
+                            visible: chatPage.isSecretChat
+                        }
+
+                        Image {
+                            source: "image://theme/icon-s-secure"
+                            width: chatPage.isPortrait ? Theme.fontSizeSmall : Theme.fontSizeExtraSmall
+                            height: width
+                            anchors.centerIn: chatSecretBackground
+                            visible: chatPage.isSecretChat
+                        }
+
+                    }
+
+                    Item {
+                        id: chatOverviewItem
+                        opacity: visible ? 1 : 0
+                        Behavior on opacity { FadeAnimation {} }
+                        width: parent.width - chatPictureThumbnail.width - Theme.paddingMedium
+                        height: chatNameText.height + chatStatusText.height
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: chatPage.isPortrait ? Theme.paddingMedium : Theme.paddingSmall
+                        Label {
+                            id: chatNameText
+                            width: Math.min(implicitWidth, parent.width)
+                            anchors.right: parent.right
+                            text: chatInformation.title !== "" ? Emoji.emojify(chatInformation.title, font.pixelSize) : qsTr("Unknown")
+                            textFormat: Text.StyledText
+                            font.pixelSize: chatPage.isPortrait ? Theme.fontSizeLarge : Theme.fontSizeMedium
+                            font.family: Theme.fontFamilyHeading
+                            color: Theme.highlightColor
+                            truncationMode: TruncationMode.Fade
+                            maximumLineCount: 1
+                        }
+                        Label {
+                            id: chatStatusText
+                            width: Math.min(implicitWidth, parent.width)
+                            anchors {
+                                right: parent.right
+                                bottom: parent.bottom
+                            }
+                            text: ""
+                            textFormat: Text.StyledText
+                            font.pixelSize: chatPage.isPortrait ? Theme.fontSizeExtraSmall : Theme.fontSizeTiny
+                            font.family: Theme.fontFamilyHeading
+                            color: headerMouseArea.pressed ? Theme.secondaryHighlightColor : Theme.secondaryColor
+                            truncationMode: TruncationMode.Fade
+                            maximumLineCount: 1
                         }
                     }
 
-                    editable: true
+                    Item {
+                        id: searchInChatItem
+                        visible: !chatOverviewItem.visible
+                        opacity: visible ? 1 : 0
+                        Behavior on opacity { FadeAnimation {} }
+                        width: parent.width - chatPictureThumbnail.width - Theme.paddingMedium
+                        height: searchInChatField.height
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: chatPage.isPortrait ? Theme.paddingSmall : 0
 
-                    onClearRequested: {
-                        newMessageInReplyToRow.inReplyToMessage = null;
+                        SearchField {
+                            id: searchInChatField
+                            visible: false
+                            width: visible ? parent.width : 0
+                            placeholderText: qsTr("Search in chat...")
+                            active: searchInChatItem.visible
+                            canHide: text === ""
+
+                            onTextChanged: {
+                                searchInChatTimer.restart();
+                            }
+
+                            onHideClicked: {
+                                resetFocus();
+                            }
+
+                            EnterKey.iconSource: "image://theme/icon-m-enter-close"
+                            EnterKey.onClicked: {
+                                resetFocus();
+                            }
+                        }
                     }
-
-                    id: newMessageInReplyToRow
-                    myUserId: chatPage.myUserId
-                    visible: false
                 }
 
-                Flickable {
-                    id: attachmentOptionsFlickable
+                PinnedMessageItem {
+                    id: pinnedMessageItem
+                    onRequestShowMessage: {
+                        messageOverlayLoader.overlayMessage = pinnedMessageItem.pinnedMessage;
+                        messageOverlayLoader.active = true;
+                    }
+                    onRequestCloseMessage: {
+                        messageOverlayLoader.overlayMessage = undefined;
+                        messageOverlayLoader.active = false;
+                    }
+                }
 
-                    property bool isNeeded: false
-                    width: chatPage.width
-                    x: -Theme.horizontalPageMargin
-                    height: isNeeded && !inlineQuery.userNameIsValid ? attachmentOptionsRow.height : 0
-                    Behavior on height { SmoothedAnimation { duration: 200 } }
+                Item {
+                    id: chatViewItem
+                    width: parent.width
+                    height: parent.height - headerRow.height - pinnedMessageItem.height - newMessageColumn.height - selectedMessagesActions.height
+
+                    property int previousHeight;
+
+                    Component.onCompleted: {
+                        previousHeight = height;
+                    }
+
+                    onHeightChanged: {
+                        var deltaHeight = previousHeight - height;
+                        chatView.contentY = chatView.contentY + deltaHeight;
+                        previousHeight = height;
+                    }
+
+                    Timer {
+                        id: chatViewCooldownTimer
+                        interval: 2000
+                        repeat: false
+                        running: false
+                        onTriggered: {
+                            Debug.log("[ChatPage] Cooldown completed...");
+                            chatView.inCooldown = false;
+
+                            if (!chatPage.isInitialized) {
+                                Debug.log("Page is initialized!");
+                                chatPage.isInitialized = true;
+                                chatView.handleScrollPositionChanged();
+                            }
+                        }
+                    }
+
+                    Loader {
+                        asynchronous: true
+                        active: chatView.blurred
+                        anchors.fill: chatView
+                        sourceComponent: Component {
+                            FastBlur {
+                                source: chatView
+                                radius: Theme.paddingLarge
+                            }
+                        }
+                    }
+
+                    SilicaListView {
+                        id: chatView
+
+                        visible: !blurred
+                        property bool blurred: messageOverlayLoader.item || stickerPickerLoader.item || voiceNoteOverlayLoader.item || inlineQuery.hasOverlay || stickerSetOverlayLoader.item
+
+                        anchors.fill: parent
+                        opacity: chatPage.loading ? 0 : 1
+                        Behavior on opacity { FadeAnimation {} }
+                        clip: true
+                        highlightMoveDuration: 0
+                        highlightResizeDuration: 0
+                        property int lastReadSentIndex: -1
+                        property bool inCooldown: false
+                        property bool manuallyScrolledToBottom
+                        property QtObject precalculatedValues: QtObject {
+                            readonly property alias page: chatPage
+                            readonly property bool showUserInfo: page.isBasicGroup || ( page.isSuperGroup && !page.isChannel)
+                            readonly property int profileThumbnailDimensions: showUserInfo ? Theme.itemSizeSmall : 0
+                            readonly property int pageMarginDouble: 2 * Theme.horizontalPageMargin
+                            readonly property int paddingMediumDouble: 2 * Theme.paddingMedium
+                            readonly property int entryWidth: chatView.width - pageMarginDouble
+                            readonly property int textItemWidth: entryWidth - profileThumbnailDimensions - Theme.paddingSmall
+                            readonly property int backgroundWidth: page.isChannel ? textItemWidth : textItemWidth - pageMarginDouble
+                            readonly property int backgroundRadius: textItemWidth/50
+                            readonly property int textColumnWidth: backgroundWidth - Theme.horizontalPageMargin
+                            readonly property int messageInReplyToHeight: Theme.fontSizeExtraSmall * 2.571428571 + Theme.paddingSmall;
+                            readonly property int webPagePreviewHeight: ( (textColumnWidth * 2 / 3) + (6 * Theme.fontSizeExtraSmall) + ( 7 * Theme.paddingSmall) )
+                            readonly property bool pageIsSelecting: chatPage.isSelecting
+
+                        }
+
+                        function handleScrollPositionChanged() {
+                            Debug.log("Current position: ", chatView.contentY);
+                            if (chatOverviewItem.visible && chatInformation.unread_count > 0) {
+                                var bottomIndex = chatView.indexAt(chatView.contentX, ( chatView.contentY + chatView.height - Theme.horizontalPageMargin ));
+                                if (bottomIndex > -1) {
+                                    viewMessageTimer.queueViewMessage(bottomIndex)
+                                }
+                            } else {
+                                tdLibWrapper.readAllChatMentions(chatInformation.id);
+                            }
+                            manuallyScrolledToBottom = chatView.atYEnd
+                        }
+
+                        function scrollToIndex(index) {
+                            if(index > 0 && index < chatView.count) {
+                                positionViewAtIndex(index, ListView.Contain)
+    //                            currentIndex = index;
+                                if(index === chatView.count - 1) {
+                                    manuallyScrolledToBottom = true;
+                                }
+                            }
+                        }
+
+                        onContentYChanged: {
+                            if (!chatPage.loading && !chatView.inCooldown) {
+                                if (chatView.indexAt(chatView.contentX, chatView.contentY) < 10) {
+                                    Debug.log("[ChatPage] Trying to get older history items...");
+                                    chatView.inCooldown = true;
+                                    chatModel.triggerLoadMoreHistory();
+                                } else if (chatOverviewItem.visible && chatView.indexAt(chatView.contentX, chatView.contentY) > ( count - 10)) {
+                                    Debug.log("[ChatPage] Trying to get newer history items...");
+                                    chatView.inCooldown = true;
+                                    chatModel.triggerLoadMoreFuture();
+                                }
+                            }
+                        }
+
+                        onMovementEnded: {
+                            handleScrollPositionChanged();
+                        }
+
+                        onQuickScrollAnimatingChanged: {
+                            if (!quickScrollAnimating) {
+                                handleScrollPositionChanged();
+                                if(atYEnd) { // handle some false guesses from quick scroll
+                                    chatView.scrollToIndex(chatView.count - 2)
+                                    chatView.scrollToIndex(chatView.count - 1)
+                                }
+                            }
+                        }
+
+                        model: chatModel
+                        header: Component {
+                            Loader {
+                                active: !!chatPage.botInformation
+                                        && !!chatPage.botInformation.bot_info && chatPage.botInformation.bot_info.description.length > 0
+                                asynchronous: true
+                                width: chatView.width
+                                sourceComponent: Component {
+                                    Label {
+                                        id: botInfoLabel
+                                        topPadding: Theme.paddingLarge
+                                        bottomPadding: Theme.paddingLarge
+                                        leftPadding: Theme.horizontalPageMargin
+                                        rightPadding: Theme.horizontalPageMargin
+                                        text: Emoji.emojify(chatPage.botInformation.bot_info.description, font.pixelSize)
+                                        font.pixelSize: Theme.fontSizeSmall
+                                        color: Theme.highlightColor
+                                        wrapMode: Text.Wrap
+                                        textFormat: Text.StyledText
+                                        horizontalAlignment: Text.AlignHCenter
+                                        onLinkActivated: {
+                                            var chatCommand = Functions.handleLink(link);
+                                            if(chatCommand) {
+                                                tdLibWrapper.sendTextMessage(chatInformation.id, chatCommand);
+                                            }
+                                        }
+                                        linkColor: Theme.primaryColor
+                                        visible: (text !== "")
+                                    }
+                                }
+                            }
+                        }
+
+                        function getContentComponentHeight(contentType, content, parentWidth) {
+                            switch(contentType) {
+                            case "messageAnimation":
+                                return Functions.getVideoHeight(parentWidth, content.animation);
+                            case "messageAudio":
+                            case "messageVoiceNote":
+                            case "messageDocument":
+                                return Theme.itemSizeLarge;
+                            case "messageGame":
+                                return parentWidth * 0.66666666 + Theme.itemSizeLarge; // 2 / 3;
+                            case "messageLocation":
+                            case "messageVenue":
+                                return parentWidth * 0.66666666; // 2 / 3;
+                            case "messagePhoto":
+                                var biggest = content.photo.sizes[content.photo.sizes.length - 1];
+                                var aspectRatio = biggest.width/biggest.height;
+                                return Math.max(Theme.itemSizeExtraSmall, Math.min(parentWidth * 0.66666666, parentWidth / aspectRatio));
+                            case "messagePoll":
+                                return Theme.itemSizeSmall * (4 + content.poll.options);
+                            case "messageSticker":
+                                return content.sticker.height;
+                            case "messageVideo":
+                                return Functions.getVideoHeight(parentWidth, content.video);
+                            case "messageVideoNote":
+                                return parentWidth
+                            }
+                        }
+
+                        readonly property var delegateMessagesContent: [
+                            "messageAnimation",
+                            "messageAudio",
+                            // "messageContact",
+                            // "messageDice"
+                            "messageDocument",
+                            "messageGame",
+                            // "messageInvoice",
+                            "messageLocation",
+                            // "messagePassportDataSent",
+                            // "messagePaymentSuccessful",
+                            "messagePhoto",
+                            "messagePoll",
+                            // "messageProximityAlertTriggered",
+                            "messageSticker",
+                            "messageVenue",
+                            "messageVideo",
+                            "messageVideoNote",
+                            "messageVoiceNote"
+                        ]
+
+                        readonly property var simpleDelegateMessages: ["messageBasicGroupChatCreate",
+                                                                       "messageChatAddMembers",
+                                                                       "messageChatChangePhoto",
+                                                                       "messageChatChangeTitle",
+                                                                       "messageChatDeleteMember",
+                                                                       "messageChatDeletePhoto",
+                                                                       "messageChatJoinByLink",
+                                                                       "messageChatSetTtl",
+                                                                       "messageChatUpgradeFrom",
+                                                                       // "messageContactRegistered","messageExpiredPhoto", "messageExpiredVideo","messageWebsiteConnected"
+                                                                       "messageGameScore",
+                                                                       "messageChatUpgradeTo",
+                                                                       "messageCustomServiceAction",
+                                                                       "messagePinMessage",
+                                                                       "messageScreenshotTaken",
+                                                                       "messageSupergroupChatCreate",
+                                                                       "messageUnsupported"]
+                        delegate: Loader {
+                            width: chatView.width
+                            Component {
+                                id: messageListViewItemComponent
+                                MessageListViewItem {
+                                    precalculatedValues: chatView.precalculatedValues
+                                    chatId: chatModel.chatId
+                                    myMessage: model.display
+                                    messageId: model.message_id
+                                    messageViewCount: model.view_count
+                                    messageIndex: model.index
+                                    hasContentComponent: !!myMessage.content && chatView.delegateMessagesContent.indexOf(model.content_type) > -1
+                                    canReplyToMessage: chatPage.canSendMessages
+                                    onReplyToMessage: {
+                                        newMessageInReplyToRow.inReplyToMessage = myMessage
+                                        newMessageTextField.focus = true
+                                    }
+                                    onEditMessage: {
+                                        newMessageColumn.editMessageId = messageId
+                                        newMessageTextField.text = Functions.getMessageText(myMessage, false, chatPage.myUserId, true)
+                                        newMessageTextField.focus = true
+                                    }
+                                }
+                            }
+                            Component {
+                                id: messageListViewItemSimpleComponent
+                                MessageListViewItemSimple {}
+                            }
+                            sourceComponent: chatView.simpleDelegateMessages.indexOf(model.content_type) > -1 ? messageListViewItemSimpleComponent : messageListViewItemComponent
+                        }
+                        VerticalScrollDecorator {}
+
+                        ViewPlaceholder {
+                            id: chatViewPlaceholder
+                            enabled: chatView.count === 0
+                            text: (chatPage.isSecretChat && !chatPage.isSecretChatReady) ? qsTr("This secret chat is not yet ready. Your chat partner needs to go online first.") : qsTr("This chat is empty.")
+                        }
+                    }
+
+                    Column {
+                        width: parent.width
+                        height: loadingLabel.height + loadingBusyIndicator.height + Theme.paddingMedium
+                        spacing: Theme.paddingMedium
+                        anchors.verticalCenter: parent.verticalCenter
+
+                        opacity: chatPage.loading ? 1 : 0
+                        Behavior on opacity { FadeAnimation {} }
+                        visible: chatPage.loading
+
+                        InfoLabel {
+                            id: loadingLabel
+                            text: qsTr("Loading messages...")
+                        }
+
+                        BusyIndicator {
+                            id: loadingBusyIndicator
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            running: chatPage.loading
+                            size: BusyIndicatorSize.Large
+                        }
+                    }
+
+                    Item {
+                        id: chatUnreadMessagesItem
+                        width: Theme.fontSizeHuge
+                        height: Theme.fontSizeHuge
+                        anchors.right: parent.right
+                        anchors.rightMargin: Theme.paddingMedium
+                        anchors.bottom: parent.bottom
+                        anchors.bottomMargin: Theme.paddingMedium
+                        visible: !chatPage.loading && chatInformation.unread_count > 0 && chatOverviewItem.visible
+                        Rectangle {
+                            id: chatUnreadMessagesCountBackground
+                            color: Theme.highlightBackgroundColor
+                            anchors.fill: parent
+                            radius: width / 2
+                            visible: chatUnreadMessagesItem.visible
+                        }
+
+                        Text {
+                            id: chatUnreadMessagesCount
+                            font.pixelSize: Theme.fontSizeMedium
+                            font.bold: true
+                            color: Theme.primaryColor
+                            anchors.centerIn: chatUnreadMessagesCountBackground
+                            visible: chatUnreadMessagesItem.visible
+                            text: chatInformation.unread_count > 99 ? "99+" : chatInformation.unread_count
+                        }
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: {
+                                chatView.scrollToIndex(chatView.count - 1 - chatInformation.unread_count)
+                            }
+                        }
+                    }
+
+                    Loader {
+                        id: stickerPickerLoader
+                        active: false
+                        asynchronous: true
+                        width: parent.width
+                        height: active ? parent.height : 0
+                        source: "../components/StickerPicker.qml"
+                    }
+
+                    Connections {
+                        target: stickerPickerLoader.item
+                        onStickerPicked: {
+                            Debug.log("Sticker picked: " + stickerId);
+                            tdLibWrapper.sendStickerMessage(chatInformation.id, stickerId, newMessageColumn.replyToMessageId);
+                            stickerPickerLoader.active = false;
+                            attachmentOptionsFlickable.isNeeded = false;
+                            newMessageInReplyToRow.inReplyToMessage = null;
+                            newMessageColumn.editMessageId = "0";
+                        }
+                    }
+
+                    Loader {
+                        id: messageOverlayLoader
+
+                        property var overlayMessage;
+
+                        active: false
+                        asynchronous: true
+                        width: parent.width
+                        height: active ? parent.height : 0
+                        sourceComponent: Component {
+                            MessageOverlayFlickable {
+                                overlayMessage: messageOverlayLoader.overlayMessage
+                                showHeader: !chatPage.isChannel
+                                onRequestClose: {
+                                    messageOverlayLoader.active = false;
+                                }
+                            }
+                        }
+                    }
+
+                    Loader {
+                        id: voiceNoteOverlayLoader
+                        active: false
+                        asynchronous: true
+                        width: parent.width
+                        height: active ? parent.height : 0
+                        source: "../components/VoiceNoteOverlay.qml"
+                        onActiveChanged: {
+                            if (!active) {
+                                fernschreiberUtils.stopRecordingVoiceNote();
+                            }
+                        }
+                    }
+
+                    Loader {
+                        id: stickerSetOverlayLoader
+
+                        property string stickerSetId;
+
+                        active: false
+                        asynchronous: true
+                        width: parent.width
+                        height: active ? parent.height : 0
+                        sourceComponent: Component {
+                            StickerSetOverlay {
+                                stickerSetId: stickerSetOverlayLoader.stickerSetId
+                                onRequestClose: {
+                                    stickerSetOverlayLoader.active = false;
+                                }
+                            }
+                        }
+
+                        onActiveChanged: {
+                            if (active) {
+                                attachmentOptionsFlickable.isNeeded = false;
+                            }
+                        }
+                    }
+
+                    InlineQuery {
+                        id: inlineQuery
+                        textField: newMessageTextField
+                        chatId: chatInformation.id
+                    }
+                }
+
+                Column {
+                    id: newMessageColumn
+                    spacing: Theme.paddingSmall
+                    topPadding: Theme.paddingSmall + inlineQuery.buttonPadding
+                    anchors.horizontalCenter: parent.horizontalCenter
                     visible: height > 0
-                    contentHeight: attachmentOptionsRow.height
-                    contentWidth: Math.max(width, attachmentOptionsRow.width)
-                    property bool fadeRight: (attachmentOptionsRow.width-contentX) > width
-                    property bool fadeLeft: !fadeRight && contentX > 0
-                    layer.enabled: fadeRight || fadeLeft
-                    layer.effect: OpacityRampEffectBase {
-                        direction: attachmentOptionsFlickable.fadeRight ? OpacityRamp.LeftToRight : OpacityRamp.RightToLeft
-                        source: attachmentOptionsFlickable
-                        slope: 1 + 6 * (chatPage.width) / Screen.width
-                        offset: 1 - 1 / slope
+                    width: parent.width - ( 2 * Theme.horizontalPageMargin )
+                    height: isNeeded ? implicitHeight : 0
+                    Behavior on height { SmoothedAnimation { duration: 200 } }
+
+                    readonly property bool isNeeded: !chatPage.isSelecting && chatPage.canSendMessages
+                    property string replyToMessageId: "0";
+                    property string editMessageId: "0";
+
+                    InReplyToRow {
+                        onInReplyToMessageChanged: {
+                            if (inReplyToMessage) {
+                                newMessageColumn.replyToMessageId = newMessageInReplyToRow.inReplyToMessage.id.toString()
+                                newMessageInReplyToRow.visible = true;
+                            } else {
+                                newMessageInReplyToRow.visible = false;
+                                newMessageColumn.replyToMessageId = "0";
+                            }
+                        }
+
+                        editable: true
+
+                        onClearRequested: {
+                            newMessageInReplyToRow.inReplyToMessage = null;
+                        }
+
+                        id: newMessageInReplyToRow
+                        myUserId: chatPage.myUserId
+                        visible: false
+                    }
+
+                    Flickable {
+                        id: attachmentOptionsFlickable
+
+                        property bool isNeeded: false
+                        width: chatPage.width
+                        x: -Theme.horizontalPageMargin
+                        height: isNeeded && !inlineQuery.userNameIsValid ? attachmentOptionsRow.height : 0
+                        Behavior on height { SmoothedAnimation { duration: 200 } }
+                        visible: height > 0
+                        contentHeight: attachmentOptionsRow.height
+                        contentWidth: Math.max(width, attachmentOptionsRow.width)
+                        property bool fadeRight: (attachmentOptionsRow.width-contentX) > width
+                        property bool fadeLeft: !fadeRight && contentX > 0
+                        layer.enabled: fadeRight || fadeLeft
+                        layer.effect: OpacityRampEffectBase {
+                            direction: attachmentOptionsFlickable.fadeRight ? OpacityRamp.LeftToRight : OpacityRamp.RightToLeft
+                            source: attachmentOptionsFlickable
+                            slope: 1 + 6 * (chatPage.width) / Screen.width
+                            offset: 1 - 1 / slope
+                        }
+
+
+                        Row {
+                            id: attachmentOptionsRow
+
+                            height: attachImageIconButton.height
+
+                            anchors.right: parent.right
+                            layoutDirection: Qt.RightToLeft
+                            spacing: Theme.paddingMedium
+                            leftPadding: Theme.horizontalPageMargin
+                            rightPadding: Theme.horizontalPageMargin
+
+                            IconButton {
+                                id: attachImageIconButton
+                                visible: chatPage.hasSendPrivilege("can_send_media_messages")
+                                icon.source: "image://theme/icon-m-image"
+                                onClicked: {
+                                    var picker = pageStack.push("Sailfish.Pickers.ImagePickerPage", {
+                                        allowedOrientations: chatPage.allowedOrientations
+                                    })
+                                    picker.selectedContentPropertiesChanged.connect(function(){
+                                        attachmentOptionsFlickable.isNeeded = false;
+                                        Debug.log("Selected document: ", picker.selectedContentProperties.filePath );
+                                        attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
+                                        attachmentPreviewRow.isPicture = true;
+                                        controlSendButton();
+                                    })
+                                }
+                            }
+                            IconButton {
+                                visible: chatPage.hasSendPrivilege("can_send_media_messages")
+                                icon.source: "image://theme/icon-m-video"
+                                onClicked: {
+                                    var picker = pageStack.push("Sailfish.Pickers.VideoPickerPage", {
+                                        allowedOrientations: chatPage.allowedOrientations
+                                    })
+                                    picker.selectedContentPropertiesChanged.connect(function(){
+                                        attachmentOptionsFlickable.isNeeded = false;
+                                        Debug.log("Selected video: ", picker.selectedContentProperties.filePath );
+                                        attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
+                                        attachmentPreviewRow.isVideo = true;
+                                        controlSendButton();
+                                    })
+                                }
+                            }
+                            IconButton {
+                                visible: chatPage.hasSendPrivilege("can_send_media_messages")
+                                icon.source: "image://theme/icon-m-mic"
+                                icon.sourceSize {
+                                    width: Theme.iconSizeMedium
+                                    height: Theme.iconSizeMedium
+                                }
+                                highlighted: down || voiceNoteOverlayLoader.active
+                                onClicked: {
+                                    voiceNoteOverlayLoader.active = !voiceNoteOverlayLoader.active;
+                                    stickerPickerLoader.active = false;
+                                }
+                            }
+                            IconButton {
+                                visible: chatPage.hasSendPrivilege("can_send_media_messages")
+                                icon.source: "image://theme/icon-m-document"
+                                onClicked: {
+                                    var picker = pageStack.push("Sailfish.Pickers.FilePickerPage", {
+                                        allowedOrientations: chatPage.allowedOrientations
+                                    })
+                                    picker.selectedContentPropertiesChanged.connect(function(){
+                                        attachmentOptionsFlickable.isNeeded = false;
+                                        Debug.log("Selected document: ", picker.selectedContentProperties.filePath );
+                                        attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
+                                        attachmentPreviewRow.isDocument = true;
+                                        controlSendButton();
+                                    })
+                                }
+                            }
+                            IconButton {
+                                visible: chatPage.hasSendPrivilege("can_send_other_messages")
+                                icon.source: "../../images/icon-m-sticker.svg"
+                                icon.sourceSize {
+                                    width: Theme.iconSizeMedium
+                                    height: Theme.iconSizeMedium
+                                }
+                                highlighted: down || stickerPickerLoader.active
+                                onClicked: {
+                                    stickerPickerLoader.active = !stickerPickerLoader.active;
+                                    voiceNoteOverlayLoader.active = false;
+                                }
+                            }
+                            IconButton {
+                                visible: !(chatPage.isPrivateChat || chatPage.isSecretChat) && chatPage.hasSendPrivilege("can_send_polls")
+                                icon.source: "image://theme/icon-m-question"
+                                onClicked: {
+                                    pageStack.push(Qt.resolvedUrl("../pages/PollCreationPage.qml"), { "chatId" : chatInformation.id, groupName: chatInformation.title});
+                                    attachmentOptionsFlickable.isNeeded = false;
+                                }
+                            }
+                            IconButton {
+                                visible: fernschreiberUtils.supportsGeoLocation() && newMessageTextField.text === ""
+                                icon.source: "image://theme/icon-m-location"
+                                icon.sourceSize {
+                                    width: Theme.iconSizeMedium
+                                    height: Theme.iconSizeMedium
+                                }
+                                onClicked: {
+                                    fernschreiberUtils.startGeoLocationUpdates();
+                                    attachmentOptionsFlickable.isNeeded = false;
+                                    attachmentPreviewRow.isLocation = true;
+                                    attachmentPreviewRow.attachmentDescription = qsTr("Location: Obtaining position...");
+                                    controlSendButton();
+                                }
+                            }
+                        }
+
                     }
 
 
                     Row {
-                        id: attachmentOptionsRow
-
-                        height: attachImageIconButton.height
-
-                        anchors.right: parent.right
-                        layoutDirection: Qt.RightToLeft
+                        id: attachmentPreviewRow
+                        visible: (!!locationData || !!fileProperties) && !inlineQuery.userNameIsValid
                         spacing: Theme.paddingMedium
-                        leftPadding: Theme.horizontalPageMargin
-                        rightPadding: Theme.horizontalPageMargin
+                        width: parent.width
+                        layoutDirection: Qt.RightToLeft
+                        anchors.right: parent.right
+
+                        property bool isPicture: false;
+                        property bool isVideo: false;
+                        property bool isDocument: false;
+                        property bool isVoiceNote: false;
+                        property bool isLocation: false;
+                        property var locationData: null;
+                        property var fileProperties: null;
+                        property string attachmentDescription: "";
+
+                        Connections {
+                            target: fernschreiberUtils
+                            onNewPositionInformation: {
+                                attachmentPreviewRow.locationData = positionInformation;
+                                if (attachmentPreviewRow.isLocation) {
+                                    attachmentPreviewRow.attachmentDescription = qsTr("Location (%1/%2)").arg(attachmentPreviewRow.locationData.latitude).arg(attachmentPreviewRow.locationData.longitude);
+                                }
+                            }
+                        }
 
                         IconButton {
-                            id: attachImageIconButton
-                            visible: chatPage.hasSendPrivilege("can_send_media_messages")
-                            icon.source: "image://theme/icon-m-image"
+                            id: removeAttachmentsIconButton
+                            icon.source: "image://theme/icon-m-clear"
                             onClicked: {
-                                var picker = pageStack.push("Sailfish.Pickers.ImagePickerPage", {
-                                    allowedOrientations: chatPage.allowedOrientations
-                                })
-                                picker.selectedContentPropertiesChanged.connect(function(){
-                                    attachmentOptionsFlickable.isNeeded = false;
-                                    Debug.log("Selected document: ", picker.selectedContentProperties.filePath );
-                                    attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
-                                    attachmentPreviewRow.isPicture = true;
-                                    controlSendButton();
-                                })
-                            }
-                        }
-                        IconButton {
-                            visible: chatPage.hasSendPrivilege("can_send_media_messages")
-                            icon.source: "image://theme/icon-m-video"
-                            onClicked: {
-                                var picker = pageStack.push("Sailfish.Pickers.VideoPickerPage", {
-                                    allowedOrientations: chatPage.allowedOrientations
-                                })
-                                picker.selectedContentPropertiesChanged.connect(function(){
-                                    attachmentOptionsFlickable.isNeeded = false;
-                                    Debug.log("Selected video: ", picker.selectedContentProperties.filePath );
-                                    attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
-                                    attachmentPreviewRow.isVideo = true;
-                                    controlSendButton();
-                                })
-                            }
-                        }
-                        IconButton {
-                            visible: chatPage.hasSendPrivilege("can_send_media_messages")
-                            icon.source: "image://theme/icon-m-mic"
-                            icon.sourceSize {
-                                width: Theme.iconSizeMedium
-                                height: Theme.iconSizeMedium
-                            }
-                            highlighted: down || voiceNoteOverlayLoader.active
-                            onClicked: {
-                                voiceNoteOverlayLoader.active = !voiceNoteOverlayLoader.active;
-                                stickerPickerLoader.active = false;
-                            }
-                        }
-                        IconButton {
-                            visible: chatPage.hasSendPrivilege("can_send_media_messages")
-                            icon.source: "image://theme/icon-m-document"
-                            onClicked: {
-                                var picker = pageStack.push("Sailfish.Pickers.FilePickerPage", {
-                                    allowedOrientations: chatPage.allowedOrientations
-                                })
-                                picker.selectedContentPropertiesChanged.connect(function(){
-                                    attachmentOptionsFlickable.isNeeded = false;
-                                    Debug.log("Selected document: ", picker.selectedContentProperties.filePath );
-                                    attachmentPreviewRow.fileProperties = picker.selectedContentProperties;
-                                    attachmentPreviewRow.isDocument = true;
-                                    controlSendButton();
-                                })
-                            }
-                        }
-                        IconButton {
-                            visible: chatPage.hasSendPrivilege("can_send_other_messages")
-                            icon.source: "../../images/icon-m-sticker.svg"
-                            icon.sourceSize {
-                                width: Theme.iconSizeMedium
-                                height: Theme.iconSizeMedium
-                            }
-                            highlighted: down || stickerPickerLoader.active
-                            onClicked: {
-                                stickerPickerLoader.active = !stickerPickerLoader.active;
-                                voiceNoteOverlayLoader.active = false;
-                            }
-                        }
-                        IconButton {
-                            visible: !(chatPage.isPrivateChat || chatPage.isSecretChat) && chatPage.hasSendPrivilege("can_send_polls")
-                            icon.source: "image://theme/icon-m-question"
-                            onClicked: {
-                                pageStack.push(Qt.resolvedUrl("../pages/PollCreationPage.qml"), { "chatId" : chatInformation.id, groupName: chatInformation.title});
-                                attachmentOptionsFlickable.isNeeded = false;
-                            }
-                        }
-                        IconButton {
-                            visible: fernschreiberUtils.supportsGeoLocation() && newMessageTextField.text === ""
-                            icon.source: "image://theme/icon-m-location"
-                            icon.sourceSize {
-                                width: Theme.iconSizeMedium
-                                height: Theme.iconSizeMedium
-                            }
-                            onClicked: {
-                                fernschreiberUtils.startGeoLocationUpdates();
-                                attachmentOptionsFlickable.isNeeded = false;
-                                attachmentPreviewRow.isLocation = true;
-                                attachmentPreviewRow.attachmentDescription = qsTr("Location: Obtaining position...");
+                                clearAttachmentPreviewRow();
                                 controlSendButton();
                             }
                         }
+
+                        Thumbnail {
+                            id: attachmentPreviewImage
+                            width: Theme.itemSizeMedium
+                            height: Theme.itemSizeMedium
+                            sourceSize.width: width
+                            sourceSize.height: height
+
+                            fillMode: Thumbnail.PreserveAspectCrop
+                            mimeType: !!attachmentPreviewRow.fileProperties ? attachmentPreviewRow.fileProperties.mimeType || "" : ""
+                            source: !!attachmentPreviewRow.fileProperties ? attachmentPreviewRow.fileProperties.url || "" : ""
+                            visible: attachmentPreviewRow.isPicture || attachmentPreviewRow.isVideo
+                        }
+
+                        Label {
+                            id: attachmentPreviewText
+                            font.pixelSize: Theme.fontSizeSmall
+                            text: ( attachmentPreviewRow.isVoiceNote || attachmentPreviewRow.isLocation ) ? attachmentPreviewRow.attachmentDescription : ( !!attachmentPreviewRow.fileProperties ? attachmentPreviewRow.fileProperties.fileName || "" : "" );
+                            anchors.verticalCenter: parent.verticalCenter
+
+                            maximumLineCount: 1
+                            truncationMode: TruncationMode.Fade
+                            color: Theme.secondaryColor
+                            visible: attachmentPreviewRow.isDocument || attachmentPreviewRow.isVoiceNote || attachmentPreviewRow.isLocation
+                        }
                     }
 
-                }
+                    Row {
+                        id: uploadStatusRow
+                        visible: false
+                        spacing: Theme.paddingMedium
+                        width: parent.width
+                        anchors.right: parent.right
 
+                        Text {
+                            id: uploadingText
+                            font.pixelSize: Theme.fontSizeSmall
+                            text: qsTr("Uploading...")
+                            anchors.verticalCenter: parent.verticalCenter
+                            color: Theme.secondaryColor
+                            visible: uploadStatusRow.visible
+                        }
 
-                Row {
-                    id: attachmentPreviewRow
-                    visible: (!!locationData || !!fileProperties) && !inlineQuery.userNameIsValid
-                    spacing: Theme.paddingMedium
-                    width: parent.width
-                    layoutDirection: Qt.RightToLeft
-                    anchors.right: parent.right
+                        ProgressBar {
+                            id: uploadingProgressBar
+                            minimumValue: 0
+                            maximumValue: 100
+                            value: 0
+                            visible: uploadStatusRow.visible
+                            width: parent.width - uploadingText.width - Theme.paddingMedium
+                        }
 
-                    property bool isPicture: false;
-                    property bool isVideo: false;
-                    property bool isDocument: false;
-                    property bool isVoiceNote: false;
-                    property bool isLocation: false;
-                    property var locationData: null;
-                    property var fileProperties: null;
-                    property string attachmentDescription: "";
+                    }
 
-                    Connections {
-                        target: fernschreiberUtils
-                        onNewPositionInformation: {
-                            attachmentPreviewRow.locationData = positionInformation;
-                            if (attachmentPreviewRow.isLocation) {
-                                attachmentPreviewRow.attachmentDescription = qsTr("Location (%1/%2)").arg(attachmentPreviewRow.locationData.latitude).arg(attachmentPreviewRow.locationData.longitude);
+                    Column {
+                        id: emojiColumn
+                        width: parent.width
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: emojiProposals ? ( emojiProposals.length > 0 ? true : false ) : false
+                        opacity: emojiProposals ? ( emojiProposals.length > 0 ? 1 : 0 ) : 0
+                        Behavior on opacity { NumberAnimation {} }
+                        spacing: Theme.paddingMedium
+
+                        Flickable {
+                            width: parent.width
+                            height: emojiResultRow.height + Theme.paddingSmall
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            contentWidth: emojiResultRow.width
+                            clip: true
+                            Row {
+                                id: emojiResultRow
+                                spacing: Theme.paddingMedium
+                                Repeater {
+                                    model: emojiProposals
+
+                                    Item {
+                                        height: singleEmojiRow.height
+                                        width: singleEmojiRow.width
+
+                                        Row {
+                                            id: singleEmojiRow
+                                            spacing: Theme.paddingSmall
+
+                                            Image {
+                                                id: emojiPicture
+                                                source: "../js/emoji/" + modelData.file_name
+                                                width: Theme.fontSizeLarge
+                                                height: Theme.fontSizeLarge
+                                            }
+
+                                        }
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            onClicked: {
+                                                replaceMessageText(newMessageTextField.text, newMessageTextField.cursorPosition, modelData.emoji);
+                                                emojiProposals = null;
+                                            }
+                                        }
+                                    }
+
+                                }
                             }
                         }
                     }
 
-                    IconButton {
-                        id: removeAttachmentsIconButton
-                        icon.source: "image://theme/icon-m-clear"
-                        onClicked: {
-                            clearAttachmentPreviewRow();
-                            controlSendButton();
+                    Column {
+                        id: atMentionColumn
+                        width: parent.width
+                        anchors.horizontalCenter: parent.horizontalCenter
+                        visible: opacity > 0
+                        opacity: knownUsersRepeater.count > 0 ? 1 : 0
+                        Behavior on opacity { NumberAnimation {} }
+                        height: knownUsersRepeater.count > 0 ? childrenRect.height : 0
+                        Behavior on height { SmoothedAnimation { duration: 200 } }
+                        spacing: Theme.paddingMedium
+
+                        Flickable {
+                            width: parent.width
+                            height: atMentionResultRow.height + Theme.paddingSmall
+                            anchors.horizontalCenter: parent.horizontalCenter
+                            contentWidth: atMentionResultRow.width
+                            clip: true
+                            Row {
+                                id: atMentionResultRow
+                                spacing: Theme.paddingMedium
+                                Repeater {
+                                    id: knownUsersRepeater
+
+                                    Item {
+                                        id: knownUserItem
+                                        height: singleAtMentionRow.height
+                                        width: singleAtMentionRow.width
+
+                                        property string atMentionText: "@" + (user_name ? user_name : user_id + "(" + title + ")");
+
+                                        Row {
+                                            id: singleAtMentionRow
+                                            spacing: Theme.paddingSmall
+
+                                            Item {
+                                                width: Theme.fontSizeHuge
+                                                height: Theme.fontSizeHuge
+                                                anchors.verticalCenter: parent.verticalCenter
+                                                ProfileThumbnail {
+                                                    id: atMentionThumbnail
+                                                    replacementStringHint: title
+                                                    width: parent.width
+                                                    height: parent.width
+                                                    photoData: photo_small
+                                                }
+                                            }
+
+                                            Column {
+                                                Text {
+                                                    text: Emoji.emojify(title, Theme.fontSizeExtraSmall)
+                                                    textFormat: Text.StyledText
+                                                    color: Theme.primaryColor
+                                                    font.pixelSize: Theme.fontSizeExtraSmall
+                                                    font.bold: true
+                                                }
+                                                Text {
+                                                    id: userHandleText
+                                                    text: user_handle
+                                                    textFormat: Text.StyledText
+                                                    color: Theme.primaryColor
+                                                    font.pixelSize: Theme.fontSizeExtraSmall
+                                                }
+                                            }
+                                        }
+
+                                        MouseArea {
+                                            anchors.fill: parent
+                                            onClicked: {
+                                                replaceMessageText(newMessageTextField.text, newMessageTextField.cursorPosition, knownUserItem.atMentionText);
+                                                knownUsersRepeater.model = undefined;
+                                            }
+                                        }
+                                    }
+
+                                }
+                            }
                         }
                     }
 
-                    Thumbnail {
-                        id: attachmentPreviewImage
-                        width: Theme.itemSizeMedium
-                        height: Theme.itemSizeMedium
-                        sourceSize.width: width
-                        sourceSize.height: height
-
-                        fillMode: Thumbnail.PreserveAspectCrop
-                        mimeType: !!attachmentPreviewRow.fileProperties ? attachmentPreviewRow.fileProperties.mimeType || "" : ""
-                        source: !!attachmentPreviewRow.fileProperties ? attachmentPreviewRow.fileProperties.url || "" : ""
-                        visible: attachmentPreviewRow.isPicture || attachmentPreviewRow.isVideo
-                    }
-
-                    Label {
-                        id: attachmentPreviewText
-                        font.pixelSize: Theme.fontSizeSmall
-                        text: ( attachmentPreviewRow.isVoiceNote || attachmentPreviewRow.isLocation ) ? attachmentPreviewRow.attachmentDescription : ( !!attachmentPreviewRow.fileProperties ? attachmentPreviewRow.fileProperties.fileName || "" : "" );
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        maximumLineCount: 1
-                        truncationMode: TruncationMode.Fade
-                        color: Theme.secondaryColor
-                        visible: attachmentPreviewRow.isDocument || attachmentPreviewRow.isVoiceNote || attachmentPreviewRow.isLocation
-                    }
-                }
-
-                Row {
-                    id: uploadStatusRow
-                    visible: false
-                    spacing: Theme.paddingMedium
-                    width: parent.width
-                    anchors.right: parent.right
-
-                    Text {
-                        id: uploadingText
-                        font.pixelSize: Theme.fontSizeSmall
-                        text: qsTr("Uploading...")
-                        anchors.verticalCenter: parent.verticalCenter
-                        color: Theme.secondaryColor
-                        visible: uploadStatusRow.visible
-                    }
-
-                    ProgressBar {
-                        id: uploadingProgressBar
-                        minimumValue: 0
-                        maximumValue: 100
-                        value: 0
-                        visible: uploadStatusRow.visible
-                        width: parent.width - uploadingText.width - Theme.paddingMedium
-                    }
-
-                }
-
-                Column {
-                    id: emojiColumn
-                    width: parent.width
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    visible: emojiProposals ? ( emojiProposals.length > 0 ? true : false ) : false
-                    opacity: emojiProposals ? ( emojiProposals.length > 0 ? 1 : 0 ) : 0
-                    Behavior on opacity { NumberAnimation {} }
-                    spacing: Theme.paddingMedium
-
-                    Flickable {
+                    Row {
                         width: parent.width
-                        height: emojiResultRow.height + Theme.paddingSmall
+                        spacing: Theme.paddingSmall
+                        visible: newMessageColumn.editMessageId !== "0"
+
+                        Text {
+                            width: parent.width - Theme.paddingSmall - removeEditMessageIconButton.width
+
+                            anchors.verticalCenter: parent.verticalCenter
+
+                            id: editMessageText
+                            font.pixelSize: Theme.fontSizeSmall
+                            font.bold: true
+                            text: qsTr("Edit Message")
+                            color: Theme.secondaryColor
+                        }
+
+                        IconButton {
+                            id: removeEditMessageIconButton
+                            icon.source: "image://theme/icon-m-clear"
+                            onClicked: {
+                                newMessageColumn.editMessageId = "0";
+                                newMessageTextField.text = "";
+                            }
+                        }
+                    }
+
+                    Row {
+                        id: newMessageRow
+                        width: parent.width
                         anchors.horizontalCenter: parent.horizontalCenter
-                        contentWidth: emojiResultRow.width
-                        clip: true
-                        Row {
-                            id: emojiResultRow
-                            spacing: Theme.paddingMedium
-                            Repeater {
-                                model: emojiProposals
 
-                                Item {
-                                    height: singleEmojiRow.height
-                                    width: singleEmojiRow.width
-
-                                    Row {
-                                        id: singleEmojiRow
-                                        spacing: Theme.paddingSmall
-
-                                        Image {
-                                            id: emojiPicture
-                                            source: "../js/emoji/" + modelData.file_name
-                                            width: Theme.fontSizeLarge
-                                            height: Theme.fontSizeLarge
-                                        }
-
-                                    }
-
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        onClicked: {
-                                            replaceMessageText(newMessageTextField.text, newMessageTextField.cursorPosition, modelData.emoji);
-                                            emojiProposals = null;
-                                        }
+                        TextArea {
+                            id: newMessageTextField
+                            width: parent.width - (attachmentIconButton.visible ? attachmentIconButton.width : 0) - (newMessageSendButton.visible ? newMessageSendButton.width : 0) - (cancelInlineQueryButton.visible ? cancelInlineQueryButton.width : 0)
+                            height: Math.min(chatContainer.height / 3, implicitHeight)
+                            anchors.verticalCenter: parent.verticalCenter
+                            font.pixelSize: Theme.fontSizeSmall
+                            placeholderText: qsTr("Your message")
+                            labelVisible: false
+                            textLeftMargin: 0
+                            textTopMargin: 0
+                            enabled: !attachmentPreviewRow.isLocation
+                            EnterKey.onClicked: {
+                                if (appSettings.sendByEnter) {
+                                    sendMessage();
+                                    newMessageTextField.text = "";
+                                    if(!appSettings.focusTextAreaAfterSend) {
+                                        newMessageTextField.focus = false;
                                     }
                                 }
+                            }
 
+                            EnterKey.enabled: !inlineQuery.userNameIsValid && (!appSettings.sendByEnter || text.length)
+                            EnterKey.iconSource: appSettings.sendByEnter ? "image://theme/icon-m-chat" : "image://theme/icon-m-enter"
+
+                            onTextChanged: {
+                                controlSendButton();
+                                textReplacementTimer.restart();
                             }
                         }
-                    }
-                }
 
-                Column {
-                    id: atMentionColumn
-                    width: parent.width
-                    anchors.horizontalCenter: parent.horizontalCenter
-                    visible: opacity > 0
-                    opacity: knownUsersRepeater.count > 0 ? 1 : 0
-                    Behavior on opacity { NumberAnimation {} }
-                    height: knownUsersRepeater.count > 0 ? childrenRect.height : 0
-                    Behavior on height { SmoothedAnimation { duration: 200 } }
-                    spacing: Theme.paddingMedium
-
-                    Flickable {
-                        width: parent.width
-                        height: atMentionResultRow.height + Theme.paddingSmall
-                        anchors.horizontalCenter: parent.horizontalCenter
-                        contentWidth: atMentionResultRow.width
-                        clip: true
-                        Row {
-                            id: atMentionResultRow
-                            spacing: Theme.paddingMedium
-                            Repeater {
-                                id: knownUsersRepeater
-
-                                Item {
-                                    id: knownUserItem
-                                    height: singleAtMentionRow.height
-                                    width: singleAtMentionRow.width
-
-                                    property string atMentionText: "@" + (user_name ? user_name : user_id + "(" + title + ")");
-
-                                    Row {
-                                        id: singleAtMentionRow
-                                        spacing: Theme.paddingSmall
-
-                                        Item {
-                                            width: Theme.fontSizeHuge
-                                            height: Theme.fontSizeHuge
-                                            anchors.verticalCenter: parent.verticalCenter
-                                            ProfileThumbnail {
-                                                id: atMentionThumbnail
-                                                replacementStringHint: title
-                                                width: parent.width
-                                                height: parent.width
-                                                photoData: photo_small
-                                            }
-                                        }
-
-                                        Column {
-                                            Text {
-                                                text: Emoji.emojify(title, Theme.fontSizeExtraSmall)
-                                                textFormat: Text.StyledText
-                                                color: Theme.primaryColor
-                                                font.pixelSize: Theme.fontSizeExtraSmall
-                                                font.bold: true
-                                            }
-                                            Text {
-                                                id: userHandleText
-                                                text: user_handle
-                                                textFormat: Text.StyledText
-                                                color: Theme.primaryColor
-                                                font.pixelSize: Theme.fontSizeExtraSmall
-                                            }
-                                        }
-                                    }
-
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        onClicked: {
-                                            replaceMessageText(newMessageTextField.text, newMessageTextField.cursorPosition, knownUserItem.atMentionText);
-                                            knownUsersRepeater.model = undefined;
-                                        }
-                                    }
+                        IconButton {
+                            id: attachmentIconButton
+                            icon.source: "image://theme/icon-m-attach?" +  (attachmentOptionsFlickable.isNeeded ? Theme.highlightColor : Theme.primaryColor)
+                            anchors.bottom: parent.bottom
+                            anchors.bottomMargin: Theme.paddingSmall
+                            enabled: !attachmentPreviewRow.visible && !stickerSetOverlayLoader.item
+                            visible: !inlineQuery.userNameIsValid
+                            onClicked: {
+                                if (attachmentOptionsFlickable.isNeeded) {
+                                    attachmentOptionsFlickable.isNeeded = false;
+                                    stickerPickerLoader.active = false;
+                                    voiceNoteOverlayLoader.active = false;
+                                } else {
+                                    attachmentOptionsFlickable.isNeeded = true;
                                 }
-
                             }
                         }
-                    }
-                }
 
-                Row {
-                    width: parent.width
-                    spacing: Theme.paddingSmall
-                    visible: newMessageColumn.editMessageId !== "0"
-
-                    Text {
-                        width: parent.width - Theme.paddingSmall - removeEditMessageIconButton.width
-
-                        anchors.verticalCenter: parent.verticalCenter
-
-                        id: editMessageText
-                        font.pixelSize: Theme.fontSizeSmall
-                        font.bold: true
-                        text: qsTr("Edit Message")
-                        color: Theme.secondaryColor
-                    }
-
-                    IconButton {
-                        id: removeEditMessageIconButton
-                        icon.source: "image://theme/icon-m-clear"
-                        onClicked: {
-                            newMessageColumn.editMessageId = "0";
-                            newMessageTextField.text = "";
-                        }
-                    }
-                }
-
-                Row {
-                    id: newMessageRow
-                    width: parent.width
-                    anchors.horizontalCenter: parent.horizontalCenter
-
-                    TextArea {
-                        id: newMessageTextField
-                        width: parent.width - (attachmentIconButton.visible ? attachmentIconButton.width : 0) - (newMessageSendButton.visible ? newMessageSendButton.width : 0) - (cancelInlineQueryButton.visible ? cancelInlineQueryButton.width : 0)
-                        height: Math.min(chatContainer.height / 3, implicitHeight)
-                        anchors.verticalCenter: parent.verticalCenter
-                        font.pixelSize: Theme.fontSizeSmall
-                        placeholderText: qsTr("Your message")
-                        labelVisible: false
-                        textLeftMargin: 0
-                        textTopMargin: 0
-                        enabled: !attachmentPreviewRow.isLocation
-                        EnterKey.onClicked: {
-                            if (appSettings.sendByEnter) {
+                        IconButton {
+                            id: newMessageSendButton
+                            icon.source: "image://theme/icon-m-chat"
+                            anchors.bottom: parent.bottom
+                            anchors.bottomMargin: Theme.paddingSmall
+                            visible: !inlineQuery.userNameIsValid && (!appSettings.sendByEnter || attachmentPreviewRow.visible)
+                            enabled: false
+                            onClicked: {
                                 sendMessage();
                                 newMessageTextField.text = "";
                                 if(!appSettings.focusTextAreaAfterSend) {
@@ -1764,88 +1896,49 @@ Page {
                             }
                         }
 
-                        EnterKey.enabled: !inlineQuery.userNameIsValid && (!appSettings.sendByEnter || text.length)
-                        EnterKey.iconSource: appSettings.sendByEnter ? "image://theme/icon-m-chat" : "image://theme/icon-m-enter"
+                        Item {
+                            width: cancelInlineQueryButton.width
+                            height: cancelInlineQueryButton.height
+                            visible: inlineQuery.userNameIsValid
+                            anchors.bottom: parent.bottom
+                            anchors.bottomMargin: Theme.paddingSmall
 
-                        onTextChanged: {
-                            controlSendButton();
-                            textReplacementTimer.restart();
-                        }
-                    }
-
-                    IconButton {
-                        id: attachmentIconButton
-                        icon.source: "image://theme/icon-m-attach?" +  (attachmentOptionsFlickable.isNeeded ? Theme.highlightColor : Theme.primaryColor)
-                        anchors.bottom: parent.bottom
-                        anchors.bottomMargin: Theme.paddingSmall
-                        enabled: !attachmentPreviewRow.visible && !stickerSetOverlayLoader.item
-                        visible: !inlineQuery.userNameIsValid
-                        onClicked: {
-                            if (attachmentOptionsFlickable.isNeeded) {
-                                attachmentOptionsFlickable.isNeeded = false;
-                                stickerPickerLoader.active = false;
-                                voiceNoteOverlayLoader.active = false;
-                            } else {
-                                attachmentOptionsFlickable.isNeeded = true;
-                            }
-                        }
-                    }
-
-                    IconButton {
-                        id: newMessageSendButton
-                        icon.source: "image://theme/icon-m-chat"
-                        anchors.bottom: parent.bottom
-                        anchors.bottomMargin: Theme.paddingSmall
-                        visible: !inlineQuery.userNameIsValid && (!appSettings.sendByEnter || attachmentPreviewRow.visible)
-                        enabled: false
-                        onClicked: {
-                            sendMessage();
-                            newMessageTextField.text = "";
-                            if(!appSettings.focusTextAreaAfterSend) {
-                                newMessageTextField.focus = false;
-                            }
-                        }
-                    }
-
-                    Item {
-                        width: cancelInlineQueryButton.width
-                        height: cancelInlineQueryButton.height
-                        visible: inlineQuery.userNameIsValid
-                        anchors.bottom: parent.bottom
-                        anchors.bottomMargin: Theme.paddingSmall
-
-                        IconButton {
-                            id: cancelInlineQueryButton
-                            icon.source: "image://theme/icon-m-cancel"
-                            visible: parent.visible
-                            opacity: inlineQuery.isLoading ? 0.2 : 1
-                            Behavior on opacity { FadeAnimation {} }
-                            onClicked: {
-                                if(inlineQuery.query !== "") {
-                                    newMessageTextField.text = "@" + inlineQuery.userName + " "
-                                    newMessageTextField.cursorPosition = newMessageTextField.text.length
-                                    lostFocusTimer.start();
-                                } else {
+                            IconButton {
+                                id: cancelInlineQueryButton
+                                icon.source: "image://theme/icon-m-cancel"
+                                visible: parent.visible
+                                opacity: inlineQuery.isLoading ? 0.2 : 1
+                                Behavior on opacity { FadeAnimation {} }
+                                onClicked: {
+                                    if(inlineQuery.query !== "") {
+                                        newMessageTextField.text = "@" + inlineQuery.userName + " "
+                                        newMessageTextField.cursorPosition = newMessageTextField.text.length
+                                        lostFocusTimer.start();
+                                    } else {
+                                        newMessageTextField.text = ""
+                                    }
+                                }
+                                onPressAndHold: {
                                     newMessageTextField.text = ""
                                 }
                             }
-                            onPressAndHold: {
-                                newMessageTextField.text = ""
+
+                            BusyIndicator {
+                                size: BusyIndicatorSize.Small
+                                anchors.centerIn: parent
+                                running: inlineQuery.isLoading
                             }
                         }
 
-                        BusyIndicator {
-                            size: BusyIndicatorSize.Small
-                            anchors.centerIn: parent
-                            running: inlineQuery.isLoading
-                        }
+
                     }
-
-
                 }
             }
         }
+
+
     }
+
 
     Loader {
         id: selectedMessagesActions

--- a/qml/pages/ChatSelectionPage.qml
+++ b/qml/pages/ChatSelectionPage.qml
@@ -28,10 +28,18 @@ Dialog {
     allowedOrientations: Orientation.All
     canAccept: false
     acceptDestinationAction: PageStackAction.Replace
-    acceptDestinationReplaceTarget: pageStack.find( function(page){ return(page._depth === 0)} )
+    acceptDestinationReplaceTarget: pageStack.find( function(page){
+        // This crazy workaround is presented to you by a bug introduced with SFOS 4.0.1
+        // See https://forum.sailfishos.org/t/4-0-1-45-pagestack-find-not-working-properly-anymore-in-a-dialog/4723 for details.
+        chatSelectionPage.currentDepth = chatSelectionPage.currentDepth - 1;
+        return(chatSelectionPage.currentDepth === 0);
+    } )
     property int myUserId: tdLibWrapper.getUserInformation().id
     property alias headerTitle: pageHeader.title
     property alias headerDescription: pageHeader.description
+
+    property var currentDepth: pageStack.depth
+
     /*
         payload dependent on chatSelectionPage.state
          - forwardMessages: {fromChatId, messageIds, neededPermissions}

--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -12,7 +12,7 @@ Name:       harbour-fernschreiber
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
 Version:    0.7.1
-Release:    3
+Release:    4
 Group:      Qt/Qt
 License:    LICENSE
 URL:        http://werkwolf.eu/

--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -12,7 +12,7 @@ Name:       harbour-fernschreiber
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
 Version:    0.7.1
-Release:    2
+Release:    3
 Group:      Qt/Qt
 License:    LICENSE
 URL:        http://werkwolf.eu/

--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -12,7 +12,7 @@ Name:       harbour-fernschreiber
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
 Version:    0.7.1
-Release:    4
+Release:    5
 Group:      Qt/Qt
 License:    LICENSE
 URL:        http://werkwolf.eu/

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -1,7 +1,7 @@
 Name: harbour-fernschreiber
 Summary: Fernschreiber is a Telegram client for Sailfish OS
 Version: 0.7.1
-Release: 2
+Release: 3
 # The contents of the Group field should be one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS
 Group: Qt/Qt

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -1,7 +1,7 @@
 Name: harbour-fernschreiber
 Summary: Fernschreiber is a Telegram client for Sailfish OS
 Version: 0.7.1
-Release: 4
+Release: 5
 # The contents of the Group field should be one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS
 Group: Qt/Qt

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -1,7 +1,7 @@
 Name: harbour-fernschreiber
 Summary: Fernschreiber is a Telegram client for Sailfish OS
 Version: 0.7.1
-Release: 3
+Release: 4
 # The contents of the Group field should be one of the groups listed here:
 # https://github.com/mer-tools/spectacle/blob/master/data/GROUPS
 Group: Qt/Qt

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -435,6 +435,14 @@
         <source>Location (%1/%2)</source>
         <translation>Standort (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Nachricht in die Zwischenablage kopieren</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -990,6 +998,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Nachricht losheften</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -463,6 +463,10 @@
         <source>Delete Message</source>
         <translation>Nachricht löschen</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation>Nachricht weiterleiten</translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -437,11 +437,31 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Nachricht in die Zwischenablage kopieren</translation>
+        <translation>Nachricht in die Zwischenablage kopieren</translation>
     </message>
     <message>
-        <source>Message Options</source>
-        <translation type="unfinished"></translation>
+        <source>Message unpinned</source>
+        <translation>Nachricht losgeheftet</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation>Nachricht losheften</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation>Nachricht anheften</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
+        <translation>Zusätzliche Optionen</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation>Nachricht gelöscht</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation>Nachricht löschen</translation>
     </message>
 </context>
 <context>
@@ -964,18 +984,6 @@
         <translation>Nachricht bearbeiten</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Nachricht in die Zwischenablage kopieren</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Nachricht gelöscht</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Nachricht löschen</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Sie</translation>
     </message>
@@ -988,20 +996,8 @@
         <translation>Nachricht auswählen</translation>
     </message>
     <message>
-        <source>Pin Message</source>
-        <translation>Nachricht anheften</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Nachricht losgeheftet</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Nachricht losheften</translation>
-    </message>
-    <message>
         <source>More Options...</source>
-        <translation type="unfinished"></translation>
+        <translation>Mehr Optionen...</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -437,11 +437,31 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Copy Message to Clipboard</translation>
+        <translation>Copy Message to Clipboard</translation>
     </message>
     <message>
-        <source>Message Options</source>
-        <translation type="unfinished"></translation>
+        <source>Message unpinned</source>
+        <translation>Message unpinned</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation>Unpin Message</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation>Pin Message</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
+        <translation>Additional Options</translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation>Message deleted</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation>Delete Message</translation>
     </message>
 </context>
 <context>
@@ -966,18 +986,6 @@ messages</numerusform>
         <translation>Edit Message</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Copy Message to Clipboard</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Message deleted</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Delete Message</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>You</translation>
     </message>
@@ -990,20 +998,8 @@ messages</numerusform>
         <translation>Select Message</translation>
     </message>
     <message>
-        <source>Pin Message</source>
-        <translation>Pin Message</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Message unpinned</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Unpin Message</translation>
-    </message>
-    <message>
         <source>More Options...</source>
-        <translation type="unfinished"></translation>
+        <translation>More Options...</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -463,6 +463,10 @@
         <source>Delete Message</source>
         <translation>Delete Message</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation>Forward Message</translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -435,6 +435,14 @@
         <source>Location (%1/%2)</source>
         <translation>Location (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Copy Message to Clipboard</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -992,6 +1000,10 @@ messages</numerusform>
     <message>
         <source>Unpin Message</source>
         <translation>Unpin Message</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -440,8 +440,28 @@
         <translation type="unfinished">Copiar</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">Mensaje desanclado</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">Desanclar mensaje</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">Anclar mensaje </translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Mensaje borrado</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Borrar</translation>
     </message>
 </context>
 <context>
@@ -964,18 +984,6 @@
         <translation>Editar</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Copiar</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Mensaje borrado</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Borrar</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Usted</translation>
     </message>
@@ -986,18 +994,6 @@
     <message>
         <source>Select Message</source>
         <translation>Seleccionar</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Anclar mensaje </translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Mensaje desanclado</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Desanclar mensaje</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -463,6 +463,10 @@
         <source>Delete Message</source>
         <translation>Borrar</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -437,19 +437,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Copiar</translation>
+        <translation>Copiar</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">Mensaje desanclado</translation>
+        <translation>Mensaje desanclado</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">Desanclar mensaje</translation>
+        <translation>Desanclar mensaje</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">Anclar mensaje </translation>
+        <translation>Anclar mensaje</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -457,11 +457,11 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">Mensaje borrado</translation>
+        <translation>Mensaje borrado</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished">Borrar</translation>
+        <translation>Borrar</translation>
     </message>
 </context>
 <context>
@@ -998,18 +998,6 @@
     <message>
         <source>More Options...</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Anclar mensaje</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Mensaje desanclado</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Desanclar mensaje</translation>
     </message>
 </context>
 <context>
@@ -2164,18 +2152,18 @@
         <source>scored %Ln points</source>
         <comment>myself</comment>
         <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
+            <numerusform>punto %Ln anotado</numerusform>
+            <numerusform>puntos %Ln anotados</numerusform>
         </translation>
     </message>
     <message>
         <source>sent a game</source>
         <comment>myself</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">envió un juego</translation>
     </message>
     <message>
         <source>sent a game</source>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">envió un juego</translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -435,6 +435,14 @@
         <source>Location (%1/%2)</source>
         <translation>Ubicación (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Copiar</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -990,6 +998,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Desanclar mensaje</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -463,6 +463,10 @@
         <source>Delete Message</source>
         <translation>Poista viesti</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -440,8 +440,28 @@
         <translation type="unfinished">Kopioi viesti leikepöydälle</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">Viestin kiinnitys poistettu</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">Poista viestin kiinnitys</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">Kiinnitä viesti</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Viesti poistettu</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Poista viesti</translation>
     </message>
 </context>
 <context>
@@ -965,18 +985,6 @@
         <translation>Muokkaa viestiä</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Kopioi viesti leikepöydälle</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Viesti poistettu</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Poista viesti</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Sinä</translation>
     </message>
@@ -987,18 +995,6 @@
     <message>
         <source>Select Message</source>
         <translation>Valitse viesti</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Kiinnitä viesti</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Viestin kiinnitys poistettu</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Poista viestin kiinnitys</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -437,19 +437,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Kopioi viesti leikepöydälle</translation>
+        <translation>Kopioi viesti leikepöydälle</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">Viestin kiinnitys poistettu</translation>
+        <translation>Viestin kiinnitys poistettu</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">Poista viestin kiinnitys</translation>
+        <translation>Poista viestin kiinnitys</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">Kiinnitä viesti</translation>
+        <translation>Kiinnitä viesti</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -457,11 +457,11 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">Viesti poistettu</translation>
+        <translation>Viesti poistettu</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished">Poista viesti</translation>
+        <translation>Poista viesti</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -435,6 +435,14 @@
         <source>Location (%1/%2)</source>
         <translation>Sijainti (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Kopioi viesti leikepöydälle</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -991,6 +999,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Poista viestin kiinnitys</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -425,6 +425,14 @@
         <source>Location (%1/%2)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -975,6 +983,10 @@
     </message>
     <message>
         <source>Unpin Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More Options...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -430,8 +430,28 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Üzenet törlése</translation>
     </message>
 </context>
 <context>
@@ -950,18 +970,6 @@
         <translation type="unfinished">Üzenet szerkesztése</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation type="unfinished">Üzenet törlése</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation type="unfinished">Te</translation>
     </message>
@@ -971,18 +979,6 @@
     </message>
     <message>
         <source>Select Message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -453,6 +453,10 @@
         <source>Delete Message</source>
         <translation type="unfinished">Üzenet törlése</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -463,6 +463,10 @@
         <source>Delete Message</source>
         <translation>Cancella messaggio</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -435,6 +435,14 @@
         <source>Location (%1/%2)</source>
         <translation>Posizione(%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Copia messaggio nella clipboard</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -990,6 +998,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Togli messaggio in evidenza</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -437,19 +437,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Copia messaggio nella clipboard</translation>
+        <translation>Copia messaggio nella clipboard</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">Messaggio non più in evidenza</translation>
+        <translation>Messaggio non più in evidenza</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">Togli messaggio in evidenza</translation>
+        <translation>Togli messaggio in evidenza</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">Metti messaggio in evidenza</translation>
+        <translation>Metti messaggio in evidenza</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -457,11 +457,11 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">Messaggio cancellato</translation>
+        <translation>Messaggio cancellato</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished">Cancella messaggio</translation>
+        <translation>Cancella messaggio</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -440,8 +440,28 @@
         <translation type="unfinished">Copia messaggio nella clipboard</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">Messaggio non più in evidenza</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">Togli messaggio in evidenza</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">Metti messaggio in evidenza</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Messaggio cancellato</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Cancella messaggio</translation>
     </message>
 </context>
 <context>
@@ -964,18 +984,6 @@
         <translation>Modifica messaggio</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Copia messaggio nella clipboard</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Messaggio cancellato</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Cancella messaggio</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Tu</translation>
     </message>
@@ -986,18 +994,6 @@
     <message>
         <source>Select Message</source>
         <translation>Seleziona messaggio</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Metti messaggio in evidenza</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Messaggio non più in evidenza</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Togli messaggio in evidenza</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -473,6 +473,10 @@
         <source>Delete Message</source>
         <translation>Usuń wiadomość</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -450,8 +450,28 @@
         <translation type="unfinished">Skopiuj wiadomość do schowka</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">Wiadomość opięta</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">Odepnij wiadomość</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">Przypnij wiadomość</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Wiadomość usunięta</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Usuń wiadomość</translation>
     </message>
 </context>
 <context>
@@ -978,18 +998,6 @@
         <translation>Edytuj widomość</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Skopiuj wiadomość do schowka</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Wiadomość usunięta</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Usuń wiadomość</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Ty</translation>
     </message>
@@ -1000,18 +1008,6 @@
     <message>
         <source>Select Message</source>
         <translation>Wybierz wiadomość</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Przypnij wiadomość</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Wiadomość odpięta</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Odepnij wiadomość</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -447,19 +447,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Skopiuj wiadomość do schowka</translation>
+        <translation>Skopiuj wiadomość do schowka</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">Wiadomość opięta</translation>
+        <translation>Wiadomość opięta</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">Odepnij wiadomość</translation>
+        <translation>Odepnij wiadomość</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">Przypnij wiadomość</translation>
+        <translation>Przypnij wiadomość</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -467,11 +467,11 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">Wiadomość usunięta</translation>
+        <translation>Wiadomość usunięta</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished">Usuń wiadomość</translation>
+        <translation>Usuń wiadomość</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -445,6 +445,14 @@
         <source>Location (%1/%2)</source>
         <translation>Lokalizacja (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Skopiuj wiadomość do schowka</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1004,6 +1012,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Odepnij wiadomość</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -445,6 +445,14 @@
         <source>Location (%1/%2)</source>
         <translation>Местоположение (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Скопировать в буфер обмена</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1007,6 +1015,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Открепить сообщение</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -447,19 +447,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Скопировать в буфер обмена</translation>
+        <translation>Скопировать в буфер обмена</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">Сообщение откреплено</translation>
+        <translation>Сообщение откреплено</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">Открепить сообщение</translation>
+        <translation>Открепить сообщение</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">Закрепить сообщение</translation>
+        <translation>Закрепить сообщение</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -467,7 +467,7 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">Сообщение удалено</translation>
+        <translation>Сообщение удалено</translation>
     </message>
     <message>
         <source>Delete Message</source>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -473,6 +473,10 @@
         <source>Delete Message</source>
         <translation type="unfinished">Удалить</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -450,8 +450,28 @@
         <translation type="unfinished">Скопировать в буфер обмена</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">Сообщение откреплено</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">Открепить сообщение</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">Закрепить сообщение</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Сообщение удалено</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Удалить</translation>
     </message>
 </context>
 <context>
@@ -981,18 +1001,6 @@
         <translation>Редактировать</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Скопировать в буфер обмена</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Сообщение удалено</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Удалить</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Вы</translation>
     </message>
@@ -1003,18 +1011,6 @@
     <message>
         <source>Select Message</source>
         <translation>Выбрать сообщение</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Закрепить сообщение</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Сообщение откреплено</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Открепить сообщение</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -473,6 +473,10 @@
         <source>Delete Message</source>
         <translation>Odstrániť správu</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -445,6 +445,14 @@
         <source>Location (%1/%2)</source>
         <translation>Poloha (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Kopírovať správu do schránky</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -1004,6 +1012,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Odopnúť správu</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -447,19 +447,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Kopírovať správu do schránky</translation>
+        <translation>Kopírovať správu do schránky</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">Správa bola odopnutá</translation>
+        <translation>Správa bola odopnutá</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">Odopnúť správu</translation>
+        <translation>Odopnúť správu</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">Pripnúť správu</translation>
+        <translation>Pripnúť správu</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -467,11 +467,11 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">Správa bola odstránená</translation>
+        <translation>Správa bola odstránená</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished">Odstrániť správu</translation>
+        <translation>Odstrániť správu</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -450,8 +450,28 @@
         <translation type="unfinished">Kopírovať správu do schránky</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">Správa bola odopnutá</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">Odopnúť správu</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">Pripnúť správu</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Správa bola odstránená</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Odstrániť správu</translation>
     </message>
 </context>
 <context>
@@ -978,18 +998,6 @@
         <translation>Upraviť správu</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Kopírovať správu do schránky</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Správa bola odstránená</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Odstrániť správu</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Ja</translation>
     </message>
@@ -1000,18 +1008,6 @@
     <message>
         <source>Select Message</source>
         <translation>Vybrať správu</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Pripnúť správu</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Správa bola odopnutá</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Odopnúť správu</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -437,19 +437,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">Kopiera meddelandet till urklipp</translation>
+        <translation>Kopiera meddelandet till urklipp</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">Meddelandet lösgjort</translation>
+        <translation>Meddelandet lösgjort</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">Lösgör meddelandet</translation>
+        <translation>Lösgör meddelandet</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">Fäst meddelandet</translation>
+        <translation>Fäst meddelandet</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -457,11 +457,11 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">Mededelande borttaget</translation>
+        <translation>Mededelande borttaget</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished">Ta bort meddelandet</translation>
+        <translation>Ta bort meddelandet</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -435,6 +435,14 @@
         <source>Location (%1/%2)</source>
         <translation>Plats (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Kopiera meddelandet till urklipp</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -990,6 +998,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>Lösgör meddelandet</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -463,6 +463,10 @@
         <source>Delete Message</source>
         <translation>Ta bort meddelandet</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -440,8 +440,28 @@
         <translation type="unfinished">Kopiera meddelandet till urklipp</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">Meddelandet lösgjort</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">Lösgör meddelandet</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">Fäst meddelandet</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Mededelande borttaget</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Ta bort meddelandet</translation>
     </message>
 </context>
 <context>
@@ -964,18 +984,6 @@
         <translation>Redigera meddelandet</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Kopiera meddelandet till urklipp</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Mededelande borttaget</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Ta bort meddelandet</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>Du</translation>
     </message>
@@ -986,18 +994,6 @@
     <message>
         <source>Select Message</source>
         <translation>Markera meddelanden</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>Fäst meddelandet</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>Meddelandet lösgjort</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>Lösgör meddelandet</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -430,8 +430,28 @@
         <translation type="unfinished">复制消息到剪切板</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
+        <translation type="unfinished">已取消置顶消息</translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished">取消置顶</translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished">置顶消息</translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">已删除消息</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">删除消息</translation>
     </message>
 </context>
 <context>
@@ -951,18 +971,6 @@
         <translation>编辑消息</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>复制消息到剪切板</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>已删除消息</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>删除消息</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>你</translation>
     </message>
@@ -973,18 +981,6 @@
     <message>
         <source>Select Message</source>
         <translation>选择消息</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation>置顶消息</translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation>已取消消息置顶</translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation>取消置顶</translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -425,6 +425,14 @@
         <source>Location (%1/%2)</source>
         <translation>位置 (%1/%2)</translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">复制消息到剪切板</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -977,6 +985,10 @@
     <message>
         <source>Unpin Message</source>
         <translation>取消置顶</translation>
+    </message>
+    <message>
+        <source>More Options...</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -453,6 +453,10 @@
         <source>Delete Message</source>
         <translation>删除消息</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -427,19 +427,19 @@
     </message>
     <message>
         <source>Copy Message to Clipboard</source>
-        <translation type="unfinished">复制消息到剪切板</translation>
+        <translation>复制消息到剪切板</translation>
     </message>
     <message>
         <source>Message unpinned</source>
-        <translation type="unfinished">已取消置顶消息</translation>
+        <translation>已取消置顶消息</translation>
     </message>
     <message>
         <source>Unpin Message</source>
-        <translation type="unfinished">取消置顶</translation>
+        <translation>取消置顶</translation>
     </message>
     <message>
         <source>Pin Message</source>
-        <translation type="unfinished">置顶消息</translation>
+        <translation>置顶消息</translation>
     </message>
     <message>
         <source>Additional Options</source>
@@ -447,11 +447,11 @@
     </message>
     <message>
         <source>Message deleted</source>
-        <translation type="unfinished">已删除消息</translation>
+        <translation>已删除消息</translation>
     </message>
     <message>
         <source>Delete Message</source>
-        <translation type="unfinished">删除消息</translation>
+        <translation>删除消息</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -440,8 +440,28 @@
         <translation type="unfinished">Copy Message to Clipboard</translation>
     </message>
     <message>
-        <source>Message Options</source>
+        <source>Message unpinned</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unpin Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Additional Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Message deleted</source>
+        <translation type="unfinished">Message deleted</translation>
+    </message>
+    <message>
+        <source>Delete Message</source>
+        <translation type="unfinished">Delete Message</translation>
     </message>
 </context>
 <context>
@@ -964,18 +984,6 @@
         <translation>Edit Message</translation>
     </message>
     <message>
-        <source>Copy Message to Clipboard</source>
-        <translation>Copy Message to Clipboard</translation>
-    </message>
-    <message>
-        <source>Message deleted</source>
-        <translation>Message deleted</translation>
-    </message>
-    <message>
-        <source>Delete Message</source>
-        <translation>Delete Message</translation>
-    </message>
-    <message>
         <source>You</source>
         <translation>You</translation>
     </message>
@@ -986,18 +994,6 @@
     <message>
         <source>Select Message</source>
         <translation>Select Message</translation>
-    </message>
-    <message>
-        <source>Pin Message</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Message unpinned</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Unpin Message</source>
-        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>More Options...</source>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -463,6 +463,10 @@
         <source>Delete Message</source>
         <translation type="unfinished">Delete Message</translation>
     </message>
+    <message>
+        <source>Forward Message</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -435,6 +435,14 @@
         <source>Location (%1/%2)</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Copy Message to Clipboard</source>
+        <translation type="unfinished">Copy Message to Clipboard</translation>
+    </message>
+    <message>
+        <source>Message Options</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatSelectionPage</name>
@@ -989,6 +997,10 @@
     </message>
     <message>
         <source>Unpin Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>More Options...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>


### PR DESCRIPTION
This change introduces a message option drawer that may hold all message options that would otherwise make the context menu become too big. With this change
- the message context menu should have 4 items maximum (one of them is "More Options...")
- this "More Options..." option opens the drawer (at the bottom on portrait, to the right on landscape) which contains the other options
Consequently, this fixes #216 :)