### PR TITLE
99+ unread balloons

### DIFF
--- a/qml/components/PhotoTextsListItem.qml
+++ b/qml/components/PhotoTextsListItem.qml
@@ -1,6 +1,7 @@
 import QtQuick 2.6
 import Sailfish.Silica 1.0
 import WerkWolf.Fernschreiber 1.0
+import "../js/functions.js" as Functions
 
 ListItem {
     id: chatListViewItem
@@ -103,7 +104,7 @@ ListItem {
                 anchors.centerIn: chatUnreadMessagesCountBackground
                 visible: chatListViewItem.unreadCount > 0
                 opacity: isMuted ? Theme.opacityHigh : 1.0
-                text: chatListViewItem.unreadCount > 99 ? "99+" : chatListViewItem.unreadCount
+                text: Functions.formatUnreadCount(chatListViewItem.unreadCount)
             }
 
             Rectangle {

--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -27,6 +27,14 @@ function setGlobals(globals) {
     tdLibWrapper = globals.tdLibWrapper;
     appNotification = globals.appNotification;
 }
+function formatUnreadCount(value) {
+    if(value < 1000) {
+        return value;
+    } else if(value > 9000) {
+        return '9k+';
+    }
+    return ''+Math.floor(value / 1000)+'k'+((value % 1000)>0 ? '+' : '');
+}
 
 function getUserName(userInformation) {
     return ((userInformation.first_name || "") + " " + (userInformation.last_name || "")).trim();

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -618,8 +618,8 @@ Page {
         onUnreadCountUpdated: {
             Debug.log("[ChatPage] Unread count updated, new count: ", unreadCount);
             chatInformation.unread_count = unreadCount;
-            chatUnreadMessagesItem.visible = ( !chatPage.loading && chatInformation.unread_count > 0 && chatOverviewItem.visible );
-            chatUnreadMessagesCount.text = unreadCount > 99 ? "99+" : unreadCount;
+            chatUnreadMessagesItem.visible = ( !chatPage.loading && unreadCount > 0 && chatOverviewItem.visible );
+            chatUnreadMessagesCount.text = Functions.formatUnreadCount(unreadCount)
         }
         onLastReadSentMessageUpdated: {
             Debug.log("[ChatPage] Updating last read sent index, new index: ", lastReadSentIndex);
@@ -1427,7 +1427,7 @@ Page {
                             color: Theme.primaryColor
                             anchors.centerIn: chatUnreadMessagesCountBackground
                             visible: chatUnreadMessagesItem.visible
-                            text: chatInformation.unread_count > 99 ? "99+" : chatInformation.unread_count
+                            text: Functions.formatUnreadCount(chatInformation.unread_count)
                         }
                         MouseArea {
                             anchors.fill: parent


### PR DESCRIPTION
A really small change:

- Unread formatting pushed to JS-Function
- Shows actual value until 999 (keeping the three char limit), then switches to 1k, 1k+, 2k, 2k+, ..., 9k+

Visually, it can be a tiny bit more crowded for some values, but I think it is nice to know the difference between, let's say, 150 or 5k. That could be the difference between "ok, I've got some time, let's read" and "oh, no way, mark all as read."