### PR TITLE
Don't have on-screen keyboard and drawer visible simultaneously

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -80,9 +80,11 @@ ListItem {
     }
 
     Connections {
-        target: messageOptionsDrawer
-        onCloseRequested: {
-            messageListItem.additionalOptionsOpened = false;
+        target: additionalOptionsOpened ? messageOptionsDrawer : null
+        onOpenChanged: {
+            if (!messageOptionsDrawer.open) {
+                additionalOptionsOpened = false
+            }
         }
     }
 

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -750,14 +750,8 @@ Page {
                     jointModel.push(messageOptionsModel[i]);
                 }
                 drawerListView.model = jointModel;
+                focus = true // Take the focus away from the text field
             }
-        }
-
-        signal closeRequested();
-
-        function closeDrawer() {
-            messageOptionsDrawer.closeRequested();
-            messageOptionsDrawer.open = false;
         }
 
         anchors.fill: parent
@@ -793,7 +787,7 @@ Page {
                     icon.source: "image://theme/icon-m-clear"
                     anchors.verticalCenter: parent.verticalCenter
                     onClicked: {
-                        messageOptionsDrawer.closeDrawer();
+                        messageOptionsDrawer.open = false
                     }
                 }
             }
@@ -808,7 +802,7 @@ Page {
                 }
                 onClicked: {
                     modelData.action();
-                    messageOptionsDrawer.closeDrawer();
+                    messageOptionsDrawer.open = false
                 }
                 hidden: !modelData.visible
             }
@@ -1918,6 +1912,11 @@ Page {
                             onTextChanged: {
                                 controlSendButton();
                                 textReplacementTimer.restart();
+                            }
+                            onActiveFocusChanged: {
+                                if (activeFocus) {
+                                    messageOptionsDrawer.open = false
+                                }
                             }
                         }
 


### PR DESCRIPTION
Also, removed unnecessary `closeRequested()` signal.

Generally, my feeling is that since this drawer thing is sort of an extension to the context menu, it should behave more like a context menu, i.e. have a stronger visual association with the item it belongs to.