### PR TITLE
Tweaked the logic of moving reactions into the view

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -325,11 +325,15 @@ ListItem {
         onTriggered: {
             Debug.log("Show item completely timer triggered, requested index: " + requestedIndex + ", current index: " + index)
             if (requestedIndex === index) {
-                chatView.highlightMoveDuration = -1;
-                chatView.highlightResizeDuration = -1;
-                chatView.scrollToIndex(requestedIndex);
-                chatView.highlightMoveDuration = 0;
-                chatView.highlightResizeDuration = 0;
+                var p = chatView.contentItem.mapFromItem(reactionsColumn, 0, 0)
+                if (chatView.contentY > p.y || p.y + reactionsColumn.height > chatView.contentY + chatView.height) {
+                    Debug.log("Moving reactions for item at", requestedIndex, "info the view")
+                    chatView.highlightMoveDuration = -1
+                    chatView.highlightResizeDuration = -1
+                    chatView.scrollToIndex(requestedIndex, height <= chatView.height ? ListView.Contain : ListView.End)
+                    chatView.highlightMoveDuration = 0
+                    chatView.highlightResizeDuration = 0
+                }
             }
         }
     }

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1241,10 +1241,9 @@ Page {
                             manuallyScrolledToBottom = chatView.atYEnd
                         }
 
-                        function scrollToIndex(index) {
+                        function scrollToIndex(index, mode) {
                             if(index > 0 && index < chatView.count) {
-                                positionViewAtIndex(index, ListView.Contain)
-    //                            currentIndex = index;
+                                positionViewAtIndex(index, (mode === undefined) ? ListView.Contain : mode)
                                 if(index === chatView.count - 1) {
                                     manuallyScrolledToBottom = true;
                                 }


### PR DESCRIPTION
There's no need to reposition list items if reactions bar are already fully visible.