### PR TITLE
Avoid UI updates in Chat selection screen when forwarding a chat message

### DIFF
--- a/src/chatlistmodel.h
+++ b/src/chatlistmodel.h
@@ -75,6 +75,7 @@ public:
 
     bool showAllChats() const;
     void setShowAllChats(bool showAll);
+    ChatListModel* clone();
 
 private slots:
     void handleChatDiscovered(const QString &chatId, const QVariantMap &chatInformation);

--- a/src/chatpermissionfiltermodel.cpp
+++ b/src/chatpermissionfiltermodel.cpp
@@ -33,7 +33,9 @@ ChatPermissionFilterModel::ChatPermissionFilterModel(QObject *parent) : QSortFil
 
 void ChatPermissionFilterModel::setSource(QObject *model)
 {
-    setSourceModel(qobject_cast<ChatListModel*>(model));
+    ChatListModel* chatListModel = qobject_cast<ChatListModel*>(model);
+    ChatListModel* chatListModelClone = chatListModel->clone();
+    setSourceModel(chatListModelClone);
 }
 
 void ChatPermissionFilterModel::setSourceModel(QAbstractItemModel *model)
@@ -42,6 +44,13 @@ void ChatPermissionFilterModel::setSourceModel(QAbstractItemModel *model)
         LOG(model);
         QSortFilterProxyModel::setSourceModel(model);
         emit sourceChanged();
+    }
+}
+
+ChatPermissionFilterModel::~ChatPermissionFilterModel() {
+    QAbstractItemModel* _sourceModel = sourceModel();
+    if(_sourceModel != nullptr) {
+        delete _sourceModel;
     }
 }
 

--- a/src/chatpermissionfiltermodel.h
+++ b/src/chatpermissionfiltermodel.h
@@ -31,7 +31,7 @@ class ChatPermissionFilterModel : public QSortFilterProxyModel
 
 public:
     ChatPermissionFilterModel(QObject *parent = Q_NULLPTR);
-
+    ~ChatPermissionFilterModel() override;
     TDLibWrapper *getTDLibWrapper() const;
     void setTDLibWrapper(QObject* obj);
 


### PR DESCRIPTION
This pull request removes the annoying and useless update of the list of chats when you select a chat to forward a message to (these constant updates actually stop you from easily selecting a chat to forward your message to).
It creates a "frozen" copy of chatlistmodel to be used by the ChatPermissionFilterModel (which is only used by the "select a chat..." screen so far).