### PR TITLE
Tweaked notification feedback settings UI

### DIFF
--- a/qml/components/settingsPage/SettingsBehavior.qml
+++ b/qml/components/settingsPage/SettingsBehavior.qml
@@ -81,7 +81,6 @@ AccordionItem {
                 }
             }
 
-
             TextSwitch {
                 width: parent.columnWidth
                 checked: appSettings.useOpenWith
@@ -90,6 +89,17 @@ AccordionItem {
                 automaticCheck: false
                 onClicked: {
                     appSettings.useOpenWith = !checked
+                }
+            }
+
+            TextSwitch {
+                width: parent.columnWidth
+                checked: appSettings.notificationAlwaysShowPreview
+                text: qsTr("Always append message preview to notifications")
+                description: qsTr("In addition to showing the number of unread messages, the latest message will also be appended to notifications.")
+                automaticCheck: false
+                onClicked: {
+                    appSettings.notificationAlwaysShowPreview = !checked
                 }
             }
 
@@ -147,59 +157,52 @@ AccordionItem {
                 }
             }
 
-            TextSwitch {
-                width: parent.columnWidth
-                checked: appSettings.notificationSuppressContent && enabled
-                text: qsTr("Hide content in Notifications")
-                enabled: appSettings.notificationFeedback !== AppSettings.NotificationFeedbackNone
-                clip: height < implicitHeight
-                visible: height > 0
-                automaticCheck: false
-                onClicked: {
-                    appSettings.notificationSuppressContent = !checked
-                }
-                Behavior on height { SmoothedAnimation { duration: 200 } }
+            Item {
+                // Occupies one grid cell so that the column ends up under the combo box
+                // in the landscape layout
+                visible: parent.columns === 2
+                width: 1
+                height: 1
             }
 
-            TextSwitch {
-                width: parent.columnWidth
-                checked: appSettings.notificationTurnsDisplayOn && enabled
-                text: qsTr("Notification turns on the display")
+            Column {
                 enabled: appSettings.notificationFeedback !== AppSettings.NotificationFeedbackNone
+                width: parent.columnWidth
                 height: enabled ? implicitHeight: 0
                 clip: height < implicitHeight
                 visible: height > 0
-                automaticCheck: false
-                onClicked: {
-                    appSettings.notificationTurnsDisplayOn = !checked
-                }
-                Behavior on height { SmoothedAnimation { duration: 200 } }
-            }
 
-            TextSwitch {
-                width: parent.columnWidth
-                checked: appSettings.notificationSoundsEnabled && enabled
-                text: qsTr("Enable notification sounds")
-                description: qsTr("When sounds are enabled, Fernschreiber will use the current Sailfish OS notification sound for chats, which can be configured in the system settings.")
-                enabled: appSettings.notificationFeedback !== AppSettings.NotificationFeedbackNone
-                height: enabled ? implicitHeight: 0
-                clip: height < implicitHeight
-                visible: height > 0
-                automaticCheck: false
-                onClicked: {
-                    appSettings.notificationSoundsEnabled = !checked
-                }
                 Behavior on height { SmoothedAnimation { duration: 200 } }
-            }
 
-            TextSwitch {
-                width: parent.columnWidth
-                checked: appSettings.notificationAlwaysShowPreview
-                text: qsTr("Always append message preview to notifications")
-                description: qsTr("In addition to showing the number of unread messages, the latest message will also be appended to notifications.")
-                automaticCheck: false
-                onClicked: {
-                    appSettings.notificationAlwaysShowPreview = !checked
+                TextSwitch {
+                    checked: appSettings.notificationSuppressContent && enabled
+                    text: qsTr("Hide content in notifications")
+                    enabled: parent.enabled
+                    automaticCheck: false
+                    onClicked: {
+                        appSettings.notificationSuppressContent = !checked
+                    }
+                }
+
+                TextSwitch {
+                    checked: appSettings.notificationTurnsDisplayOn && enabled
+                    text: qsTr("Notification turns on the display")
+                    enabled: parent.enabled
+                    automaticCheck: false
+                    onClicked: {
+                        appSettings.notificationTurnsDisplayOn = !checked
+                    }
+                }
+
+                TextSwitch {
+                    checked: appSettings.notificationSoundsEnabled && enabled
+                    text: qsTr("Enable notification sounds")
+                    description: qsTr("When sounds are enabled, Fernschreiber will use the current Sailfish OS notification sound for chats, which can be configured in the system settings.")
+                    enabled: parent.enabled
+                    automaticCheck: false
+                    onClicked: {
+                        appSettings.notificationSoundsEnabled = !checked
+                    }
                 }
             }
         }


### PR DESCRIPTION
Particularly fixed the behavior of appearing/disappearing switches when notification feedback is being enabled/disabled. Organized feedback options into a column, slightly reduced the number of animations (animate the entire column rather than individual switches).