### PR TITLE
Jump to post from quote

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -468,8 +468,7 @@ ListItem {
                                         page.toggleMessageSelection(myMessage)
                                     } else {
                                         messageOptionsDrawer.open = false
-                                        messageOverlayLoader.overlayMessage = messageInReplyToRow.inReplyToMessage
-                                        messageOverlayLoader.active = true
+                                        chatPage.showMessage(messageInReplyToRow.inReplyToMessage.id, true)
                                     }
                                 }
                                 onPressAndHold: {

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -54,6 +54,7 @@ Page {
     property bool iterativeInitialization: false;
     property var messageToShow;
     property string messageIdToShow;
+    property string messageIdToScrollTo;
     readonly property bool userIsMember: ((isPrivateChat || isSecretChat) && chatInformation["@type"]) || // should be optimized
                                 (isBasicGroup || isSuperGroup) && (
                                     (chatGroupInformation.status["@type"] === "chatMemberStatusMember")
@@ -407,6 +408,23 @@ Page {
         chatPage.focus = true;
     }
 
+    function showMessage(messageId, initialRun) {
+        // Means we tapped a quoted message and had to load it.
+        if(initialRun) {
+            chatPage.messageIdToScrollTo = messageId
+        }
+        if (chatPage.messageIdToScrollTo && chatPage.messageIdToScrollTo != "") {
+            var index = chatModel.getMessageIndex(chatPage.messageIdToScrollTo);
+            if(index !== -1) {
+                chatPage.messageIdToScrollTo = "";
+                chatView.scrollToIndex(index);
+            } else if(initialRun) {
+                // we only want to do this once.
+                chatModel.triggerLoadHistoryForMessage(chatPage.messageIdToScrollTo)
+            }
+        }
+    }
+
     Timer {
         id: forwardMessagesTimer
         interval: 200
@@ -652,6 +670,8 @@ Page {
             if (chatView.height > chatView.contentHeight) {
                 Debug.log("[ChatPage] Chat content quite small...");
                 viewMessageTimer.queueViewMessage(chatView.count - 1);
+            } else if (chatPage.messageIdToScrollTo && chatPage.messageIdToScrollTo != "") {
+                showMessage(chatPage.messageIdToScrollTo, false)
             }
             chatViewCooldownTimer.restart();
             chatViewStartupReadTimer.restart();

--- a/src/chatmodel.cpp
+++ b/src/chatmodel.cpp
@@ -363,6 +363,15 @@ void ChatModel::initialize(const QVariantMap &chatInformation)
     tdLibWrapper->getChatHistory(chatId, this->chatInformation.value(LAST_READ_INBOX_MESSAGE_ID).toLongLong());
 }
 
+void ChatModel::triggerLoadHistoryForMessage(qlonglong messageId)
+{
+    if (!this->inIncrementalUpdate && !messages.isEmpty()) {
+        LOG("Trigger loading message with id..." << messageId);
+        this->inIncrementalUpdate = true;
+        this->tdLibWrapper->getChatHistory(chatId, messageId);
+    }
+}
+
 void ChatModel::triggerLoadMoreHistory()
 {
     if (!this->inIncrementalUpdate && !messages.isEmpty()) {
@@ -398,6 +407,17 @@ QVariantMap ChatModel::getMessage(int index)
         return messages.at(index)->messageData;
     }
     return QVariantMap();
+}
+
+int ChatModel::getMessageIndex(qlonglong messageId)
+{
+    if (messages.size() == 0) {
+        return -1;
+    }
+    if (messageIndexMap.contains(messageId)) {
+        return messageIndexMap.value(messageId);
+    }
+    return -1;
 }
 
 int ChatModel::getLastReadMessageIndex()

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -40,12 +40,14 @@ public:
     Q_INVOKABLE void clear(bool contentOnly = false);
     Q_INVOKABLE void initialize(const QVariantMap &chatInformation);
     Q_INVOKABLE void triggerLoadMoreHistory();
+    Q_INVOKABLE void triggerLoadHistoryForMessage(qlonglong messageId);
     Q_INVOKABLE void triggerLoadMoreFuture();
     Q_INVOKABLE QVariantMap getChatInformation();
     Q_INVOKABLE QVariantMap getMessage(int index);
     Q_INVOKABLE int getLastReadMessageIndex();
     Q_INVOKABLE void setSearchQuery(const QString newSearchQuery);
 
+    Q_INVOKABLE int getMessageIndex(qlonglong messageId);
     QVariantMap smallPhoto() const;
     qlonglong getChatId() const;
 


### PR DESCRIPTION
This PR fixes https://github.com/Wunderfitz/harbour-fernschreiber/issues/502 and jumps to the quoted message (instead of opening it in a popup (overlay) view).
If needed, the message is first loaded, and only then scrolled to.