### PR TITLE
Fix new line in TextInput when using Send By Enter

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1901,6 +1901,8 @@ Page {
                             enabled: !attachmentPreviewRow.isLocation
                             EnterKey.onClicked: {
                                 if (appSettings.sendByEnter) {
+                                    var messageText = newMessageTextField.text;
+                                    newMessageTextField.text = messageText.substring(0, newMessageTextField.cursorPosition -1) + messageText.substring(newMessageTextField.cursorPosition);
                                     sendMessage();
                                     newMessageTextField.text = "";
                                     if(!appSettings.focusTextAreaAfterSend) {


### PR DESCRIPTION
Fixed the line feed that gets added to message text if the cursor is placed anywhere in-between the message text.

Fixes #406 