### PR TITLE
Adapt handling of sponsored messages to the new format

### DIFF
--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -558,7 +558,7 @@ void ChatModel::handleMessageSendSucceeded(qlonglong messageId, qlonglong oldMes
         const QModelIndex messageIndex(index(pos));
         emit dataChanged(messageIndex, messageIndex, changedRoles);
         emit lastReadSentMessageUpdated(calculateLastReadSentMessageId());
-        tdLibWrapper->viewMessage(QString::number(this->chatId), QString::number(messageId), false);
+        tdLibWrapper->viewMessage(this->chatId, messageId, false);
     }
 }
 

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -346,17 +346,6 @@ void TDLibWrapper::viewMessage(qlonglong chatId, qlonglong messageId, bool force
     this->sendRequest(requestObject);
 }
 
-void TDLibWrapper::viewSponsoredMessage(qlonglong chatId, qlonglong messageId)
-{
-    LOG("Mark sponsored message as viewed" << chatId << messageId);
-    QVariantMap requestObject;
-    requestObject.insert(_TYPE, "viewSponsoredMessage");
-    requestObject.insert(CHAT_ID, chatId);
-    requestObject.insert("sponsored_message_id", messageId);
-    requestObject.insert(_EXTRA, "viewSponsoredMessage");
-    this->sendRequest(requestObject);
-}
-
 void TDLibWrapper::pinMessage(const QString &chatId, const QString &messageId, bool disableNotification)
 {
     LOG("Pin message to chat" << chatId << messageId << disableNotification);
@@ -1890,7 +1879,7 @@ void TDLibWrapper::handleSponsoredMessage(qlonglong chatId, const QVariantMap &m
         break;
     case AppSettings::SponsoredMessAutoView:
         LOG("Auto-viewing sponsored message");
-        viewSponsoredMessage(chatId, message.value(ID).toULongLong());
+        viewMessage(chatId, message.value(MESSAGE_ID).toULongLong(), false);
         break;
     case AppSettings::SponsoredMessIgnore:
         LOG("Ignoring sponsored message");

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -333,7 +333,7 @@ void TDLibWrapper::getChatHistory(qlonglong chatId, qlonglong fromMessageId, int
     this->sendRequest(requestObject);
 }
 
-void TDLibWrapper::viewMessage(const QString &chatId, const QString &messageId, bool force)
+void TDLibWrapper::viewMessage(qlonglong chatId, qlonglong messageId, bool force)
 {
     LOG("Mark message as viewed" << chatId << messageId);
     QVariantMap requestObject;

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -158,7 +158,7 @@ public:
     Q_INVOKABLE void leaveChat(const QString &chatId);
     Q_INVOKABLE void deleteChat(qlonglong chatId);
     Q_INVOKABLE void getChatHistory(qlonglong chatId, qlonglong fromMessageId = 0, int offset = -1, int limit = 50, bool onlyLocal = false);
-    Q_INVOKABLE void viewMessage(const QString &chatId, const QString &messageId, bool force);
+    Q_INVOKABLE void viewMessage(qlonglong chatId, qlonglong messageId, bool force);
     Q_INVOKABLE void viewSponsoredMessage(qlonglong chatId, qlonglong messageId);
     Q_INVOKABLE void pinMessage(const QString &chatId, const QString &messageId, bool disableNotification = false);
     Q_INVOKABLE void unpinMessage(const QString &chatId, const QString &messageId);

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -159,7 +159,6 @@ public:
     Q_INVOKABLE void deleteChat(qlonglong chatId);
     Q_INVOKABLE void getChatHistory(qlonglong chatId, qlonglong fromMessageId = 0, int offset = -1, int limit = 50, bool onlyLocal = false);
     Q_INVOKABLE void viewMessage(qlonglong chatId, qlonglong messageId, bool force);
-    Q_INVOKABLE void viewSponsoredMessage(qlonglong chatId, qlonglong messageId);
     Q_INVOKABLE void pinMessage(const QString &chatId, const QString &messageId, bool disableNotification = false);
     Q_INVOKABLE void unpinMessage(const QString &chatId, const QString &messageId);
     Q_INVOKABLE void sendTextMessage(const QString &chatId, const QString &message, const QString &replyToMessageId = "0");


### PR DESCRIPTION
```
[D] TDLibReceiver::receiverLoop:185 - [TDLibReceiver] Raw result: {
    "@extra": "viewSponsoredMessage",
    "@type": "error",
    "code": 400,
    "message": "Failed to parse JSON object as TDLib request: Unknown class \"viewSponsoredMessage\""
}
```