### PR TITLE
Don't try to load message with zero id

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1130,7 +1130,7 @@ Page {
                                     messageOverlayLoader.overlayMessage = chatPage.messageToShow;
                                     messageOverlayLoader.active = true;
                                 }
-                                if (typeof chatPage.messageIdToShow !== "undefined") {
+                                if (chatPage.messageIdToShow) {
                                     tdLibWrapper.getMessage(chatPage.chatInformation.id, chatPage.messageIdToShow);
                                 }
                             }


### PR DESCRIPTION
`chatPage.messageIdToShow` can be defined and yet be zero