### PR TITLE
Move macros to yaml

### DIFF
--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -6,9 +6,9 @@
 Name:       harbour-fernschreiber
 
 # >> macros
+# << macros
 %define __provides_exclude_from ^%{_datadir}/.*$
 %define __requires_exclude ^libtdjson.*$
-# << macros
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
 Version:    0.17

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -30,6 +30,11 @@ PkgConfigBR:
   - nemonotifications-qt5
   - openssl
 
+# NB: spectacle has a bug where it will remove custom "#<< macros" lines, so define them here:
+Macros:
+  - '__provides_exclude_from;^%{_datadir}/.*$'
+  - '__requires_exclude;^libtdjson.*$'
+
 # Build dependencies without a pkgconfig setup can be listed here
 PkgBR:
    - gperf


### PR DESCRIPTION
Define Macros in the .yaml file.

Due to a bug in spectacle, custom definitions in the .spec will be deleted on the next `specify` run.

See https://github.com/sailfishos/spectacle/issues/1 and https://forum.sailfishos.org/t/sdk-spectacle-deletes-custom-macros-in-rpm-spec/10868

This is not the case if macros are defined in the .yaml
