### PR TITLE
Show up to 6 items in popup menu of a message on large wide screen

### DIFF
--- a/qml/components/MessageListViewItem.qml
+++ b/qml/components/MessageListViewItem.qml
@@ -58,7 +58,7 @@ ListItem {
         (additionalItemsModel ? additionalItemsModel.length : 0)
     readonly property bool deleteMessageIsOnlyExtraOption: canDeleteMessage && !numberOfExtraOptionsOtherThanDeleteMessage
 
-    readonly property int maxContextMenuItemCount: page.isPortrait ? 5 : 4
+    readonly property int maxContextMenuItemCount: page.isPortrait ? 5 : Functions.isWidescreen(appWindow) ? 6 : 4
     readonly property int baseContextMenuItemCount: (canReplyToMessage ? 1 : 0) +
         (myMessage.can_be_edited ? 1 : 0) + 2 /* "Select Message" and "More Options..." */
     readonly property bool showCopyMessageToClipboardMenuItem: (baseContextMenuItemCount + 1) <= maxContextMenuItemCount


### PR DESCRIPTION
On a large wide screen (tablet mode as I call it), we can easily show more popup menu items for a chat message context menu. I set this number to 6 - it looks nice on my tablet.