### PR TITLE
Do not animate message item content height

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -26,7 +26,6 @@ import "../js/debug.js" as Debug
 ListItem {
     id: messageListItem
     contentHeight: messageBackground.height + Theme.paddingMedium + ( reactionsColumn.visible ? reactionsColumn.height : 0 )
-    Behavior on contentHeight { NumberAnimation { duration: 200 } }
     property var chatId
     property var messageId
     property int messageIndex


### PR DESCRIPTION
This animation looks really unnecessary or even annoying after switching between portrait and landscape