### PR TITLE
Added "unread mention" indicator to the chat list

### DIFF
--- a/qml/components/PhotoTextsListItem.qml
+++ b/qml/components/PhotoTextsListItem.qml
@@ -108,27 +108,38 @@ ListItem {
             }
 
             Rectangle {
-                id: chatUnreadReactionCountBackground
                 color: isMuted ? ((Theme.colorScheme === Theme.DarkOnLight) ? "lightgray" : "dimgray") : Theme.highlightBackgroundColor
                 width: Theme.fontSizeLarge
                 height: Theme.fontSizeLarge
                 anchors.right: parent.right
                 anchors.top: parent.top
                 radius: parent.width / 2
-                visible: chatListViewItem.unreadReactionCount > 0
-            }
+                visible: chatListViewItem.unreadReactionCount > 0 || chatListViewItem.unreadMentionCount > 0
 
-            Icon {
-                source: "image://theme/icon-s-favorite"
-                height: Theme.iconSizeExtraSmall
-                width: Theme.iconSizeExtraSmall
-                highlighted: chatListViewItem.highlighted
-                anchors.centerIn: chatUnreadReactionCountBackground
-                visible: chatListViewItem.unreadReactionCount > 0
-            }
+                Icon {
+                    source: "image://theme/icon-s-favorite"
+                    height: Theme.iconSizeExtraSmall
+                    width: Theme.iconSizeExtraSmall
+                    highlighted: chatListViewItem.highlighted
+                    anchors.centerIn: parent
+                    visible: chatListViewItem.unreadReactionCount > 0 && !chatListViewItem.unreadMentionCount
+                }
 
+                Text {
+                    font {
+                        pixelSize: Theme.iconSizeExtraSmall
+                        bold: true
+                    }
+                    color: Theme.primaryColor
+                    anchors.centerIn: parent
+                    visible: chatListViewItem.unreadMentionCount > 0
+                    opacity: isMuted ? Theme.opacityHigh : 1.0
+                    text: "@"
+                }
+            }
         }
     }
+
     Column {
         id: contentColumn
         anchors {

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -175,6 +175,7 @@ TDLibReceiver::TDLibReceiver(void *tdLibClient, QObject *parent) : QThread(paren
     handlers.insert("updateMessageInteractionInfo", &TDLibReceiver::processUpdateMessageInteractionInfo);
     handlers.insert("sessions", &TDLibReceiver::processSessions);
     handlers.insert("availableReactions", &TDLibReceiver::processAvailableReactions);
+    handlers.insert("updateMessageMentionRead", &TDLibReceiver::processUpdateChatUnreadMentionCount);
     handlers.insert("updateChatUnreadMentionCount", &TDLibReceiver::processUpdateChatUnreadMentionCount);
     handlers.insert("updateChatUnreadReactionCount", &TDLibReceiver::processUpdateChatUnreadReactionCount);
     handlers.insert("updateActiveEmojiReactions", &TDLibReceiver::processUpdateActiveEmojiReactions);
@@ -736,6 +737,8 @@ void TDLibReceiver::processAvailableReactions(const QVariantMap &receivedInforma
 
 void TDLibReceiver::processUpdateChatUnreadMentionCount(const QVariantMap &receivedInformation)
 {
+    // Handles both updateMessageMentionRead and updateChatUnreadMentionCount
+    // They both have chat_id and unread_mention_count which is all we need
     const qlonglong chatId = receivedInformation.value(CHAT_ID).toLongLong();
     const int unreadMentionCount = receivedInformation.value(UNREAD_MENTION_COUNT).toInt();
     LOG("Chat unread mention count updated" << chatId << unreadMentionCount);


### PR DESCRIPTION
It's displayed in place of the "unread reaction" indicator. In case if there are both unread mentions and reactions, "unread mention" takes precedence. The end result is supposed to look like this:

![image](https://github.com/Wunderfitz/harbour-fernschreiber/assets/5909522/7753c6aa-b724-4d8b-8bc6-58eb4632a588)
