### PR TITLE
Improve message when search yields no results

### DIFF
--- a/qml/pages/NewChatPage.qml
+++ b/qml/pages/NewChatPage.qml
@@ -139,7 +139,9 @@ Page {
                         ViewPlaceholder {
                             y: Theme.paddingLarge
                             enabled: contactsListView.count === 0
-                            text: qsTr("You don't have any contacts.")
+                            text: (contactsSearchField.text.length > 0)
+                                ? qsTr("No contacts found.")
+                                : qsTr("You don't have any contacts.")
                         }
 
                         delegate: Item {


### PR DESCRIPTION
Currently, if one searches for contacts in the "New Chat" page, and no contacts match you get the message that  "You don't have any contacts".

This shows "No contacts found" if a search term has been entered.