### PR TITLE
Fixed message reference in Replies chat

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -228,9 +228,9 @@ ListItem {
 
     Component.onCompleted: {
         delegateComponentLoadingTimer.start();
-
-        if (myMessage.reply_to_message_id !== 0) {
-            tdLibWrapper.getMessage(page.chatInformation.id, myMessage.reply_to_message_id);
+        if (myMessage.reply_to_message_id) {
+            tdLibWrapper.getMessage(myMessage.reply_in_chat_id ? myMessage.reply_in_chat_id : page.chatInformation.id,
+                myMessage.reply_to_message_id)
         }
     }
 


### PR DESCRIPTION
According to `td_api.tl`:

**`@reply_in_chat_id`** If non-zero, the identifier of the chat to which the replied message belongs; Currently, only messages in the Replies chat can have different reply_in_chat_id and chat_id