### PR TITLE
Add Github action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,105 @@
+name: Fernschreiber build
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+  # to prevent secrets leaking,
+  # we don't build on PRs
+  #pull_request:
+  #  branches:
+  #    - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+
+    - name: Prepare
+      run: mkdir output
+      
+    - name: Fetch TDLib
+      uses: dsaltares/fetch-gh-release-asset@master
+      with: 
+        repo: "Wunderfitz/td"
+        file: "tdlib.zip"
+        target: tdlib/tdlib.zip
+        token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Decompress TDLib
+      uses: TonyBogdanov/zip@1.0
+      with:
+        args: unzip -qq ./tdlib/tdlib.zip -d ./tdlib
+        
+    - name: Set Secrets
+      uses: DamianReeves/write-file-action@master
+      with:
+        path: ./src/tdlibsecrets.h
+        contents: |
+          #ifndef TDLIBSECRETS_H
+          #define TDLIBSECRETS_H
+          const char TDLIB_API_ID[] = "${{secrets.TDLIB_API_ID}}";
+          const char TDLIB_API_HASH[] = "${{secrets.TDLIB_API_HASH}}";
+          #endif // TDLIBSECRETS_H
+        write-mode: overwrite
+
+    - name: Build armv7hl
+      id: build_armv7hl
+      uses: coderus/github-sfos-build@master
+      with:
+        release: 3.4.0.24
+        
+    - name: Build i486
+      id: build_i486
+      uses: coderus/github-sfos-build@master
+      with:
+        release: 3.4.0.24
+        arch: i486
+
+    # aarch64 complains about ssl/crypto
+    # with older targets, so we use a
+    # newer release
+    - name: Build aarch64
+      id: build_aarch64
+      uses: coderus/github-sfos-build@master
+      with:
+        release: 4.0.1.45
+        arch: aarch64
+      
+    - name: Upload build result
+      uses: actions/upload-artifact@v2
+      with:
+        name: rpm-build-result
+        path: RPMS
+
+    - name: Create release
+      if: contains(github.ref, 'v')
+      run: |
+        set -x
+        assets=()
+        for asset in RPMS/*.rpm; do
+          assets+=("-a" "$asset")
+        done
+        tag_name="${GITHUB_REF##*/}"
+        hub release create "${assets[@]}" -m "$tag_name" "$tag_name"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Create prerelease
+      if: contains(github.ref, 'pre')
+      run: |
+        set -x
+        assets=()
+        for asset in RPMS/*.rpm; do
+          assets+=("-a" "$asset")
+        done
+        tag_name="${GITHUB_REF##*/}"
+        hub release create -p "${assets[@]}" -m "$tag_name" -m "This is a pre-release for testing purposes only. It may or may not be unstable." -m "Join the Telegram group to help out: https://github.com/Wunderfitz/harbour-fernschreiber/issues/162" "$tag_name"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Fernschreiber
 A Telegram client for Sailfish OS
 
+[![Fernschreiber build](https://github.com/Wunderfitz/harbour-fernschreiber/actions/workflows/main.yml/badge.svg)](https://github.com/Wunderfitz/harbour-fernschreiber/actions/workflows/main.yml)
 ## Authors
 Sebastian J. Wolf [sebastian@ygriega.de](mailto:sebastian@ygriega.de) and several contributors
 
@@ -10,7 +11,7 @@ Fernschreiber wouldn't be the same without all the people helping in making it b
 
 ### Code (Features, Bugfixes, Optimizations etc.)
 - Chat list model, chat model, notifications, TDLib receiver, animated stickers, project dependencies, qml/c++ optimizations, chatPhoto, TDLibFile, code reviews, logging categories: [Slava Monich](https://github.com/monich)
-- Chat info page, performance improvements to chat page, location support, app initialization/registration with Telegram, project dependencies, emoji handling, qml/js optimizations, multi-message actions, i18n fixes, chat permission handling, code reviews, logging categories, bot support: [jgibbon](https://github.com/jgibbon)
+- Chat info page, performance improvements to chat page, location support, app initialization/registration with Telegram, project dependencies, emoji handling, qml/js optimizations, multi-message actions, i18n fixes, chat permission handling, code reviews, logging categories, bot support, github build: [jgibbon](https://github.com/jgibbon)
 - Copy message to clipboard [Christian Stemmle](https://github.com/chstem)
 - Hide send message button if send-by-enter is switched on, focus text input on entering a chat [santhoshmanikandan](https://github.com/santhoshmanikandan)
 
@@ -32,6 +33,7 @@ Fernschreiber wouldn't be the same without all the people helping in making it b
 Licensed under GNU GPLv3
 
 ## Build
+### Local build
 Simply clone this repository and ensure to have all [submodules](https://git-scm.com/docs/git-submodule) imported as well (e.g. by using `git submodule update --init`). Then use the project file `harbour-fernschreiber.pro` to import the sources in your SailfishOS IDE. To build and run Fernschreiber or an application which is based on Fernschreiber, you need to create the file `harbour-fernschreiber/src/tdlibsecrets.h` and enter the required constants in the following format:
 
 ```
@@ -45,6 +47,8 @@ const char TDLIB_API_HASH[] = "1234567890abcdef1234567890abcdef";
 You get the Telegram API ID and hash as soon as you've registered your own application on [https://my.telegram.org](https://my.telegram.org).
 
 Moreover, you need to have a compiled version of [TDLib 1.7](https://github.com/tdlib/td) in the sub-directory `tdlib`. This sub-directory must contain another sub-directory that fits to the target device architecture (e.g. armv7hl, i486). Within this directory, there needs to be a folder called `lib` that contains at least `libtdjson.so`. For armv7hl the relative path would consequently be `tdlib/armv7hl/lib`.
+
+You may just want to download the [tdlib.zip from our fork](https://github.com/Wunderfitz/td/releases) to just use the exact version of the latest official Fernschreiber release. To use it, you need to extract it into your local `tdlib/` folder as described above. If so, you're done and can compile Fernschreiber using the Sailfish SDK. If you want to build TDLib for yourself, please keep on reading.
 
 In case you encounter strange performance issues on startup (several seconds delay, app seems to do nothing), please be sure to [follow the instructions from the respective GitHub issue](https://github.com/tdlib/td/issues/1322), i.e. let TDLib build SQLite with `-DOMIT_MEMLOCK` and be sure to comment the two lines 22558 (`#ifndef OMIT_MEMLOCK`) and 22567 (`#endif`) in the file `sqlite/sqlite/sqlite3.c`.
 
@@ -61,11 +65,22 @@ In case you want to use the same codebase which was used to compile the library 
 
 You'll find the compiled library in the directory `td/tdlib`.
 
+### Github Action
+Please read the "Local build" section anyway to understand what's going on before continuing. If you want to automatically build your fork on Github, you'll still need to get a Telegram API ID and hash. These are then [added as project secrets](https://docs.github.com/en/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository) named `TDLIB_API_ID` and `TDLIB_API_HASH`.
+
+By default, only commits to the master branch will be built. You may [change that for your fork](https://docs.github.com/en/actions/quickstart), but please don't create a pull request to the official repository changing the github action without consulting the [Fernschreiber contributors](https://github.com/Wunderfitz/harbour-fernschreiber/issues/162) first.
+
+If you push a tag containing the letter "v" (for example "v0.99.3"), a github release will be created allowing easy download of the resulting rpms. If the tag is named for example "pre-0.99.3", the resulting release is marked as a pre-release for testing purposes.
+
 
 ## Debug
 Fernschreiber does only output a few TDLib messages by default. To get its own debug log messages, you can either run a debug build to see all of them or use the environment variable `QT_LOGGING_RULES` to specify/filter which messages you'd like to see.
 
 Run `QT_LOGGING_RULES="fernschreiber.*=true" harbour-fernschreiber` to see all messages or replace the `*` with specific logging categories. You'll find the logging category inside the corresponding `.cpp` file for backend usage or you can use `JS` to only see frontend messages.
+
+You can append ` &> fernschreiber.log` to the command to create a text file containing the debug messages. 
+
+**Please be aware that debug messages will most likely include personal information** including (but not limited to) chat content and user ids/names of yourself and all your chat partners. Do not share it publicly and, at your discretion, try to remove private info even from the parts you do share with a trusted person.
 
 ## Contribute
 


### PR DESCRIPTION
As far as I've seen, it works well – but I've lacked the time to test the resulting packages thoroughly, just quickly installed/ran on my dev XA2.

Minimal documentation of what to do and how to use it is inside the README.md – basically, it tries to build after each push to master (we could limit that in the future). After adding the repository secrets, these builds should even work and produce an artifact .zip. Pushing a tag like "v0.123.9" creates a github release, "pre-0.123.9" creates a release marked as "pre release". See https://github.com/jgibbon/harbour-fernschreiber/releases.

Aarch64 builds on a 4.0 target to avoid different errors with both 3.4 and the brand new 4.1 target. The other architectures use 3.4.

cheers!