### PR TITLE
Force xz rpm compression

### DIFF
--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -9,6 +9,7 @@ Name:       harbour-fernschreiber
 # << macros
 %define __provides_exclude_from ^%{_datadir}/.*$
 %define __requires_exclude ^libtdjson.*$
+%define _binary_payload w6.xzdio
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
 Version:    0.17

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -34,6 +34,7 @@ PkgConfigBR:
 Macros:
   - '__provides_exclude_from;^%{_datadir}/.*$'
   - '__requires_exclude;^libtdjson.*$'
+  - '_binary_payload;w6.xzdio'
 
 # Build dependencies without a pkgconfig setup can be listed here
 PkgBR:


### PR DESCRIPTION
That improves the chances of rpm being installable on a system that doesn't support zstd compression (like my tablet)

It's not clear to me why to maintain both yaml and spec files but if the owner likes it this way then so be it