### PR TITLE
Use larger font for settings section headers

### DIFF
--- a/qml/components/settingsPage/AccordionItem.qml
+++ b/qml/components/settingsPage/AccordionItem.qml
@@ -78,7 +78,6 @@ Item {
             }
             horizontalAlignment: Text.AlignRight
             truncationMode: TruncationMode.Fade
-            font.pixelSize: Theme.fontSizeSmall
             color: button.highlighted ? Theme.highlightColor : Theme.primaryColor
             textFormat: Text.PlainText
         }


### PR DESCRIPTION
Small font in settings section header is bothering me 🙂

![Screenshot_20211205_001](https://user-images.githubusercontent.com/5909522/144727449-78bb256e-2590-4c29-a2c0-fe80534ce6ef.png) ![Screenshot_20211205_002](https://user-images.githubusercontent.com/5909522/144727453-3af611cb-b630-4568-bbfc-542481d7937d.png)

Small size on the left, default (proposed) size on the right. What do you think?