### PR TITLE
Limit message width in widescreen UI.

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -130,6 +130,12 @@ ListItem {
     }
 
     function getContentWidthMultiplier() {
+        var type = myMessage.content["@type"];
+        if(type === "messagePoll") {
+            // We do not want to limit messagePoll content width on wide screens, it will not result in huge message items
+            // as other content types like image and video do.
+            return 1.0
+        }
         return Functions.isWidescreen(appWindow) ? 0.4 : 1.0
     }
 

--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -133,6 +133,10 @@ ListItem {
         return Functions.isWidescreen(appWindow) ? 0.4 : 1.0
     }
 
+    function shouldRightAlignMessage() {
+        return page.isPrivateChat && messageListItem.isOwnMessage
+    }
+
     onClicked: {
         if (messageListItem.precalculatedValues.pageIsSelecting) {
             page.toggleMessageSelection(myMessage);
@@ -394,7 +398,8 @@ ListItem {
         spacing: Theme.paddingSmall
         width: precalculatedValues.entryWidth
         anchors.horizontalCenter: Functions.isWidescreen(appWindow) ? undefined : parent.horizontalCenter
-        anchors.left: Functions.isWidescreen(appWindow) ? parent.left : undefined
+        anchors.left: Functions.isWidescreen(appWindow) || !shouldRightAlignMessage ? parent.left : undefined
+        anchors.right: Functions.isWidescreen(appWindow) && shouldRightAlignMessage ? parent.right : undefined
         y: Theme.paddingSmall
         anchors.leftMargin: Functions.isWidescreen(appWindow) ? Theme.paddingMedium : undefined
 
@@ -630,7 +635,7 @@ ListItem {
                     id: webPagePreviewLoader
                     active: false
                     asynchronous: true
-                    width: parent.width * getContentWidthMultiplier()
+                    width: parent.width
                     height: (status === Loader.Ready) ? item.implicitHeight : myMessage.content.web_page ? precalculatedValues.webPagePreviewHeight : 0
 
                     sourceComponent: Component {
@@ -638,6 +643,7 @@ ListItem {
                             webPageData: myMessage.content.web_page
                             width: parent.width
                             highlighted: messageListItem.highlighted
+                            mediaAttachmentSizeMultiplier: getContentWidthMultiplier()
                         }
                     }
                 }

--- a/qml/components/MessageOverlayFlickable.qml
+++ b/qml/components/MessageOverlayFlickable.qml
@@ -172,6 +172,7 @@ Flickable {
                     webPageData: overlayMessage.content.web_page
                     largerFontSize: true
                     width: parent.width
+                    mediaAttachmentSizeMultiplier: Functions.isWidescreen(appWindow) ? 0.4 : 1.0
                 }
             }
         }

--- a/qml/components/messageContent/WebPagePreview.qml
+++ b/qml/components/messageContent/WebPagePreview.qml
@@ -29,6 +29,7 @@ Column {
     property var webPageData;
     property bool largerFontSize: false;
     property bool highlighted
+    property double mediaAttachmentSizeMultiplier
     readonly property bool hasImage: picture.fileId !== 0
     readonly property int fontSize: largerFontSize ? Theme.fontSizeSmall : Theme.fontSizeExtraSmall
 
@@ -109,7 +110,7 @@ Column {
 
     Item {
         id: webPagePreviewImageItem
-        width: parent.width
+        width: parent.width * mediaAttachmentSizeMultiplier
         height: width * 2 / 3
         visible: hasImage
 

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -1215,7 +1215,7 @@ Page {
                             readonly property int profileThumbnailDimensions: showUserInfo ? Theme.itemSizeSmall : 0
                             readonly property int pageMarginDouble: 2 * Theme.horizontalPageMargin
                             readonly property int paddingMediumDouble: 2 * Theme.paddingMedium
-                            readonly property int entryWidth: chatView.width - pageMarginDouble
+                            readonly property int entryWidth: Functions.isWidescreen(appWindow) ? chatView.width * 0.75 : chatView.width - pageMarginDouble
                             readonly property int textItemWidth: entryWidth - profileThumbnailDimensions - Theme.paddingSmall
                             readonly property int backgroundWidth: page.isChannel ? textItemWidth : textItemWidth - pageMarginDouble
                             readonly property int backgroundRadius: textItemWidth/50


### PR DESCRIPTION
This was intended to be included in https://github.com/Wunderfitz/harbour-fernschreiber/pull/540, but this change didn't make it into PR.

It further improved chat UI on tablets (or wide screens as we call them now) by limiting message width to 75% of the screen.