### PR TITLE
Add focus text on entering chat

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1899,6 +1899,7 @@ Page {
                             textLeftMargin: 0
                             textTopMargin: 0
                             enabled: !attachmentPreviewRow.isLocation
+                            focus: appSettings.focusTextAreaOnChatOpen
                             EnterKey.onClicked: {
                                 if (appSettings.sendByEnter) {
                                     var messageText = newMessageTextField.text;

--- a/qml/pages/SettingsPage.qml
+++ b/qml/pages/SettingsPage.qml
@@ -550,6 +550,17 @@ Page {
 
                 TextSwitch {
                     width: parent.columnWidth
+                    checked: appSettings.focusTextAreaOnChatOpen
+                    text: qsTr("Focus text input on chat open")
+                    description: qsTr("Focus the text input area when entering a chat")
+                    automaticCheck: false
+                    onClicked: {
+                        appSettings.focusTextAreaOnChatOpen = !checked
+                    }
+                }
+
+                TextSwitch {
+                    width: parent.columnWidth
                     checked: appSettings.focusTextAreaAfterSend
                     text: qsTr("Focus text input area after send")
                     description: qsTr("Focus the text input area after sending a message")

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -34,6 +34,7 @@ namespace {
     const QString KEY_REMAINING_INTERACTION_HINTS("remainingInteractionHints");
     const QString KEY_ONLINE_ONLY_MODE("onlineOnlyMode");
     const QString KEY_DELAY_MESSAGE_READ("delayMessageRead");
+    const QString KEY_FOCUS_TEXTAREA_ON_CHAT_OPEN("focusTextAreaOnChatOpen");
 }
 
 AppSettings::AppSettings(QObject *parent) : QObject(parent), settings("harbour-fernschreiber", "settings")
@@ -220,5 +221,19 @@ void AppSettings::setDelayMessageRead(bool enable)
         LOG(KEY_DELAY_MESSAGE_READ << enable);
         settings.setValue(KEY_DELAY_MESSAGE_READ, enable);
         emit delayMessageReadChanged();
+    }
+}
+
+bool AppSettings::getFocusTextAreaOnChatOpen() const
+{
+    return settings.value(KEY_FOCUS_TEXTAREA_ON_CHAT_OPEN, false).toBool();
+}
+
+void AppSettings::setFocusTextAreaOnChatOpen(bool focusTextAreaOnChatOpen)
+{
+    if (getFocusTextAreaOnChatOpen() != focusTextAreaOnChatOpen) {
+        LOG(KEY_FOCUS_TEXTAREA_ON_CHAT_OPEN << focusTextAreaOnChatOpen);
+        settings.setValue(KEY_FOCUS_TEXTAREA_ON_CHAT_OPEN, focusTextAreaOnChatOpen);
+        emit focusTextAreaOnChatOpenChanged();
     }
 }

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -36,6 +36,8 @@ class AppSettings : public QObject {
     Q_PROPERTY(int remainingInteractionHints READ remainingInteractionHints WRITE setRemainingInteractionHints NOTIFY remainingInteractionHintsChanged)
     Q_PROPERTY(bool onlineOnlyMode READ onlineOnlyMode WRITE setOnlineOnlyMode NOTIFY onlineOnlyModeChanged)
     Q_PROPERTY(bool delayMessageRead READ delayMessageRead WRITE setDelayMessageRead NOTIFY delayMessageReadChanged)
+    Q_PROPERTY(bool focusTextAreaOnChatOpen READ getFocusTextAreaOnChatOpen WRITE setFocusTextAreaOnChatOpen NOTIFY focusTextAreaOnChatOpenChanged)
+
 
 public:
     enum NotificationFeedback {
@@ -87,6 +89,9 @@ public:
     bool delayMessageRead() const;
     void setDelayMessageRead(bool enable);
 
+    bool getFocusTextAreaOnChatOpen() const;
+    void setFocusTextAreaOnChatOpen(bool focusTextAreaOnChatOpen);
+
 signals:
     void sendByEnterChanged();
     void focusTextAreaAfterSendChanged();
@@ -101,6 +106,7 @@ signals:
     void remainingInteractionHintsChanged();
     void onlineOnlyModeChanged();
     void delayMessageReadChanged();
+    void focusTextAreaOnChatOpenChanged();
 
 private:
     QSettings settings;

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -1709,6 +1709,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber wird ein bisschen warten, bevor Nachrichten als gelesen markiert werden</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -1711,6 +1711,14 @@ messages</numerusform>
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber will wait a bit before messages are marked as read</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -1709,6 +1709,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Si esta habilitado, la apl espera un segundo hasta que un mensaje que está en la pantalla se marque como leído. Si deshabilitas esta función, los mensajes se marcarán inmediatamente como leído una vez que esté en la pantalla sin desplazarse al mensaje</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -1710,6 +1710,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber odottaa hetken ennen kuin viestit merkitään luetuiksi</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -1682,6 +1682,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -1709,6 +1709,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber attende un attimo prima di segnare i messaggi come già letti</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -1736,6 +1736,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber odczeka chwilę, zanim wiadomości zostaną oznaczone jako przeczytane </translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -1739,6 +1739,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber может отмечать сообщения как прочитанные с некоторой задержкой, а не сразу как только они показываются на экране.</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -1736,6 +1736,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber chvíľu počká, kým budú správy označené ako prečítané</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -1709,6 +1709,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber väntar en stund innan meddelanden markeras som lästa</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -1683,6 +1683,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation>Fernschreiber 将会在标记消息已读之前延迟一下</translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -1709,6 +1709,14 @@
         <source>Fernschreiber will wait a bit before messages are marked as read</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Focus the text input area when entering a chat</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Focus text input on chat open</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>StickerPicker</name>


### PR DESCRIPTION
Added an option to focus the text area when entering a chat has
been added and the same is exposed under the Settings page.

Closes #322 
