### PR TITLE
Attempt to optimize sponsored message handling

### DIFF
--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -36,6 +36,7 @@ namespace {
     const QString KEY_ONLINE_ONLY_MODE("onlineOnlyMode");
     const QString KEY_DELAY_MESSAGE_READ("delayMessageRead");
     const QString KEY_FOCUS_TEXTAREA_ON_CHAT_OPEN("focusTextAreaOnChatOpen");
+    const QString KEY_SPONSORED_MESS("sponsoredMess");
 }
 
 AppSettings::AppSettings(QObject *parent) : QObject(parent), settings("harbour-fernschreiber", "settings")
@@ -250,5 +251,20 @@ void AppSettings::setFocusTextAreaOnChatOpen(bool focusTextAreaOnChatOpen)
         LOG(KEY_FOCUS_TEXTAREA_ON_CHAT_OPEN << focusTextAreaOnChatOpen);
         settings.setValue(KEY_FOCUS_TEXTAREA_ON_CHAT_OPEN, focusTextAreaOnChatOpen);
         emit focusTextAreaOnChatOpenChanged();
+    }
+}
+
+AppSettings::SponsoredMess AppSettings::getSponsoredMess() const
+{
+    return (SponsoredMess) settings.value(KEY_SPONSORED_MESS, (int)
+        AppSettings::SponsoredMessHandle).toInt();
+}
+
+void AppSettings::setSponsoredMess(SponsoredMess sponsoredMess)
+{
+    if (getSponsoredMess() != sponsoredMess) {
+        LOG(KEY_SPONSORED_MESS << sponsoredMess);
+        settings.setValue(KEY_SPONSORED_MESS, sponsoredMess);
+        emit sponsoredMessChanged();
     }
 }

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -38,9 +38,16 @@ class AppSettings : public QObject {
     Q_PROPERTY(bool onlineOnlyMode READ onlineOnlyMode WRITE setOnlineOnlyMode NOTIFY onlineOnlyModeChanged)
     Q_PROPERTY(bool delayMessageRead READ delayMessageRead WRITE setDelayMessageRead NOTIFY delayMessageReadChanged)
     Q_PROPERTY(bool focusTextAreaOnChatOpen READ getFocusTextAreaOnChatOpen WRITE setFocusTextAreaOnChatOpen NOTIFY focusTextAreaOnChatOpenChanged)
-
+    Q_PROPERTY(SponsoredMess sponsoredMess READ getSponsoredMess WRITE setSponsoredMess NOTIFY sponsoredMessChanged)
 
 public:
+    enum SponsoredMess {
+        SponsoredMessHandle,
+        SponsoredMessAutoView,
+        SponsoredMessIgnore
+    };
+    Q_ENUM(SponsoredMess)
+
     enum NotificationFeedback {
         NotificationFeedbackNone,
         NotificationFeedbackNew,
@@ -96,6 +103,9 @@ public:
     bool getFocusTextAreaOnChatOpen() const;
     void setFocusTextAreaOnChatOpen(bool focusTextAreaOnChatOpen);
 
+    SponsoredMess getSponsoredMess() const;
+    void setSponsoredMess(SponsoredMess sponsoredMess);
+
 signals:
     void sendByEnterChanged();
     void focusTextAreaAfterSendChanged();
@@ -112,6 +122,7 @@ signals:
     void onlineOnlyModeChanged();
     void delayMessageReadChanged();
     void focusTextAreaOnChatOpenChanged();
+    void sponsoredMessChanged();
 
 private:
     QSettings settings;

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -248,7 +248,7 @@ ChatModel::ChatModel(TDLibWrapper *tdLibWrapper) :
 {
     this->tdLibWrapper = tdLibWrapper;
     connect(this->tdLibWrapper, SIGNAL(messagesReceived(QVariantList, int)), this, SLOT(handleMessagesReceived(QVariantList, int)));
-    connect(this->tdLibWrapper, SIGNAL(sponsoredMessagesReceived(QVariantList)), this, SLOT(handleSponsoredMessagesReceived(QVariantList)));
+    connect(this->tdLibWrapper, SIGNAL(sponsoredMessagesReceived(qlonglong, QVariantList)), this, SLOT(handleSponsoredMessagesReceived(qlonglong, QVariantList)));
     connect(this->tdLibWrapper, SIGNAL(newMessageReceived(qlonglong, QVariantMap)), this, SLOT(handleNewMessageReceived(qlonglong, QVariantMap)));
     connect(this->tdLibWrapper, SIGNAL(receivedMessage(qlonglong, qlonglong, QVariantMap)), this, SLOT(handleMessageReceived(qlonglong, qlonglong, QVariantMap)));
     connect(this->tdLibWrapper, SIGNAL(chatReadInboxUpdated(QString, QString, int)), this, SLOT(handleChatReadInboxUpdated(QString, QString, int)));
@@ -479,10 +479,10 @@ void ChatModel::handleMessagesReceived(const QVariantList &messages, int totalCo
 
 }
 
-void ChatModel::handleSponsoredMessagesReceived(const QVariantList &sponsoredMessages)
+void ChatModel::handleSponsoredMessagesReceived(qlonglong chatId, const QVariantList &sponsoredMessages)
 {
-    LOG("Handling sponsored messages:" <<sponsoredMessages.size());
-    if (sponsoredMessages.size() > 0) {
+    if (chatId == this->chatId && sponsoredMessages.size() > 0) {
+        LOG("Handling sponsored messages:" <<sponsoredMessages.size());
         QList<MessageData*> messagesToBeAdded;
         for (QVariant sponsoredMessage: sponsoredMessages) {
             QVariantMap sponsoredMessageData = sponsoredMessage.toMap();

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -63,7 +63,7 @@ signals:
 
 private slots:
     void handleMessagesReceived(const QVariantList &messages, int totalCount);
-    void handleSponsoredMessagesReceived(const QVariantList &sponsoredMessages);
+    void handleSponsoredMessagesReceived(qlonglong chatId, const QVariantList &sponsoredMessages);
     void handleNewMessageReceived(qlonglong chatId, const QVariantMap &message);
     void handleMessageReceived(qlonglong chatId, qlonglong messageId, const QVariantMap &message);
     void handleChatReadInboxUpdated(const QString &chatId, const QString &lastReadInboxMessageId, int unreadCount);

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -359,8 +359,9 @@ void TDLibReceiver::processMessages(const QVariantMap &receivedInformation)
 
 void TDLibReceiver::processSponsoredMessages(const QVariantMap &receivedInformation)
 {
-    LOG("Received sponsored messages");
-    emit sponsoredMessagesReceived(receivedInformation.value("messages").toList());
+    const qlonglong chatId = receivedInformation.value(EXTRA).toLongLong(); // See TDLibWrapper::getChatSponsoredMessages
+    LOG("Received sponsored messages for chat" << chatId);
+    emit sponsoredMessagesReceived(chatId, receivedInformation.value(MESSAGES).toList());
 }
 
 void TDLibReceiver::processUpdateNewMessage(const QVariantMap &receivedInformation)

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -56,7 +56,7 @@ signals:
     void superGroupUpdated(qlonglong groupId, const QVariantMap &groupInformation);
     void chatOnlineMemberCountUpdated(const QString &chatId, int onlineMemberCount);
     void messagesReceived(const QVariantList &messages, int totalCount);
-    void sponsoredMessagesReceived(const QVariantList &sponsoredMessages);
+    void sponsoredMessagesReceived(qlonglong chatId, const QVariantList &messages);
     void newMessageReceived(qlonglong chatId, const QVariantMap &message);
     void messageInformation(qlonglong chatId, qlonglong messageId, const QVariantMap &message);
     void messageSendSucceeded(qlonglong messageId, qlonglong oldMessageId, const QVariantMap &message);

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -262,7 +262,7 @@ signals:
     void superGroupUpdated(qlonglong groupId);
     void chatOnlineMemberCountUpdated(const QString &chatId, int onlineMemberCount);
     void messagesReceived(const QVariantList &messages, int totalCount);
-    void sponsoredMessagesReceived(const QVariantList &sponsoredMessages);
+    void sponsoredMessagesReceived(qlonglong chatId, const QVariantList &messages);
     void newMessageReceived(qlonglong chatId, const QVariantMap &message);
     void copyToDownloadsSuccessful(const QString &fileName, const QString &filePath);
     void copyToDownloadsError(const QString &fileName, const QString &filePath);
@@ -335,6 +335,7 @@ public slots:
     void handleMessageIsPinnedUpdated(qlonglong chatId, qlonglong messageId, bool isPinned);
     void handleUserPrivacySettingRules(const QVariantMap &rules);
     void handleUpdatedUserPrivacySettingRules(const QVariantMap &updatedRules);
+    void handleSponsoredMess(qlonglong chatId, const QVariantList &messages);
 
 private:
     void setOption(const QString &name, const QString &type, const QVariant &value);


### PR DESCRIPTION
By reducing number of `QVariantMap` lookups and various run-time conversions to/from `QString`. At expense of allocating even more memory for `messageType`🙁

It's hard to tell whether `messageType` allocation vs `QVariantMap` lookup trade-off really makes sense. Static `TYPE_SPONSORED_MESSAGE` and use of already existing `_TYPE` key definitely do make sense, though.