### PR TITLE
Add admin member actions to the group members list

### DIFF
--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -134,6 +134,7 @@ DISTFILES += qml/harbour-fernschreiber.qml \
     qml/js/functions.js \
     qml/pages/ChatInformationPage.qml \
     qml/pages/ChatPage.qml \
+    qml/pages/ChatMemberPermissionsPage.qml \
     qml/pages/ChatSelectionPage.qml \
     qml/pages/CoverPage.qml \
     qml/pages/DebugPage.qml \

--- a/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
+++ b/qml/components/chatInformationPage/ChatInformationTabItemMembersGroups.qml
@@ -71,10 +71,101 @@ ChatInformationTabItemBase {
             text: (chatInformationPage.isPrivateChat || chatInformationPage.isSecretChat) ? qsTr("You don't have any groups in common with this user.") : ( chatInformationPage.isChannel ? qsTr("Channel members are anonymous.") : qsTr("This group is empty.") )
         }
         delegate: PhotoTextsListItem {
+            id: memberListItem
             pictureThumbnail {
                 photoData: user.profile_photo ? user.profile_photo.small : null
             }
             width: parent.width
+
+            // Admin actions on other members: only offered if we can restrict
+            // members and the target is a regular/restricted member (admins and
+            // the creator can't be managed this way). Newer TDLib nests the
+            // admin rights in status.rights, older TDLib has them flat.
+            readonly property bool ownUserCanRestrictMembers: (chatInformationPage.isSuperGroup || chatInformationPage.isBasicGroup)
+                                                              && chatInformationPage.groupInformation.status
+                                                              && ( chatInformationPage.groupInformation.status["@type"] === "chatMemberStatusCreator"
+                                                                  || ( chatInformationPage.groupInformation.status["@type"] === "chatMemberStatusAdministrator"
+                                                                      && ( chatInformationPage.groupInformation.status.rights
+                                                                          ? chatInformationPage.groupInformation.status.rights.can_restrict_members
+                                                                          : chatInformationPage.groupInformation.status.can_restrict_members ) ) )
+            readonly property bool memberIsManageable: member_id.user_id !== chatInformationPage.myUserId
+                                                       && ( model.status["@type"] === "chatMemberStatusMember"
+                                                           || model.status["@type"] === "chatMemberStatusRestricted" )
+
+            menu: (ownUserCanRestrictMembers && memberIsManageable) ? memberContextMenu : null
+
+            Component {
+                id: memberContextMenu
+                ContextMenu {
+                    MenuItem {
+                        visible: chatInformationPage.isSuperGroup
+                        text: qsTr("Member Permissions", "edit a group member's individual permissions")
+                        onClicked: {
+                            var setIndex = index;
+                            var dialog = pageStack.push(Qt.resolvedUrl("../../pages/ChatMemberPermissionsPage.qml"), {
+                                chatId: chatInformationPage.chatInformation.id,
+                                memberUserId: member_id.user_id,
+                                userName: Functions.getUserName(user),
+                                memberStatus: model.status,
+                                defaultPermissions: chatInformationPage.chatInformation.permissions
+                            });
+                            dialog.accepted.connect(function() {
+                                if (dialog.resultStatus) {
+                                    pageContent.membersList.set(setIndex, { status: dialog.resultStatus });
+                                }
+                            });
+                        }
+                    }
+                    MenuItem {
+                        visible: chatInformationPage.isSuperGroup && model.status["@type"] === "chatMemberStatusMember"
+                        text: qsTr("Revoke Write Permission", "restrict a group member")
+                        onClicked: {
+                            // All chatPermissions fields default to false, so an
+                            // empty object mutes the member regardless of the
+                            // TDLib generation (old flat vs. new granular fields).
+                            var newStatus = {
+                                "@type": "chatMemberStatusRestricted",
+                                is_member: true,
+                                restricted_until_date: 0,
+                                permissions: { "@type": "chatPermissions" }
+                            };
+                            tdLibWrapper.setChatMemberStatus(chatInformationPage.chatInformation.id, member_id.user_id, newStatus);
+                            pageContent.membersList.set(index, { status: newStatus });
+                        }
+                    }
+                    MenuItem {
+                        visible: chatInformationPage.isSuperGroup && model.status["@type"] === "chatMemberStatusRestricted"
+                        text: qsTr("Remove Restrictions", "lift restrictions from a group member")
+                        onClicked: {
+                            var newStatus = { "@type": "chatMemberStatusMember" };
+                            tdLibWrapper.setChatMemberStatus(chatInformationPage.chatInformation.id, member_id.user_id, newStatus);
+                            pageContent.membersList.set(index, { status: newStatus });
+                        }
+                    }
+                    MenuItem {
+                        text: qsTr("Remove from Group", "ban a group member")
+                        onClicked: {
+                            var chatId = chatInformationPage.chatInformation.id;
+                            var userId = member_id.user_id;
+                            memberListItem.remorseAction(qsTr("Removing member", "remorse timer text"), function() {
+                                tdLibWrapper.banChatMember(chatId, userId, 0, false);
+                                pageContent.membersList.remove(index);
+                            });
+                        }
+                    }
+                    MenuItem {
+                        text: qsTr("Remove and Delete All Messages", "ban a group member, revoking their messages")
+                        onClicked: {
+                            var chatId = chatInformationPage.chatInformation.id;
+                            var userId = member_id.user_id;
+                            memberListItem.remorseAction(qsTr("Removing member and deleting messages", "remorse timer text"), function() {
+                                tdLibWrapper.banChatMember(chatId, userId, 0, true);
+                                pageContent.membersList.remove(index);
+                            });
+                        }
+                    }
+                }
+            }
 
             // chat title
             primaryText.text: Emoji.emojify(Functions.getUserName(user), primaryText.font.pixelSize)

--- a/qml/pages/ChatMemberPermissionsPage.qml
+++ b/qml/pages/ChatMemberPermissionsPage.qml
@@ -1,0 +1,128 @@
+/*
+    Copyright (C) 2020 Sebastian J. Wolf and other contributors
+
+    This file is part of Fernschreiber.
+
+    Fernschreiber is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Fernschreiber is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Fernschreiber. If not, see <http://www.gnu.org/licenses/>.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+Dialog {
+    id: memberPermissionsDialog
+    allowedOrientations: Orientation.All
+
+    property string chatId
+    property string memberUserId
+    property string userName
+    property var memberStatus: ({})
+    property var defaultPermissions: ({})
+    // set on accept; the new chatMemberStatus that was sent to TDLib
+    property var resultStatus: null
+
+    readonly property bool isRestricted: memberStatus["@type"] === "chatMemberStatusRestricted"
+
+    // key: granular chatPermissions field (TDLib >= 1.8.11),
+    // legacy: pre-granular fallback used when reading older TDLib data
+    readonly property var permissionItems: [
+        { key: "can_send_basic_messages", legacy: "can_send_messages", label: qsTr("Send Text Messages", "member permission") },
+        { key: "can_send_photos", legacy: "can_send_media_messages", label: qsTr("Send Photos", "member permission") },
+        { key: "can_send_videos", legacy: "can_send_media_messages", label: qsTr("Send Videos", "member permission") },
+        { key: "can_send_audios", legacy: "can_send_media_messages", label: qsTr("Send Music & Audio Files", "member permission") },
+        { key: "can_send_documents", legacy: "can_send_media_messages", label: qsTr("Send Files", "member permission") },
+        { key: "can_send_voice_notes", legacy: "can_send_media_messages", label: qsTr("Send Voice Messages", "member permission") },
+        { key: "can_send_video_notes", legacy: "can_send_media_messages", label: qsTr("Send Video Messages", "member permission") },
+        { key: "can_send_polls", legacy: "can_send_polls", label: qsTr("Send Polls", "member permission") },
+        { key: "can_send_other_messages", legacy: "can_send_other_messages", label: qsTr("Send Stickers, GIFs & Games", "member permission") },
+        { key: "can_add_web_page_previews", legacy: "can_add_web_page_previews", label: qsTr("Add Web Page Previews", "member permission") },
+        { key: "can_change_info", legacy: "can_change_info", label: qsTr("Change Chat Info", "member permission") },
+        { key: "can_invite_users", legacy: "can_invite_users", label: qsTr("Invite Users", "member permission") },
+        { key: "can_pin_messages", legacy: "can_pin_messages", label: qsTr("Pin Messages", "member permission") }
+    ]
+
+    function lookupPermission(permissions, item) {
+        if (!permissions) {
+            return true;
+        }
+        if (permissions[item.key] !== undefined) {
+            return permissions[item.key];
+        }
+        if (permissions[item.legacy] !== undefined) {
+            return permissions[item.legacy];
+        }
+        return true;
+    }
+    function chatAllows(item) {
+        return lookupPermission(defaultPermissions, item);
+    }
+    function memberHas(item) {
+        return isRestricted ? lookupPermission(memberStatus.permissions, item) : chatAllows(item);
+    }
+
+    onAccepted: {
+        var permissions = { "@type": "chatPermissions" };
+        var fullyUnrestricted = true;
+        for (var i = 0; i < permissionItems.length; i++) {
+            var permissionSwitch = permissionRepeater.itemAt(i);
+            permissions[permissionItems[i].key] = permissionSwitch.checked;
+            // a switch disabled by the chat's default permissions can't grant
+            // anything anyway, so it doesn't keep the member "restricted"
+            if (permissionSwitch.enabled && !permissionSwitch.checked) {
+                fullyUnrestricted = false;
+            }
+        }
+        if (isRestricted && memberStatus.permissions && memberStatus.permissions.can_manage_topics !== undefined) {
+            permissions.can_manage_topics = memberStatus.permissions.can_manage_topics;
+        }
+        resultStatus = fullyUnrestricted ? { "@type": "chatMemberStatusMember" }
+                                         : { "@type": "chatMemberStatusRestricted",
+                                             is_member: true,
+                                             restricted_until_date: 0,
+                                             permissions: permissions };
+        tdLibWrapper.setChatMemberStatus(chatId, memberUserId, resultStatus);
+    }
+
+    SilicaFlickable {
+        anchors.fill: parent
+        contentHeight: contentColumn.height
+
+        Column {
+            id: contentColumn
+            width: parent.width
+
+            DialogHeader {
+                title: memberPermissionsDialog.userName
+                acceptText: qsTr("Save", "member permissions dialog")
+            }
+
+            SectionHeader {
+                text: qsTr("What can this member do?", "member permissions dialog")
+            }
+
+            Repeater {
+                id: permissionRepeater
+                model: memberPermissionsDialog.permissionItems
+
+                TextSwitch {
+                    text: modelData.label
+                    description: enabled ? "" : qsTr("Not allowed by the group's default permissions", "member permissions dialog")
+                    checked: memberPermissionsDialog.memberHas(modelData)
+                    enabled: memberPermissionsDialog.chatAllows(modelData)
+                }
+            }
+        }
+
+        VerticalScrollDecorator {}
+    }
+}

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -937,6 +937,37 @@ void TDLibWrapper::setChatPermissions(const QString &chatId, const QVariantMap &
     this->sendRequest(requestObject);
 }
 
+void TDLibWrapper::setChatMemberStatus(const QString &chatId, const QString &memberUserId, const QVariantMap &status)
+{
+    LOG("Setting Chat Member Status" << chatId << memberUserId);
+    QVariantMap memberId;
+    memberId.insert(_TYPE, "messageSenderUser");
+    memberId.insert("user_id", memberUserId);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "setChatMemberStatus");
+    requestObject.insert(_EXTRA, chatId);
+    requestObject.insert(CHAT_ID, chatId);
+    requestObject.insert("member_id", memberId);
+    requestObject.insert("status", status);
+    this->sendRequest(requestObject);
+}
+
+void TDLibWrapper::banChatMember(const QString &chatId, const QString &memberUserId, int bannedUntilDate, bool revokeMessages)
+{
+    LOG("Banning Chat Member" << chatId << memberUserId);
+    QVariantMap memberId;
+    memberId.insert(_TYPE, "messageSenderUser");
+    memberId.insert("user_id", memberUserId);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "banChatMember");
+    requestObject.insert(_EXTRA, chatId);
+    requestObject.insert(CHAT_ID, chatId);
+    requestObject.insert("member_id", memberId);
+    requestObject.insert("banned_until_date", bannedUntilDate);
+    requestObject.insert("revoke_messages", revokeMessages);
+    this->sendRequest(requestObject);
+}
+
 void TDLibWrapper::setChatSlowModeDelay(const QString &chatId, int delay)
 {
 

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -210,6 +210,8 @@ public:
     Q_INVOKABLE void getGroupsInCommon(const QString &userId, int limit, int offset);
     Q_INVOKABLE void getUserProfilePhotos(const QString &userId, int limit, int offset);
     Q_INVOKABLE void setChatPermissions(const QString &chatId, const QVariantMap &chatPermissions);
+    Q_INVOKABLE void setChatMemberStatus(const QString &chatId, const QString &memberUserId, const QVariantMap &status);
+    Q_INVOKABLE void banChatMember(const QString &chatId, const QString &memberUserId, int bannedUntilDate, bool revokeMessages);
     Q_INVOKABLE void setChatSlowModeDelay(const QString &chatId, int delay);
     Q_INVOKABLE void setChatDescription(const QString &chatId, const QString &description);
     Q_INVOKABLE void setChatTitle(const QString &chatId, const QString &title);

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Mitglieder von Kanälen sind anonym.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation>Berechtigungen</translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation>Schreibrechte entziehen</translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation>Einschränkungen aufheben</translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation>Aus der Gruppe entfernen</translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation>Entferne Mitglied</translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation>Entfernen und alle Nachrichten löschen</translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation>Entferne Mitglied und lösche Nachrichten</translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Chat stummschalten</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation>Speichern</translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation>Was darf dieses Mitglied?</translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation>Durch die Standardrechte der Gruppe nicht erlaubt</translation>
+    </message>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation>Textnachrichten senden</translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation>Fotos senden</translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation>Videos senden</translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation>Musik &amp; Audiodateien senden</translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation>Dateien senden</translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation>Sprachnachrichten senden</translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation>Videonachrichten senden</translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation>Umfragen senden</translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation>Sticker, GIFs &amp; Spiele senden</translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation>Linkvorschauen anfügen</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation>Chatinfo ändern</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation>Benutzer einladen</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation>Nachrichten anpinnen</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Channel members are anonymous.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation>Member Permissions</translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation>Revoke Write Permission</translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation>Remove Restrictions</translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation>Remove from Group</translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation>Removing member</translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation>Remove and Delete All Messages</translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation>Removing member and deleting messages</translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Mute chat</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation>Save</translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation>What can this member do?</translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation>Not allowed by the group&apos;s default permissions</translation>
+    </message>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation>Send Text Messages</translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation>Send Photos</translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation>Send Videos</translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation>Send Music &amp; Audio Files</translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation>Send Files</translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation>Send Voice Messages</translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation>Send Video Messages</translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation>Send Polls</translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation>Send Stickers, GIFs &amp; Games</translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation>Add Web Page Previews</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation>Change Chat Info</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation>Invite Users</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation>Pin Messages</translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Los miembros del grupo son anónimos.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation>No notificar</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Agregar vistas previas de páginas web</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Cambiar detalles de Charla</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Invitar usuarios</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Mensajes Pin</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Kanavan jäsenet ovat anonyymejä.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Vaimenna keskustelu</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Lähettää verkkosivuesikatseluita</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Muuttaa keskustelun tietoja</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Kutsua jäseniä</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Kiinnittää viestejä</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-fr.ts
+++ b/translations/harbour-fernschreiber-fr.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Les membres du canal sont anonymes.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Mettre la conversation en sourdine</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Ajouter la prévisualisation de la page web</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Changer les informations de la conversation</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Inviter des utilisateurs</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Épingler des messages</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -212,6 +212,41 @@
         <source>Channel members are anonymous.</source>
         <translation>A csatorna tagjai névtelenek.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -285,6 +320,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Csevegés némítása</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>I membri del canale sono anonimi</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Silenzia chat</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Aggiungi anteprima sito web</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Modifica info chat</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Invita utenti</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Metti i messaggi in evidenza</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -218,6 +218,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Członkowie kanału są anonimowi.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -290,6 +325,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Wycisz czat</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Dodaj podglad stron internetowych</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Zmień informacje o czacie</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Zaproś użytkowników</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Przypnij wiadomość</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -218,6 +218,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Участники группы анонимны.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -290,6 +325,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Выключить уведомления</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Добавлять предпросмотр веб страниц</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Менять информацию о чате</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Приглашать участников</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Прицеплять сообщения</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -218,6 +218,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Členovia kanála sú anonymní.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -290,6 +325,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Umlčať čet</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Pridávať náhľad webovej stránky</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Meniť informácie o čete</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Pozývať používateľov</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Pripínať správu</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Kanalmedlemmar är anonyma.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation>Stäng av chatten</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Lägga till förhandsvisning av webbsida</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Ändra chattinformation</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Bjuda in användare</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">Fästa meddelanden</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -212,6 +212,41 @@
         <source>Channel members are anonymous.</source>
         <translation>频道成员已匿名。</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -284,6 +319,89 @@
     <message>
         <source>Mute chat</source>
         <translation>静音对话</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">添加网页预览</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">修改群组消息</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">邀请用户</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation type="unfinished">置顶消息</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -215,6 +215,41 @@
         <source>Channel members are anonymous.</source>
         <translation>Channel members are anonymous.</translation>
     </message>
+    <message>
+        <source>Member Permissions</source>
+        <comment>edit a group member&apos;s individual permissions</comment>
+        <translation>Member Permissions</translation>
+    </message>
+    <message>
+        <source>Revoke Write Permission</source>
+        <comment>restrict a group member</comment>
+        <translation>Revoke Write Permission</translation>
+    </message>
+    <message>
+        <source>Remove Restrictions</source>
+        <comment>lift restrictions from a group member</comment>
+        <translation>Remove Restrictions</translation>
+    </message>
+    <message>
+        <source>Remove from Group</source>
+        <comment>ban a group member</comment>
+        <translation>Remove from Group</translation>
+    </message>
+    <message>
+        <source>Removing member</source>
+        <comment>remorse timer text</comment>
+        <translation>Removing member</translation>
+    </message>
+    <message>
+        <source>Remove and Delete All Messages</source>
+        <comment>ban a group member, revoking their messages</comment>
+        <translation>Remove and Delete All Messages</translation>
+    </message>
+    <message>
+        <source>Removing member and deleting messages</source>
+        <comment>remorse timer text</comment>
+        <translation>Removing member and deleting messages</translation>
+    </message>
 </context>
 <context>
     <name>ChatInformationTabView</name>
@@ -287,6 +322,89 @@
     <message>
         <source>Mute chat</source>
         <translation type="unfinished">Mute chat</translation>
+    </message>
+</context>
+<context>
+    <name>ChatMemberPermissionsPage</name>
+    <message>
+        <source>Save</source>
+        <comment>member permissions dialog</comment>
+        <translation>Save</translation>
+    </message>
+    <message>
+        <source>What can this member do?</source>
+        <comment>member permissions dialog</comment>
+        <translation>What can this member do?</translation>
+    </message>
+    <message>
+        <source>Not allowed by the group&apos;s default permissions</source>
+        <comment>member permissions dialog</comment>
+        <translation>Not allowed by the group&apos;s default permissions</translation>
+    </message>
+    <message>
+        <source>Send Text Messages</source>
+        <comment>member permission</comment>
+        <translation>Send Text Messages</translation>
+    </message>
+    <message>
+        <source>Send Photos</source>
+        <comment>member permission</comment>
+        <translation>Send Photos</translation>
+    </message>
+    <message>
+        <source>Send Videos</source>
+        <comment>member permission</comment>
+        <translation>Send Videos</translation>
+    </message>
+    <message>
+        <source>Send Music &amp; Audio Files</source>
+        <comment>member permission</comment>
+        <translation>Send Music &amp; Audio Files</translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <comment>member permission</comment>
+        <translation>Send Files</translation>
+    </message>
+    <message>
+        <source>Send Voice Messages</source>
+        <comment>member permission</comment>
+        <translation>Send Voice Messages</translation>
+    </message>
+    <message>
+        <source>Send Video Messages</source>
+        <comment>member permission</comment>
+        <translation>Send Video Messages</translation>
+    </message>
+    <message>
+        <source>Send Polls</source>
+        <comment>member permission</comment>
+        <translation>Send Polls</translation>
+    </message>
+    <message>
+        <source>Send Stickers, GIFs &amp; Games</source>
+        <comment>member permission</comment>
+        <translation>Send Stickers, GIFs &amp; Games</translation>
+    </message>
+    <message>
+        <source>Add Web Page Previews</source>
+        <comment>member permission</comment>
+        <translation>Add Web Page Previews</translation>
+    </message>
+    <message>
+        <source>Change Chat Info</source>
+        <comment>member permission</comment>
+        <translation>Change Chat Info</translation>
+    </message>
+    <message>
+        <source>Invite Users</source>
+        <comment>member permission</comment>
+        <translation>Invite Users</translation>
+    </message>
+    <message>
+        <source>Pin Messages</source>
+        <comment>member permission</comment>
+        <translation>Pin Messages</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION

Small, self-contained feature: managing group members from inside Fernschreiber
instead of having to reach for another client. Five source files plus the
translations, no new dependencies, no build-system changes beyond one
`DISTFILES` line.

This is deliberately kept separate from the calls PR — the two have nothing to do
with each other, and this one should not have to wait for that discussion.

## What it does

Long-pressing a member in a group's member list opens a context menu. Which
entries appear depends on what *you* are allowed to do and on what the target
is — admins and the creator are never offered, and nothing shows up at all
unless you have the right to restrict members.

| Entry | Effect |
|---|---|
| **Member Permissions** | opens a dialog with 13 granular permission switches |
| **Revoke Write Permission** | quick restrict, without opening the dialog |
| **Remove Restrictions** | back to the chat's default permissions |
| **Remove from Group** | removes the member (remorse timer) |
| **Remove and Delete All Messages** | removes and revokes their messages (remorse timer) |

The permissions dialog is prefilled with the member's *current* rights and each
switch is **capped by the chat's default permissions**: a right the group does
not grant at all is shown disabled, with the reason spelled out
("Not allowed by the group's default permissions"), rather than silently doing
nothing when toggled.

## How it works

Pure TDLib signalling — `setChatMemberStatus` and `banChatMember` on
`TDLibWrapper`, plus the QML. No new libraries, no C++ beyond those two wrappers.

One thing worth knowing for review: **`updateChatMember` is only delivered to
bots**, so a user client never gets told that its own change went through. The
member list is therefore updated optimistically in the model after the request is
sent. If you would prefer an explicit re-fetch of the member instead, that is an
easy change.

## A caveat that has since resolved itself

When this PR was opened, the `tdlib/include` headers in the repo were **older
than the shipped `libtdjson.so` 1.8.21**, so the runtime JSON did not match them:
admin rights arrived nested in `status.rights` rather than flat on `status`, and
`chatPermissions` already used the granular field names. I read the real names
with `strings` on the shipped `.so` rather than trusting the headers.

Since the 1.8.67 update on master, headers and library agree again —
`chatMemberStatusAdministrator` nests its rights in `rights`, and
`chatPermissions` carries sixteen granular `can_*` fields. The code still reads
both layouts and each permission keeps a `legacy:` fallback name, so a member
restricted by an older TDLib is shown correctly either way. What the rebase did
change is in the comment below.

## Translations

German and English are translated; the other languages carry the new strings as
`type="unfinished"`. The `.ts` diff is exactly what your own build produces —
I added the entries by hand first, then let a `mb2 build` run its `lupdate` and
committed that result, so the files are canonical and your working copy stays
clean after the first build. Every file gains the same 118 lines and loses none.

## Tested

On device (Jolla phone, SailfishOS 5.2.0.17 aarch64), after the 1.8.67 rebase:
all five actions against a real group, including the permission caps and both
remorse timers. That run found the two bugs described in the comment below;
both are fixed and were re-tested on the device afterwards.

Built from this branch's exact commit on top of the current master:
`SailfishOS-4.6.0.13-aarch64`, clean, with `ChatMemberPermissionsPage.qml` in the
RPM. The older three-target matrix (4.6.0.13 aarch64 + armv7hl, 5.0.0.62 aarch64)
was measured on the pre-rebase commit.

Happy to adjust the wording, the menu structure, or the optimistic-update
approach if you would rather have it differently.
