### PR TITLE
Fix Copy message to clipboard not working from extended menu

### DIFF
--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -781,7 +781,7 @@ Page {
             NamedAction {
                 visible: messageOptionsDrawer.showCopyMessageToClipboardMenuItem
                 name: qsTr("Copy Message to Clipboard")
-                action: messageOptionsDrawer.myMessage.copyMessageToClipboard
+                action: messageOptionsDrawer.sourceItem.copyMessageToClipboard
             },
             NamedAction {
                 visible: messageOptionsDrawer.showForwardMessageMenuItem && messageOptionsDrawer.myMessage.can_be_forwarded


### PR DESCRIPTION
Fix issue https://github.com/Wunderfitz/harbour-fernschreiber/issues/549