### PR TITLE
Add option to suppress notification previews

### DIFF
--- a/qml/components/settingsPage/SettingsBehavior.qml
+++ b/qml/components/settingsPage/SettingsBehavior.qml
@@ -137,8 +137,11 @@ AccordionItem {
 
             TextSwitch {
                 width: parent.columnWidth
-                checked: appSettings.notificationSuppressContent
+                checked: appSettings.notificationSuppressContent && enabled
                 text: qsTr("Hide content in Notifications")
+                enabled: appSettings.notificationFeedback !== AppSettings.NotificationFeedbackNone
+                clip: height < implicitHeight
+                visible: height > 0
                 automaticCheck: false
                 onClicked: {
                     appSettings.notificationSuppressContent = !checked

--- a/qml/components/settingsPage/SettingsBehavior.qml
+++ b/qml/components/settingsPage/SettingsBehavior.qml
@@ -137,7 +137,7 @@ AccordionItem {
 
             TextSwitch {
                 width: parent.columnWidth
-                checked: appSettings.notificationSuppressContent && enabled
+                checked: appSettings.notificationSuppressContent
                 text: qsTr("Hide content in Notifications")
                 automaticCheck: false
                 onClicked: {

--- a/qml/components/settingsPage/SettingsBehavior.qml
+++ b/qml/components/settingsPage/SettingsBehavior.qml
@@ -137,6 +137,17 @@ AccordionItem {
 
             TextSwitch {
                 width: parent.columnWidth
+                checked: appSettings.notificationSuppressContent && enabled
+                text: qsTr("Hide content in Notifications")
+                automaticCheck: false
+                onClicked: {
+                    appSettings.notificationSuppressContent = !checked
+                }
+                Behavior on height { SmoothedAnimation { duration: 200 } }
+            }
+
+            TextSwitch {
+                width: parent.columnWidth
                 checked: appSettings.notificationTurnsDisplayOn && enabled
                 text: qsTr("Notification turns on the display")
                 enabled: appSettings.notificationFeedback !== AppSettings.NotificationFeedbackNone

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -29,6 +29,7 @@ namespace {
     const QString KEY_ANIMATE_STICKERS("animateStickers");
     const QString KEY_NOTIFICATION_TURNS_DISPLAY_ON("notificationTurnsDisplayOn");
     const QString KEY_NOTIFICATION_SOUNDS_ENABLED("notificationSoundsEnabled");
+    const QString KEY_NOTIFICATION_SUPPRESS_ENABLED("notificationSuppressContent");
     const QString KEY_NOTIFICATION_FEEDBACK("notificationFeedback");
     const QString KEY_STORAGE_OPTIMIZER("useStorageOptimizer");
     const QString KEY_INLINEBOT_LOCATION_ACCESS("allowInlineBotLocationAccess");
@@ -152,6 +153,20 @@ void AppSettings::setNotificationSoundsEnabled(bool enable)
         LOG(KEY_NOTIFICATION_SOUNDS_ENABLED << enable);
         settings.setValue(KEY_NOTIFICATION_SOUNDS_ENABLED, enable);
         emit notificationSoundsEnabledChanged();
+    }
+}
+
+bool AppSettings::notificationSuppressContent() const
+{
+    return settings.value(KEY_NOTIFICATION_SUPPRESS_ENABLED, false).toBool();
+}
+
+void AppSettings::setNotificationSuppressContent(bool enable)
+{
+    if (notificationSuppressContent() != enable) {
+        LOG(KEY_NOTIFICATION_SUPPRESS_ENABLED << enable);
+        settings.setValue(KEY_NOTIFICATION_SUPPRESS_ENABLED, enable);
+        emit notificationSuppressContentChanged();
     }
 }
 

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -32,6 +32,7 @@ class AppSettings : public QObject {
     Q_PROPERTY(bool animateStickers READ animateStickers WRITE setAnimateStickers NOTIFY animateStickersChanged)
     Q_PROPERTY(bool notificationTurnsDisplayOn READ notificationTurnsDisplayOn WRITE setNotificationTurnsDisplayOn NOTIFY notificationTurnsDisplayOnChanged)
     Q_PROPERTY(bool notificationSoundsEnabled READ notificationSoundsEnabled WRITE setNotificationSoundsEnabled NOTIFY notificationSoundsEnabledChanged)
+    Q_PROPERTY(bool notificationSuppressContent READ notificationSuppressContent WRITE setNotificationSuppressContent NOTIFY notificationSuppressContentChanged)
     Q_PROPERTY(NotificationFeedback notificationFeedback READ notificationFeedback WRITE setNotificationFeedback NOTIFY notificationFeedbackChanged)
     Q_PROPERTY(bool storageOptimizer READ storageOptimizer WRITE setStorageOptimizer NOTIFY storageOptimizerChanged)
     Q_PROPERTY(bool allowInlineBotLocationAccess READ allowInlineBotLocationAccess WRITE setAllowInlineBotLocationAccess NOTIFY allowInlineBotLocationAccessChanged)
@@ -83,6 +84,9 @@ public:
     bool notificationSoundsEnabled() const;
     void setNotificationSoundsEnabled(bool enable);
 
+    bool notificationSuppressContent() const;
+    void setNotificationSuppressContent(bool enable);
+
     NotificationFeedback notificationFeedback() const;
     void setNotificationFeedback(NotificationFeedback feedback);
 
@@ -116,6 +120,7 @@ signals:
     void animateStickersChanged();
     void notificationTurnsDisplayOnChanged();
     void notificationSoundsEnabledChanged();
+    void notificationSuppressContentChanged();
     void notificationFeedbackChanged();
     void storageOptimizerChanged();
     void allowInlineBotLocationAccessChanged();

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -380,7 +380,7 @@ void NotificationManager::publishNotification(const NotificationGroup *notificat
         if (!appSettings->notificationSuppressContent()) {
             nemoNotification->setPreviewBody(notificationBody);
         } else {
-            nemoNotification->setPreviewBody(tr("<<message content hidden>>",""));
+            nemoNotification->setPreviewBody(tr("%Ln unread messages", "", notificationGroup->totalCount));
         }
         nemoNotification->setPreviewSummary(summary);
         nemoNotification->setHintValue(HINT_SUPPRESS_SOUND, !appSettings->notificationSoundsEnabled());

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -377,7 +377,11 @@ void NotificationManager::publishNotification(const NotificationGroup *notificat
         nemoNotification->setHintValue(HINT_VISIBILITY, QString());
         nemoNotification->setUrgency(Notification::Low);
     } else {
-        nemoNotification->setPreviewBody(notificationBody);
+        if (!appSettings->notificationSuppressContent()) {
+            nemoNotification->setPreviewBody(notificationBody);
+        } else {
+            nemoNotification->setPreviewBody(tr("<<message content hidden>>",""));
+        }
         nemoNotification->setPreviewSummary(summary);
         nemoNotification->setHintValue(HINT_SUPPRESS_SOUND, !appSettings->notificationSoundsEnabled());
         nemoNotification->setHintValue(HINT_DISPLAY_ON, appSettings->notificationTurnsDisplayOn());


### PR DESCRIPTION
Currently untested, this was suggested in the German SFOS Telegram group.
Does not show message content in notifications.

A privacy/anti-embarrassment feature.
