### PR TITLE
fix range + message updates; implement album filter

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -22,6 +22,7 @@ DEFINES += QT_STATICPLUGIN
 
 SOURCES += src/harbour-fernschreiber.cpp \
     src/appsettings.cpp \
+    src/boolfiltermodel.cpp \
     src/chatpermissionfiltermodel.cpp \
     src/chatlistmodel.cpp \
     src/chatmodel.cpp \
@@ -105,14 +106,21 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/components/messageContent/MessageGame.qml \
     qml/components/messageContent/MessageLocation.qml \
     qml/components/messageContent/MessagePhoto.qml \
+    qml/components/messageContent/MessagePhotoAlbum.qml \
     qml/components/messageContent/MessagePoll.qml \
     qml/components/messageContent/MessageSticker.qml \
     qml/components/messageContent/MessageVenue.qml \
+    qml/components/messageContent/MessageVideoAlbum.qml \
     qml/components/messageContent/MessageVideoNote.qml \
     qml/components/messageContent/MessageVideo.qml \
     qml/components/messageContent/MessageVoiceNote.qml \
     qml/components/messageContent/SponsoredMessage.qml \
     qml/components/messageContent/WebPagePreview.qml \
+    qml/components/messageContent/mediaAlbumPage/FullscreenOverlay.qml \
+    qml/components/messageContent/mediaAlbumPage/PhotoComponent.qml \
+    qml/components/messageContent/mediaAlbumPage/VideoComponent.qml \
+    qml/components/messageContent/mediaAlbumPage/ZoomArea.qml \
+    qml/components/messageContent/mediaAlbumPage/ZoomImage.qml \
     qml/components/settingsPage/Accordion.qml \
     qml/components/settingsPage/AccordionItem.qml \
     qml/components/settingsPage/ResponsiveGrid.qml \
@@ -130,6 +138,7 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/pages/CoverPage.qml \
     qml/pages/DebugPage.qml \
     qml/pages/InitializationPage.qml \
+    qml/pages/MediaAlbumPage.qml \
     qml/pages/NewChatPage.qml \
     qml/pages/OverviewPage.qml \
     qml/pages/AboutPage.qml \
@@ -212,6 +221,7 @@ INSTALLS += telegram 86.png 108.png 128.png 172.png 256.png \
 
 HEADERS += \
     src/appsettings.h \
+    src/boolfiltermodel.h \
     src/chatpermissionfiltermodel.h \
     src/chatlistmodel.h \
     src/chatmodel.h \

--- a/qml/components/TDLibMinithumbnail.qml
+++ b/qml/components/TDLibMinithumbnail.qml
@@ -24,6 +24,7 @@ Loader {
     id: loader
     property var minithumbnail
     property bool highlighted
+    property int fillMode: tdLibImage.fillMode
     anchors.fill: parent
     active: !!minithumbnail
     sourceComponent: Component {
@@ -32,7 +33,7 @@ Loader {
                 id: minithumbnailImage
                 anchors.fill: parent
                 source: "data:image/jpg;base64,"+minithumbnail.data
-                fillMode: tdLibImage.fillMode
+                fillMode: loader.fillMode
                 opacity: status === Image.Ready ? 1.0 : 0.0
                 cache: false
                 visible: opacity > 0
@@ -43,12 +44,12 @@ Loader {
                     effect: PressEffect { source: minithumbnailImage }
                 }
             }
-
-            FastBlur {
-                anchors.fill: parent
-                source: minithumbnailImage
-                radius: Theme.paddingLarge
-            }
+            // this had a visible impact on performance
+//            FastBlur {
+//                anchors.fill: parent
+//                source: minithumbnailImage
+//                radius: Theme.paddingLarge
+//            }
         }
     }
 }

--- a/qml/components/TDLibThumbnail.qml
+++ b/qml/components/TDLibThumbnail.qml
@@ -59,7 +59,7 @@ Item {
 
     readonly property bool hasVisibleThumbnail: thumbnailImage.opacity !== 1.0
         && !(videoThumbnailLoader.item && videoThumbnailLoader.item.opacity === 1.0)
-
+    property alias fillMode: thumbnailImage.fillMode
     layer {
         enabled: highlighted
         effect: PressEffect { source: tdlibThumbnail }
@@ -67,6 +67,7 @@ Item {
 
     TDLibMinithumbnail {
         id: minithumbnailLoader
+        fillMode: thumbnailImage.fillMode
         active: !!minithumbnail && thumbnailImage.opacity < 1.0
     }
     BackgroundImage {
@@ -103,6 +104,7 @@ Item {
                 sourceSize.width: width
                 sourceSize.height: height
                 mimeType: tdlibThumbnail.videoMimeType
+                fillMode: thumbnailImage.fillMode == Image.PreserveAspectFit ? Thumbnail.PreserveAspectFit : Thumbnail.PreserveAspectCrop
                 visible: opacity > 0
                 opacity: status === Thumbnail.Ready ? 1.0 : 0.0
                 Behavior on opacity { FadeAnimation {} }

--- a/qml/components/messageContent/MessagePhoto.qml
+++ b/qml/components/messageContent/MessagePhoto.qml
@@ -22,36 +22,30 @@ import "../"
 
 MessageContentBase {
 
-    function calculateBiggest() {
-        var candidateBiggest = rawMessage.content.photo.sizes[rawMessage.content.photo.sizes.length - 1];
-        if (candidateBiggest.width === 0 && rawMessage.content.photo.sizes.length > 1) {
-           for (var i = (rawMessage.content.photo.sizes.length - 2); i >= 0; i--) {
-               candidateBiggest = rawMessage.content.photo.sizes[i];
-               if (candidateBiggest.width > 0) {
+    height: Math.max(Theme.itemSizeExtraSmall, Math.min(Math.round(width * 0.66666666), width / getAspectRatio()))
+    readonly property alias photoData: photo.photo;
+
+    onClicked: {
+        pageStack.push(Qt.resolvedUrl("../../pages/MediaAlbumPage.qml"), {
+            "messages" : [rawMessage],
+        })
+    }
+    function getAspectRatio() {
+        var candidate = photoData.sizes[photoData.sizes.length - 1];
+        if (candidate.width === 0 && photoData.sizes.length > 1) {
+           for (var i = (photoData.sizes.length - 2); i >= 0; i--) {
+               candidate = photoData.sizes[i];
+               if (candidate.width > 0) {
                    break;
                }
            }
         }
-        return candidateBiggest;
-    }
-
-    height: Math.max(Theme.itemSizeExtraSmall, Math.min(defaultHeight, width / (biggest.width/biggest.height)))
-    readonly property int defaultHeight: Math.round(width * 0.66666666)
-    readonly property var biggest: calculateBiggest();
-
-    onClicked: {
-        pageStack.push(Qt.resolvedUrl("../../pages/ImagePage.qml"), {
-            "photoData" : photo.photo,
-//            "pictureFileInformation" : photo.fileInformation
-        })
+        return candidate.width / candidate.height;
     }
     TDLibPhoto {
         id: photo
         anchors.fill: parent
         photo: rawMessage.content.photo
         highlighted: parent.highlighted
-    }
-    BackgroundImage {
-        visible: !rawMessage.content.photo.minithumbnail && photo.image.status !== Image.Ready
     }
 }

--- a/qml/components/messageContent/MessagePhotoAlbum.qml
+++ b/qml/components/messageContent/MessagePhotoAlbum.qml
@@ -1,0 +1,207 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import "../"
+
+MessageContentBase {
+    id: messageContent
+    property string chatId
+    readonly property int heightUnit: Math.round(width * 0.66666666)
+    readonly property var albumId: rawMessage.media_album_id
+    property var albumMessageIds: messageListItem ? messageListItem.messageAlbumMessageIds : []//overlayFlickable.messageAlbumMessageIds
+    onAlbumMessageIdsChanged: albumMessages = getMessages() //chatModel.getMessagesForAlbum(messageContent.albumId)
+    property var albumMessages: getMessages()//chatModel.getMessagesForAlbum(messageContent.albumId)
+    property bool firstLarge: albumMessages.length % 2 !== 0;
+
+    clip: true
+    height: defaultExtraContentHeight//(firstLarge ? heightUnit * 0.75 : 0 ) + heightUnit * 0.25 * albumMessageIds.length
+
+
+    onClicked: {
+        if(messageListItem.precalculatedValues.pageIsSelecting) {
+            page.toggleMessageSelection(rawMessage);
+            return;
+        }
+        openDetail(-1);
+    }
+    function getMessages() {
+        var msgs = [rawMessage];
+        if(messageContent.albumId === '0' || messageContent.albumMessageIds.length < 2) {
+            return msgs;
+        }
+//        var othermsgIds =
+        // getMessages from tdlib isn't faster
+//        if(rawMessage && rawMessage.chat_id) {
+//            var messages = [];
+//            return albumMessageIds.map(function(msgId){
+//                if(msgId === rawMessage.id) {
+//                    return rawMessage;
+//                }
+//                return tdLibWrapper.getMessage(rawMessage.chat_id, msgId);
+//            })
+//        }
+         chatModel.getMessagesForAlbum(messageContent.albumId, 1).forEach(function(msg){
+            msgs.push(msg);
+         });
+        //
+        return msgs; //chatModel.getMessagesForAlbum(messageContent.albumId);
+    }
+
+    function openDetail(index) {
+        console.log('open detail', index || 0);
+
+
+        pageStack.push(Qt.resolvedUrl("../../pages/MediaAlbumPage.qml"), {
+                           "messages" : albumMessages,
+                           "index": index || 0
+                       })
+    }
+    Connections { // TODO: needed?
+        target: tdLibWrapper
+
+        onReceivedMessage: {
+            if (albumMessageIds.indexOf(messageId)) {
+//                albumMessages = getMessages()
+            }
+        }
+    }
+
+    Component {
+        id: photoPreviewComponent
+        MessagePhoto {
+//            width: parent.width
+//            height: parent.height
+            messageListItem: messageContent.messageListItem
+            overlayFlickable: messageContent.overlayFlickable
+            rawMessage: albumMessages[modelIndex]
+            highlighted: mediaBackgroundItem.highlighted
+        }
+    }
+    Component {
+        id: videoPreviewComponent
+        Item {
+            property bool highlighted: mediaBackgroundItem.highlighted
+            anchors.fill: parent
+            clip: true
+            TDLibThumbnail {
+                id: tdLibImage
+                width: parent.width //don't use anchors here for easier custom scaling
+                height: parent.height
+                highlighted: parent.highlighted
+                thumbnail: albumMessages[modelIndex].content.video.thumbnail
+                minithumbnail: albumMessages[modelIndex].content.video.minithumbnail
+            }
+            Rectangle {
+                anchors {
+                    fill: videoIcon
+                    leftMargin: -Theme.paddingSmall
+                    topMargin: -Theme.paddingSmall
+                    bottomMargin: -Theme.paddingSmall
+                    rightMargin: -Theme.paddingLarge
+
+                }
+
+                radius: Theme.paddingSmall
+                color: Theme.rgba(Theme.overlayBackgroundColor, 0.4)
+
+            }
+
+            Icon {
+                id: videoIcon
+                source: "image://theme/icon-m-video"
+                width: Theme.iconSizeSmall
+                height: Theme.iconSizeSmall
+                highlighted: parent.highlighted
+                anchors {
+                    right: parent.right
+                    rightMargin: Theme.paddingSmall
+                    bottom: parent.bottom
+                }
+            }
+        }
+    }
+
+    Flow {
+        id: contentGrid
+        property int firstWidth: firstLarge ? contentGrid.width : normalWidth
+        property int firstHeight: firstLarge ? heightUnit - contentGrid.spacing : normalHeight
+        property int normalWidth: (contentGrid.width - contentGrid.spacing) / 2
+        property int normalHeight: (heightUnit / 2) - contentGrid.spacing
+
+        anchors.fill: parent
+        spacing: Theme.paddingMedium
+
+        Repeater {
+            model: albumMessages
+            delegate: BackgroundItem {
+                id: mediaBackgroundItem
+                property bool isLarge: firstLarge && model.index === 0
+                width: model.index === 0 ? contentGrid.firstWidth : contentGrid.normalWidth
+                height: model.index === 0 ? contentGrid.firstHeight : contentGrid.normalHeight
+
+                readonly property bool isSelected: messageListItem.precalculatedValues.pageIsSelecting && page.selectedMessages.some(function(existingMessage) {
+                    return existingMessage.id === albumMessages[index].id
+                });
+                highlighted: isSelected || down || messageContent.highlighted
+                onClicked: {
+                    if(messageListItem.precalculatedValues.pageIsSelecting) {
+                        page.toggleMessageSelection(albumMessages[index]);
+                        return;
+                    }
+
+                    openDetail(index);
+                }
+                onPressAndHold: {
+                    page.toggleMessageSelection(albumMessages[index]);
+                }
+
+                Loader {
+                    anchors.fill: parent
+//                    asynchronous: true
+
+                    readonly property int modelIndex: index
+                    sourceComponent: albumMessages[index].content["@type"] === 'messageVideo' ? videoPreviewComponent : photoPreviewComponent
+                    opacity: status === Loader.Ready
+                    Behavior on opacity {FadeAnimator{}}
+                }
+
+                /*
+                  TODO video:
+                    rawMessage.content.video.thumbnail
+    TDLibPhoto {
+        id: photo
+        anchors.fill: parent
+        photo: rawMessage.content.photo
+        highlighted: parent.highlighted
+    }
+                  */
+                Rectangle {
+                    visible: mediaBackgroundItem.isSelected
+                    anchors {
+                        fill: parent
+                    }
+                    color: 'transparent'
+                    border.color: Theme.highlightColor
+                    border.width: Theme.paddingSmall
+                }
+            }
+        }
+    }
+}

--- a/qml/components/messageContent/MessageVideo.qml
+++ b/qml/components/messageContent/MessageVideo.qml
@@ -26,7 +26,12 @@ import "../../js/debug.js" as Debug
 MessageContentBase {
     id: videoMessageComponent
 
-    property var videoData:  ( rawMessage.content['@type'] === "messageVideo" ) ?  rawMessage.content.video : ( ( rawMessage.content['@type'] === "messageAnimation" ) ? rawMessage.content.animation : rawMessage.content.video_note )
+    property var videoData:  ( rawMessage.content['@type'] === "messageVideo" )
+                             ? rawMessage.content.video
+                             : (
+                                   ( rawMessage.content['@type'] === "messageAnimation" )
+                                   ? rawMessage.content.animation
+                                   : rawMessage.content.video_note )
     property string videoUrl;
     property int previewFileId;
     property int videoFileId;

--- a/qml/components/messageContent/MessageVideoAlbum.qml
+++ b/qml/components/messageContent/MessageVideoAlbum.qml
@@ -16,16 +16,4 @@
     You should have received a copy of the GNU General Public License
     along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
 */
-import QtQuick 2.6
-import Sailfish.Silica 1.0
-import QtMultimedia 5.6
-import "../"
-import "../../js/debug.js" as Debug
-
-Item {
-    property ListItem messageListItem
-    property MessageOverlayFlickable overlayFlickable
-    property var rawMessage: messageListItem ? messageListItem.myMessage : overlayFlickable.overlayMessage
-    property bool highlighted
-    signal clicked()
-}
+MessagePhotoAlbum {}

--- a/qml/components/messageContent/mediaAlbumPage/FullscreenOverlay.qml
+++ b/qml/components/messageContent/mediaAlbumPage/FullscreenOverlay.qml
@@ -1,0 +1,279 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import QtGraphicalEffects 1.0
+import Sailfish.Silica 1.0
+import "../../../js/functions.js" as Functions
+
+
+Item {
+    // id
+    id: overlay
+    // property declarations
+    property int pageCount
+    property int currentIndex
+    property alias text: captionLabel.text
+    property bool active: true
+    property var message
+    readonly property color gradientColor: '#bb000000'
+    readonly property int gradientPadding: Theme.itemSizeMedium
+    // signal declarations
+    // JavaScript functions
+    // object properties
+    anchors.fill: parent
+    opacity: active ? 1 : 0
+    Behavior on opacity { FadeAnimator {} }
+    // large property bindings
+    // child objects
+    // states
+    // transitions
+
+    onActiveChanged: {
+        console.log('overlay active', active)
+    }
+
+    function forwardMessage() {
+        var neededPermissions = Functions.getMessagesNeededForwardPermissions([message]);
+        pageStack.push(Qt.resolvedUrl("../../../pages/ChatSelectionPage.qml"), {
+            myUserId: tdLibWrapper.getUserInformation().id,
+            headerDescription: qsTr("Forward %Ln messages", "dialog header", 1),
+            payload: {fromChatId: message.chat_id, messageIds:[message.id], neededPermissions: neededPermissions},
+            state: "forwardMessages"
+        });
+    }
+
+    // "header"
+
+    LinearGradient {
+        id: topGradient
+        property int startY: 0;
+//        Behavior on startY { NumberAnimation {duration: 2000} }
+        start: Qt.point(0, Math.min(height-gradientPadding*2, startY))
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: parent.top
+            bottom: closeButton.bottom
+
+            bottomMargin: -gradientPadding
+        }
+
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: gradientColor }
+            GradientStop { position: 1.0; color: 'transparent' }
+        }
+    }
+
+
+    IconButton {
+        id: closeButton
+         icon.source: "image://theme/icon-m-cancel?" + (pressed
+                      ? Theme.highlightColor
+                      : Theme.lightPrimaryColor)
+         onClicked: pageStack.pop()
+         anchors {
+             right: parent.right
+             top: parent.top
+             margins: Theme.horizontalPageMargin
+         }
+     }
+
+    SilicaFlickable {
+        id: captionFlickable
+        anchors {
+            left: parent.left
+//            leftMargin: Theme.horizontalPageMargin
+            right: closeButton.left
+            top: parent.top
+//            topMargin: Theme.horizontalPageMargin
+        }
+        interactive: captionLabel.expanded && contentHeight > height
+        clip: true
+        height: Math.min(contentHeight, parent.height / 4)
+        contentHeight: captionLabel.height + Theme.horizontalPageMargin
+        flickableDirection: Flickable.VerticalFlick
+        VerticalScrollDecorator {
+            opacity: visible ? 1.0 : 0.0
+            flickable: captionFlickable
+        }
+
+        Label {
+            id: captionLabel
+            property bool expandable: expanded || height < contentHeight
+            property bool expanded
+
+            height: text ?
+                        expanded
+                            ? contentHeight
+                            : Theme.itemSizeMedium
+                      : 0;
+    //        maximumLineCount: expanded ? 0 : 3
+            color: Theme.primaryColor
+//            text: model.modelData.content.caption.text
+            text: Emoji.emojify(Functions.enhanceMessageText(message.content.caption, false), Theme.fontSizeExtraSmall)
+            onTextChanged: expanded = false
+            font.pixelSize: Theme.fontSizeExtraSmall
+            wrapMode: Text.WrapAnywhere
+            bottomPadding: expanded ? Theme.paddingLarge : 0
+            anchors {
+                left: parent.left
+                leftMargin: Theme.horizontalPageMargin
+                rightMargin: Theme.paddingLarge
+                right: parent.right
+                top: parent.top
+                topMargin: Theme.horizontalPageMargin
+            }
+
+            Behavior on height { NumberAnimation {duration: 300} }
+            Behavior on text {
+                SequentialAnimation {
+                    FadeAnimation {
+                        target: captionLabel
+                        to: 0.0
+                        duration: 300
+                    }
+                    PropertyAction {}
+                    FadeAnimation {
+                        target: captionLabel
+                        to: 1.0
+                        duration: 300
+                    }
+                }
+            }
+
+        }
+
+        OpacityRampEffect {
+                        sourceItem: captionLabel
+                        enabled: !captionLabel.expanded
+                        direction: OpacityRamp.TopToBottom
+                    }
+        MouseArea {
+            anchors.fill: captionLabel
+            enabled: captionLabel.expandable
+            onClicked: {
+                captionLabel.expanded = !captionLabel.expanded
+            }
+        }
+    }
+
+    // "footer"
+    LinearGradient {
+        anchors {
+            left: parent.left
+            right: parent.right
+            top: buttons.top
+            bottom: parent.bottom
+            topMargin: -gradientPadding
+        }
+
+        gradient: Gradient {
+            GradientStop { position: 0.0; color: 'transparent' }
+            GradientStop { position: 1.0; color: gradientColor }
+        }
+    }
+    Loader {
+        asynchronous: true
+        active: overlay.pageCount > 1
+
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            verticalCenter: buttons.bottom
+        }
+        sourceComponent: Component {
+
+            Row {
+                id: pageIndicatorRow
+                height: Theme.paddingSmall
+                spacing:  height
+                Repeater {
+                    id: pageIndicator
+                    model: overlay.pageCount
+                    Rectangle {
+                        property bool active: model.index === overlay.currentIndex
+                        width: pageIndicatorRow.height
+                        height: pageIndicatorRow.height
+                        color: active ? Theme.lightPrimaryColor : Theme.rgba(Theme.lightSecondaryColor, Theme.opacityLow)
+                        Behavior on color { ColorAnimation {} }
+                        radius: Theme.paddingSmall
+                    }
+                }
+            }
+        }
+    }
+
+
+    Row {
+        id: buttons
+        height: Theme.itemSizeSmall
+        width: childrenRect.width
+        spacing:  Theme.paddingLarge
+        anchors {
+            horizontalCenter: parent.horizontalCenter
+            bottom: parent.bottom
+            bottomMargin: Theme.paddingLarge
+        }
+
+//        IconButton {
+//             icon.source: "image://theme/icon-m-cancel?" + (pressed
+//                          ? Theme.highlightColor
+//                          : Theme.lightPrimaryColor)
+//             onClicked: pageStack.pop()
+
+//         }
+        IconButton {
+             icon.source: "image://theme/icon-m-downloads?" + (pressed
+                          ? Theme.highlightColor
+                          : Theme.lightPrimaryColor)
+             onClicked: pageStack.pop()
+         }
+        Item {
+            width: Theme.itemSizeSmall
+            height: Theme.itemSizeSmall
+        }
+
+        IconButton {
+             enabled: message.can_be_forwarded
+             opacity: enabled ? 1.0 : 0.2
+             icon.source: "image://theme/icon-m-share?" + (pressed
+                          ? Theme.highlightColor
+                          : Theme.lightPrimaryColor)
+             onClicked: forwardMessage()
+         }
+    }
+    states: [
+        State {
+            name: 'hasCaption'
+            when: captionLabel.height > 0
+            PropertyChanges { target: topGradient;
+                startY: captionFlickable.height
+            }
+            AnchorChanges {
+                target: topGradient
+//                anchors.top: captionLabel.verticalCenter
+                anchors.bottom: captionFlickable.bottom
+            }
+        }
+    ]
+    transitions:
+        Transition {
+            AnchorAnimation { duration: 200 }
+            NumberAnimation { properties: "startY"; duration: 200 }
+        }
+}

--- a/qml/components/messageContent/mediaAlbumPage/PhotoComponent.qml
+++ b/qml/components/messageContent/mediaAlbumPage/PhotoComponent.qml
@@ -1,0 +1,16 @@
+
+import QtQuick 2.6
+
+ZoomImage {
+    photoData: model.modelData.content.photo
+    onClicked: {
+        console.log('clicked', zoomed)
+        if(zoomed) {
+            zoomOut(true)
+            page.overlayActive = true
+        } else {
+            page.overlayActive = !page.overlayActive
+        }
+    }
+
+}

--- a/qml/components/messageContent/mediaAlbumPage/VideoComponent.qml
+++ b/qml/components/messageContent/mediaAlbumPage/VideoComponent.qml
@@ -1,0 +1,181 @@
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import WerkWolf.Fernschreiber 1.0
+import QtMultimedia 5.6
+import QtGraphicalEffects 1.0
+import "../../"
+
+Video {
+    id: video
+    property var videoData: model.modelData.content.video
+    readonly property bool isPlaying: playbackState === MediaPlayer.PlayingState
+    readonly property bool isCurrent: index === page.index
+    property bool shouldPlay
+    autoLoad: true
+    source: file.isDownloadingCompleted ? file.path : ''
+    onIsCurrentChanged: {
+        if(!isCurrent) {
+            pause()
+        }
+    }
+    onStatusChanged: {
+        if(status === MediaPlayer.EndOfMedia) {
+            page.overlayActive = true
+        }
+    }
+    TDLibThumbnail {
+        id: tdLibImage
+
+        property bool active: !file.isDownloadingCompleted || (!video.isPlaying && (video.position === 0 || video.status === MediaPlayer.EndOfMedia))
+        opacity: active ? 1 : 0
+        visible: active || opacity > 0
+
+        width: parent.width //don't use anchors here for easier custom scaling
+        height: parent.height
+//        highlighted: parent.highlighted
+        thumbnail: videoData.thumbnail
+        minithumbnail: videoData.minithumbnail
+        fillMode: Image.PreserveAspectFit
+
+
+    }
+
+    TDLibFile {
+        id: file
+        autoLoad: false
+        tdlib: tdLibWrapper
+        fileInformation: videoData.video
+        property real progress: isDownloadingCompleted ? 1.0 : (downloadedSize / size)
+        onDownloadingCompletedChanged: {
+            if(isDownloadingCompleted) {
+                video.source = file.path
+                if(video.shouldPlay) {
+                    video.play()
+                    delayedOverlayHide.start()
+                    video.shouldPlay = false
+                }
+            }
+        }
+    }
+    Label {
+        anchors.centerIn: parent
+        text: 'dl: '+file.downloadedSize
+              + ' \ns: '+file.size
+              + ' \nes: '+file.expectedSize
+              + ' \nd:'+file.isDownloadingActive
+              + ' \nc:'+file.isDownloadingCompleted
+
+    }
+
+    MouseArea {
+        anchors.fill: parent
+        onClicked: page.overlayActive = !page.overlayActive
+    }
+
+    RadialGradient { // white videos = invisible button. I can't tell since which SFOS version the opaque button is available, so:
+        id: buttonBg
+        anchors.centerIn: parent
+        width: Theme.itemSizeLarge; height: Theme.itemSizeLarge
+        property color baseColor: Theme.rgba(palette.overlayBackgroundColor, 0.2)
+
+        enabled: videoUI.active || !file.isDownloadingCompleted
+        opacity: enabled ? 1 : 0
+        Behavior on opacity { FadeAnimator {} }
+        gradient: Gradient {
+
+            GradientStop { position: 0.0; color: buttonBg.baseColor }
+            GradientStop { position: 0.3; color: buttonBg.baseColor }
+            GradientStop { position: 0.5; color: 'transparent' }
+        }
+
+        IconButton {
+            anchors.fill: parent
+            icon.source: "image://theme/icon-l-"+(video.isPlaying || video.shouldPlay ? 'pause' : 'play')+"?" + (pressed
+                         ? Theme.highlightColor
+                         : Theme.lightPrimaryColor)
+            onClicked: {
+                if (!file.isDownloadingCompleted) {
+                    video.shouldPlay = !video.shouldPlay;
+                    if(video.shouldPlay) {
+                        file.load()
+                    } else {
+                        file.cancel()
+                    }
+                    return;
+                }
+
+                if (video.isPlaying) {
+                    video.pause()
+                } else {
+                    video.play()
+                    delayedOverlayHide.start()
+                }
+            }
+        }
+    }
+
+    ProgressCircle {
+        property bool active: file.isDownloadingActive
+        opacity: active ? 1 : 0
+        Behavior on opacity { FadeAnimator {} }
+        anchors.centerIn: parent
+        value: file.progress
+    }
+    Item {
+        id: videoUI
+        property bool active: overlay.active// && file.isDownloadingCompleted
+        anchors.fill: parent
+        opacity: active ? 1 : 0
+        Behavior on opacity { FadeAnimator {} }
+
+        Slider {
+            id: slider
+            value: video.position
+            minimumValue: 0
+            maximumValue: video.duration || 0.1
+            enabled: parent.active && video.seekable
+            width: parent.width
+            handleVisible: false
+            animateValue: true
+            stepSize: 500
+            anchors {
+                bottom: parent.bottom
+                bottomMargin: Theme.itemSizeMedium
+            }
+            valueText: value > 0 || down ? Format.formatDuration((value)/1000, Formatter.Duration) : ''
+            leftMargin: Theme.horizontalPageMargin
+            rightMargin: Theme.horizontalPageMargin
+            onDownChanged: {
+                if(!down) {
+                    video.seek(value)
+                    value = Qt.binding(function() { return video.position })
+                }
+            }
+            Label {
+                anchors {
+                    right: parent.right
+                    rightMargin: Theme.horizontalPageMargin
+                    bottom: parent.bottom
+                    topMargin: Theme.paddingSmall
+                }
+                font.pixelSize: Theme.fontSizeExtraSmall
+                text: file.isDownloadingCompleted
+                      ? Format.formatDuration((parent.maximumValue - parent.value)/1000, Formatter.Duration)
+                      : (video.videoData.duration
+                        ? Format.formatDuration(video.videoData.duration, Formatter.Duration) + ', '
+                        : '') + Format.formatFileSize(file.size || file.expectedSize)
+                color: Theme.secondaryColor
+            }
+        }
+
+        Timer {
+            id: delayedOverlayHide
+            interval: 500
+            onTriggered: {
+                if(video.isPlaying) {
+                    page.overlayActive = false
+                }
+            }
+        }
+    }
+}

--- a/qml/components/messageContent/mediaAlbumPage/ZoomArea.qml
+++ b/qml/components/messageContent/mediaAlbumPage/ZoomArea.qml
@@ -1,0 +1,148 @@
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+SilicaFlickable {
+    // id
+    id: flickable
+    // property declarations
+    property real zoom
+    property bool zoomed
+    // override if needed
+    property bool zoomEnabled: true
+    property real minimumZoom: fitZoom
+    property real maximumZoom: 4 //Math.max(fitZoom, 1) * 3
+
+    default property alias zoomContentItem: zoomContentItem.data
+    property alias implicitContentWidth: zoomContentItem.implicitWidth
+    property alias implicitContentHeight: zoomContentItem.implicitHeight
+    // factor for "PreserveAspectFit"
+    readonly property real fitZoom: implicitContentWidth > 0 && implicitContentHeight > 0
+        ? Math.min(maximumZoom, width / implicitContentWidth, height / implicitContentHeight)
+        : 1.0
+    readonly property int minimumBoundaryAxis: (implicitContentWidth / implicitContentHeight) > (width / height) ? Qt.Horizontal : Qt.Vertical
+
+    // JavaScript functions
+    function zoomOut(animated) {
+        if (zoomed) {
+            if(animated) { zoomOutAnimation.start() }
+            else {
+                zoom = fitZoom
+                zoomed = false
+            }
+        }
+    }
+
+    // object properties
+    contentWidth: Math.max(width, zoomContentItem.width)
+    contentHeight: Math.max(height, zoomContentItem.height)
+    enabled: !zoomOutAnimation.running && implicitContentWidth > 0 && implicitContentHeight > 0
+    flickableDirection: Flickable.HorizontalAndVerticalFlick
+    interactive: zoomed
+    // According to Jolla, otherwise pinching would sometimes not work:
+    pressDelay: 0
+    Binding { // Update zoom on orientation changes and set as default
+        target: flickable
+        when: !zoomed
+        property: "zoom"
+        value: minimumZoom
+    }
+    // child objects
+
+    PinchArea {
+        id: pinchArea
+        parent: flickable.contentItem
+        width: flickable.contentWidth
+        height: flickable.contentHeight
+        enabled: zoomEnabled && minimumZoom !== maximumZoom && flickable.enabled
+        onPinchUpdated: {
+            scrollDecoratorTimer.restart()
+            var f = flickable;
+            var requestedZoomFactor = 1.0 + pinch.scale - pinch.previousScale;
+            var previousWidth = f.contentWidth
+            var previousHeight = f.contentHeight
+            var targetWidth
+            var targetHeight
+            var targetZoom = requestedZoomFactor * f.zoom;
+            if (targetZoom < f.minimumZoom) {
+                f.zoom = f.minimumZoom;
+                f.zoomed = false;
+                f.contentX = 0;
+                f.contentY = 0;
+                return
+            }  else if(targetZoom >= f.maximumZoom) {
+                f.zoom = f.maximumZoom;
+                targetHeight = f.implicitContentHeight * f.zoom
+                targetWidth = f.implicitContentWidth * f.zoom
+            }
+            else if(targetZoom < f.maximumZoom) {
+                if (f.minimumBoundaryAxis == Qt.Horizontal) {
+                    targetWidth = f.contentWidth * requestedZoomFactor
+                    f.zoom = targetWidth / f.implicitContentWidth
+                    targetHeight = f.implicitContentHeight * f.zoom
+                } else {
+                    targetHeight = f.contentHeight * requestedZoomFactor
+                    f.zoom = targetHeight / f.implicitContentHeight
+                    targetWidth = f.implicitContentWidth * f.zoom
+                }
+            }
+            // calculate center difference
+            f.contentX += pinch.previousCenter.x - pinch.center.x
+            f.contentY += pinch.previousCenter.y - pinch.center.y
+            // move to new (zoomed) center. this jumps a tiny bit, but is bearable:
+            if (targetWidth > f.width)
+                f.contentX -= (previousWidth - targetWidth)/(previousWidth/pinch.previousCenter.x)
+            if (targetHeight > f.height)
+                f.contentY -= (previousHeight - targetHeight)/(previousHeight/pinch.previousCenter.y)
+
+            f.zoomed = true
+        }
+        onPinchFinished: {
+            returnToBounds()
+        }
+        Item {
+            id: zoomContentItem
+            anchors.centerIn: parent
+            implicitWidth: flickable.width
+            implicitHeight: flickable.height
+            width: Math.ceil(implicitWidth * zoom)
+            height: Math.ceil(implicitHeight * zoom)
+        }
+    }
+    // enable zoom to minimumZoom on click
+    ParallelAnimation {
+        id: zoomOutAnimation
+        NumberAnimation {
+            target: flickable
+            properties: "contentX, contentY"
+            to: 0
+        }
+        NumberAnimation {
+            target: flickable
+            property: "zoom"
+            to: fitZoom
+        }
+        onRunningChanged: {
+            if(!running) {
+                zoomed = false
+            }
+        }
+    }
+
+    // show scroll decorators when scrolling OR zooming
+    Timer {
+        id: scrollDecoratorTimer
+        readonly property bool moving: flickable.moving
+        readonly property bool showing: moving || running
+        onMovingChanged: restart()
+        interval: 300
+    }
+
+    VerticalScrollDecorator {
+        flickable: flickable
+        opacity: scrollDecoratorTimer.showing ? 1.0 : 0.0
+    }
+    HorizontalScrollDecorator {
+        flickable: flickable
+        opacity: scrollDecoratorTimer.showing ? 1.0 : 0.0
+    }
+}

--- a/qml/components/messageContent/mediaAlbumPage/ZoomImage.qml
+++ b/qml/components/messageContent/mediaAlbumPage/ZoomImage.qml
@@ -1,0 +1,127 @@
+import QtQuick 2.0
+import Sailfish.Silica 1.0
+import WerkWolf.Fernschreiber 1.0
+import "../../"
+
+ZoomArea {
+    // id
+    id: zoomArea
+    property var photoData //albumMessages[index].content.photo
+    property bool active: true
+    property alias image: image
+
+    signal clicked
+
+    maximumZoom: Math.max(Screen.width, Screen.height) / 200
+//    maximumZoom: Math.max(fitZoom, 1) * 3
+    implicitContentWidth: image.implicitWidth
+    implicitContentHeight: image.implicitHeight
+    zoomEnabled: image.status == Image.Ready
+
+    onActiveChanged: {
+        if (!active) {
+            zoomOut()
+        }
+    }
+
+    Component.onCompleted: {
+//        var photoData = albumMessages[index].content.photo;
+        if (photoData) {
+
+            var biggestIndex = -1
+            for (var i = 0; i < photoData.sizes.length; i++) {
+                if (biggestIndex === -1 || photoData.sizes[i].width > photoData.sizes[biggestIndex].width) {
+                    biggestIndex = i;
+                }
+            }
+            if (biggestIndex > -1) {
+//                imageDelegate.imageWidth = photoData.sizes[biggestIndex].width;
+//                imageDelegate.imageHeight = photoData.sizes[biggestIndex].height;
+                image.sourceSize.width = photoData.sizes[biggestIndex].width
+                image.sourceSize.height = photoData.sizes[biggestIndex].height
+                image.fileInformation = photoData.sizes[biggestIndex].photo
+
+                console.log('loading photo', JSON.stringify(image.fileInformation))
+            }
+        }
+    }
+    TDLibImage {
+        id: image
+
+        width: parent.width
+        height: parent.height
+        source: file.isDownloadingCompleted ? file.path : ""
+//        enabled: true //!!file.fileId
+//        anchors.fill: parent
+        anchors.centerIn: parent
+
+        fillMode: Image.PreserveAspectFit
+        asynchronous: true
+        smooth: !(movingVertically || movingHorizontally)
+
+//        sourceSize.width: Screen.height
+//        visible: opacity > 0
+//        opacity: status === Image.Ready ? 1 : 0
+
+        Behavior on opacity { FadeAnimator{} }
+    }
+//    Label {
+//        anchors.fill: parent
+//        text: 'ok?' + image.enabled +' fileid:' +!!(image.file.fileId)
+//              + '\n - dl?' + image.file.isDownloadingActive
+//              + '\n completed?' + image.file.isDownloadingCompleted + ' path:'+ image.file.path
+//              + '\n ' + image.source
+//        wrapMode: Text.WrapAtWordBoundaryOrAnywhere
+//    }
+//    Rectangle {
+//        color: 'green'
+//        anchors.fill: image
+//        opacity: 0.3
+
+//    }
+
+//    Image {
+//        id: image
+//        anchors.fill: parent
+//        smooth: !(movingVertically || movingHorizontally)
+//        sourceSize.width: Screen.height
+//        fillMode: Image.PreserveAspectFit
+//        asynchronous: true
+//        cache: false
+
+//        onSourceChanged: {
+//            zoomOut()
+//        }
+
+//        opacity: status == Image.Ready ? 1 : 0
+//        Behavior on opacity { FadeAnimator{} }
+//    }
+    Item {
+        anchors.fill: parent
+
+    }
+    MouseArea {
+        anchors.centerIn: parent
+        width: zoomArea.contentWidth
+        height: zoomArea.contentHeight
+        onClicked: zoomArea.clicked()
+    }
+
+
+    BusyIndicator {
+        running: image.file.isDownloadingActive && !delayBusyIndicator.running
+        size: BusyIndicatorSize.Large
+        anchors.centerIn: parent
+        parent: zoomArea
+        Timer {
+            id: delayBusyIndicator
+            running: image.file.isDownloadingActive
+            interval: 1000
+        }
+    }
+//    Rectangle {
+//        color: 'green'
+//        anchors.fill: parent
+//        parent: zoomArea
+//    }
+}

--- a/qml/pages/MediaAlbumPage.qml
+++ b/qml/pages/MediaAlbumPage.qml
@@ -1,0 +1,109 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+// jolla-gallery/pages/FlickableImageView.qml
+/*
+
+FullscreenContentPage
+    - PagedView (jolla-gallery/FlickableImageView)
+        - delegate: Loader
+            - SilicaFlickable (Silica.private/ZoomableFlickable) (Sailfish.Gallery/ImageViewer)
+                - PinchArea
+                    - dragDetector(?)
+                    - image
+        - Item (Sailfish.Gallery/GalleryOverlay)
+
+*/
+
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import WerkWolf.Fernschreiber 1.0
+import "../components"
+
+import "../components/messageContent/mediaAlbumPage"
+import "../js/twemoji.js" as Emoji
+import "../js/functions.js" as Functions
+
+Page {
+    // id
+    id: page
+    // property declarations
+
+    property alias index: pagedView.currentIndex
+    property alias overlayActive: overlay.active
+    property alias delegate: pagedView.delegate
+    property var messages: [];
+    // message.content.caption.text
+    palette.colorScheme: Theme.LightOnDark
+    clip: status !== PageStatus.Active || pageStack.dragInProgress
+    navigationStyle: PageNavigation.Vertical
+    backgroundColor: 'black'
+    allowedOrientations: Orientation.All
+    // signal declarations
+    // JavaScript functions
+
+    // object (parent) properties
+    // large property bindings
+    // child objects
+    // states
+    // transitions
+
+
+
+    // content
+    PagedView {
+        id: pagedView
+        anchors.fill: parent
+        model: messages
+        delegate: Component {
+            Loader {
+                id: loader
+                asynchronous: true
+                visible: status == Loader.Ready
+                width: PagedView.contentWidth
+                height: PagedView.contentHeight
+
+                states: [
+                    State {
+                        when: model.modelData.content['@type'] === 'messagePhoto'
+                        PropertyChanges {
+                            target: loader
+                            source: "../components/messageContent/mediaAlbumPage/PhotoComponent.qml"
+                        }
+                    },
+                    State {
+                        when: model.modelData.content['@type'] === 'messageVideo'
+                        PropertyChanges {
+                            target: loader
+                            source: "../components/messageContent/mediaAlbumPage/VideoComponent.qml"
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+    // overlay
+    FullscreenOverlay {
+        id: overlay
+        pageCount: messages.length
+        currentIndex: page.index
+        message: messages[currentIndex]
+//
+    }
+}

--- a/src/boolfiltermodel.cpp
+++ b/src/boolfiltermodel.cpp
@@ -1,0 +1,153 @@
+/*
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "boolfiltermodel.h"
+
+#define DEBUG_MODULE BoolFilterModel
+#include "debuglog.h"
+
+BoolFilterModel::BoolFilterModel(QObject *parent) : QSortFilterProxyModel(parent)
+{
+    setDynamicSortFilter(true);
+//    setFilterCaseSensitivity(Qt::CaseInsensitive);
+//    setFilterFixedString(QString());
+    filterValue = true;
+}
+
+void BoolFilterModel::setSource(QObject *model)
+{
+    setSourceModel(qobject_cast<QAbstractItemModel*>(model));
+}
+
+void BoolFilterModel::setSourceModel(QAbstractItemModel *model)
+{
+    if (sourceModel() != model) {
+        LOG(model);
+        QSortFilterProxyModel::setSourceModel(model);
+        updateFilterRole();
+        emit sourceChanged();
+    }
+}
+
+QString BoolFilterModel::getFilterRoleName() const
+{
+    return filterRoleName;
+}
+
+void BoolFilterModel::setFilterRoleName(QString role)
+{
+    if (filterRoleName != role) {
+        filterRoleName = role;
+        LOG(role);
+        updateFilterRole();
+        emit filterRoleNameChanged();
+    }
+}
+
+bool BoolFilterModel::getFilterValue() const
+{
+    return filterValue;
+}
+
+void BoolFilterModel::setFilterValue(bool value)
+{
+    if(value != filterValue) {
+        filterValue = value;
+        invalidateFilter();
+    }
+}
+
+int BoolFilterModel::mapRowFromSource(int i, int fallbackDirection)
+{
+    QModelIndex myIndex = mapFromSource(sourceModel()->index(i, 0));
+    LOG("mapping index" << i << "to source model:" << myIndex.row() << "valid?" << myIndex.isValid());
+    if(myIndex.isValid()) {
+        return myIndex.row();
+    }
+
+    if(fallbackDirection > 0) {
+        int max = sourceModel()->rowCount();
+        i += 1;
+        while (i < max) {
+            myIndex = mapFromSource(sourceModel()->index(i, 0));
+
+            LOG("fallback ++ " << i << "to source model:" << myIndex.row() << "valid?" << myIndex.isValid());
+            if(myIndex.isValid()) {
+                return myIndex.row();
+            }
+            i += 1;
+        }
+    } else if(fallbackDirection < 0) {
+        i -= 1;
+        while (i > -1) {
+            myIndex = mapFromSource(sourceModel()->index(i, 0));
+            LOG("fallback -- " << i << "to source model:" << myIndex.row() << "valid?" << myIndex.isValid());
+            if(myIndex.isValid()) {
+                return myIndex.row();
+            }
+            i -= 1;
+        }
+    }
+
+    return myIndex.row(); // may still be -1
+}
+
+int BoolFilterModel::mapRowToSource(int i)
+{
+    QModelIndex sourceIndex = mapToSource(index(i, 0));
+    return sourceIndex.row();
+}
+bool BoolFilterModel::filterAcceptsRow(int sourceRow,
+         const QModelIndex &sourceParent) const
+ {
+//    sourceModel()->index(sourceRow, 0, sourceParent.child(sourceRow, 0)).data(); //.toString().contains( /*string for column 0*/ ))
+//    LOG("Filter Role " <<  filterRole());
+//    QModelIndex index = this->sourceModel()->index(sourceRow,1,sourceParent);
+//    sourceModel()->index(sourceRow, 0, sourceParent.child(sourceRow, 0)).data(filterRole()).toBool();
+//    LOG("Filter index DATA"<< sourceModel()->index(sourceRow, 0, sourceParent.child(sourceRow, 0)).data(filterRole())); //<<  index << index.isValid());
+//    LOG("Filter parent " <<  sourceParent << sourceParent.isValid());
+//    LOG("Filter Model Value" << sourceModel()->index(sourceRow, 0, sourceParent.child(sourceRow, 0)).data(filterRole()).toBool());
+//    LOG("Filter Model filterValue" << filterValue);
+//    LOG("Filter Model result" << (sourceModel()->index(sourceRow, 0, sourceParent.child(sourceRow, 0)).data(filterRole()).toBool() == filterValue));
+//    LOG("Filter Model MESSAGE" << sourceModel()->index(sourceRow, 0, sourceParent.child(sourceRow, 0)).data());
+    return sourceModel()->index(sourceRow, 0, sourceParent.child(sourceRow, 0)).data(filterRole()).toBool() == filterValue;
+ }
+
+int BoolFilterModel::findRole(QAbstractItemModel *model, QString role)
+{
+    if (model && !role.isEmpty()) {
+        const QByteArray roleName(role.toUtf8());
+        const QHash<int,QByteArray> roleMap(model->roleNames());
+        const QList<int> roles(roleMap.keys());
+        const int n = roles.count();
+        for (int i = 0; i < n; i++) {
+            const QByteArray name(roleMap.value(roles.at(i)));
+            if (name == roleName) {
+                LOG(role << roles.at(i));
+                return roles.at(i);
+            }
+        }
+        LOG("Unknown role" << role);
+    }
+    return -1;
+}
+
+void BoolFilterModel::updateFilterRole()
+{
+    const int role = findRole(sourceModel(), filterRoleName);
+    setFilterRole((role >= 0) ? role : Qt::DisplayRole);
+}

--- a/src/boolfiltermodel.h
+++ b/src/boolfiltermodel.h
@@ -1,0 +1,63 @@
+/*
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef BOOLFILTERMODEL_H
+#define BOOLFILTERMODEL_H
+
+#include <QSortFilterProxyModel>
+
+class BoolFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+    Q_PROPERTY(QString filterRoleName READ getFilterRoleName WRITE setFilterRoleName NOTIFY filterRoleNameChanged)
+    Q_PROPERTY(bool filterValue READ getFilterValue WRITE setFilterValue NOTIFY filterValueChanged)
+    Q_PROPERTY(QObject* sourceModel READ sourceModel WRITE setSource NOTIFY sourceChanged)
+
+public:
+    BoolFilterModel(QObject *parent = Q_NULLPTR);
+
+    void setSource(QObject* model);
+    void setSourceModel(QAbstractItemModel *model) Q_DECL_OVERRIDE;
+
+
+    QString getFilterRoleName() const;
+    void setFilterRoleName(QString role);
+
+    bool getFilterValue() const;
+    void setFilterValue(bool value);
+    Q_INVOKABLE int mapRowFromSource(int i, int fallbackDirection);
+    Q_INVOKABLE int mapRowToSource(int i);
+
+signals:
+    void sourceChanged();
+    void filterRoleNameChanged();
+    void filterValueChanged();
+
+private slots:
+    void updateFilterRole();
+
+private:
+    static int findRole(QAbstractItemModel *model, QString role);
+
+private:
+    QString filterRoleName;
+    bool filterValue;
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+};
+
+#endif // BOOLFILTERMODEL_H

--- a/src/chatmodel.h
+++ b/src/chatmodel.h
@@ -44,6 +44,8 @@ public:
     Q_INVOKABLE void triggerLoadMoreFuture();
     Q_INVOKABLE QVariantMap getChatInformation();
     Q_INVOKABLE QVariantMap getMessage(int index);
+    Q_INVOKABLE QVariantList getMessageIdsForAlbum(qlonglong albumId);
+    Q_INVOKABLE QVariantList getMessagesForAlbum(qlonglong albumId, int startAt);
     Q_INVOKABLE int getLastReadMessageIndex();
     Q_INVOKABLE void setSearchQuery(const QString newSearchQuery);
 
@@ -85,6 +87,10 @@ private:
     void insertMessages(const QList<MessageData*> newMessages);
     void appendMessages(const QList<MessageData*> newMessages);
     void prependMessages(const QList<MessageData*> newMessages);
+    void updateAlbumMessages(qlonglong albumId, bool checkDeleted);
+    void updateAlbumMessages(QList<qlonglong> albumIds, bool checkDeleted);
+    void setMessagesAlbum(const QList<MessageData*> newMessages);
+    void setMessagesAlbum(MessageData *message);
     QVariantMap enhanceMessage(const QVariantMap &message);
     int calculateLastKnownMessageId();
     int calculateLastReadSentMessageId();
@@ -95,6 +101,7 @@ private:
     TDLibWrapper *tdLibWrapper;
     QList<MessageData*> messages;
     QHash<qlonglong,int> messageIndexMap;
+    QHash<qlonglong, QVariantList> albumMessageMap;
     QVariantMap chatInformation;
     qlonglong chatId;
     bool inReload;

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -51,6 +51,7 @@
 #include "processlauncher.h"
 #include "stickermanager.h"
 #include "textfiltermodel.h"
+#include "boolfiltermodel.h"
 #include "tgsplugin.h"
 #include "fernschreiberutils.h"
 #include "knownusersmodel.h"
@@ -130,6 +131,7 @@ int main(int argc, char *argv[])
     qmlRegisterType<TDLibFile>(uri, 1, 0, "TDLibFile");
     qmlRegisterType<NamedAction>(uri, 1, 0, "NamedAction");
     qmlRegisterType<TextFilterModel>(uri, 1, 0, "TextFilterModel");
+    qmlRegisterType<BoolFilterModel>(uri, 1, 0, "BoolFilterModel");
     qmlRegisterType<ChatPermissionFilterModel>(uri, 1, 0, "ChatPermissionFilterModel");
     qmlRegisterSingletonType<DebugLogJS>(uri, 1, 0, "DebugLog", DebugLogJS::createSingleton);
 


### PR DESCRIPTION
- fixes some irregularities with updated/deleted messages chatmodel. messageIndexMap got out of sync for messages after deleted ones.
- adds media album
- reworks detail view for media messagecontents


this was mostly reworked/rebased in the middle of the night at 37C3, so it really needs some testing and a bit more clean up… I think I'll get to do some additional commits here. The main changes should be set, though.

Perhaps we give our "advanced users" a go with the usual disclaimer?

here are some rpms (zipped because of github restrictions):
[harbour-fernschreiber-0.17-12.aarch64.zip](https://github.com/Wunderfitz/harbour-fernschreiber/files/13786635/harbour-fernschreiber-0.17-12.aarch64.zip)
[harbour-fernschreiber-0.17-12.armv7hl.zip](https://github.com/Wunderfitz/harbour-fernschreiber/files/13786636/harbour-fernschreiber-0.17-12.armv7hl.zip)
[harbour-fernschreiber-0.17-12.i486.zip](https://github.com/Wunderfitz/harbour-fernschreiber/files/13786637/harbour-fernschreiber-0.17-12.i486.zip)

edit: this does not change anything in regards to the "reaction bubble" – perhaps a click on the date could also trigger the "general click"?