### PR TITLE
Add a setting to hide "Delete Chat" from the chat menu

### DIFF
--- a/qml/components/settingsPage/SettingsBehavior.qml
+++ b/qml/components/settingsPage/SettingsBehavior.qml
@@ -94,6 +94,17 @@ AccordionItem {
 
             TextSwitch {
                 width: parent.columnWidth
+                checked: appSettings.showDeleteChat
+                text: qsTr("Show \"Delete Chat\" in the chat menu")
+                description: qsTr("Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.")
+                automaticCheck: false
+                onClicked: {
+                    appSettings.showDeleteChat = !checked
+                }
+            }
+
+            TextSwitch {
+                width: parent.columnWidth
                 checked: appSettings.notificationAlwaysShowPreview
                 text: qsTr("Always append message preview to notifications")
                 description: qsTr("In addition to showing the number of unread messages, the latest message will also be appended to notifications.")

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -924,7 +924,7 @@ Page {
 
                 MenuItem {
                     id: deleteChatMenuItem
-                    visible: chatPage.isPrivateChat
+                    visible: chatPage.isPrivateChat && appSettings.showDeleteChat
                     onClicked: {
                         var privateChatId = chatInformation.id;
                         var confirmationDialog = pageStack.push(deleteChatConfirmationDialog);

--- a/src/appsettings.cpp
+++ b/src/appsettings.cpp
@@ -33,6 +33,7 @@ namespace {
     const QString KEY_NOTIFICATION_FEEDBACK("notificationFeedback");
     const QString KEY_NOTIFICATION_ALWAYS_SHOW_PREVIEW("notificationAlwaysShowPreview");
     const QString KEY_GO_TO_QUOTED_MESSAGE("goToQuotedMessage");
+    const QString KEY_SHOW_DELETE_CHAT("showDeleteChat");
     const QString KEY_STORAGE_OPTIMIZER("useStorageOptimizer");
     const QString KEY_INLINEBOT_LOCATION_ACCESS("allowInlineBotLocationAccess");
     const QString KEY_REMAINING_INTERACTION_HINTS("remainingInteractionHints");
@@ -213,6 +214,20 @@ void AppSettings::setGoToQuotedMessage(bool enable)
         LOG(KEY_GO_TO_QUOTED_MESSAGE << enable);
         settings.setValue(KEY_GO_TO_QUOTED_MESSAGE, enable);
         emit goToQuotedMessageChanged();
+    }
+}
+
+bool AppSettings::showDeleteChat() const
+{
+    return settings.value(KEY_SHOW_DELETE_CHAT, true).toBool();
+}
+
+void AppSettings::setShowDeleteChat(bool show)
+{
+    if (showDeleteChat() != show) {
+        LOG(KEY_SHOW_DELETE_CHAT << show);
+        settings.setValue(KEY_SHOW_DELETE_CHAT, show);
+        emit showDeleteChatChanged();
     }
 }
 

--- a/src/appsettings.h
+++ b/src/appsettings.h
@@ -36,6 +36,7 @@ class AppSettings : public QObject {
     Q_PROPERTY(NotificationFeedback notificationFeedback READ notificationFeedback WRITE setNotificationFeedback NOTIFY notificationFeedbackChanged)
     Q_PROPERTY(bool notificationAlwaysShowPreview READ notificationAlwaysShowPreview WRITE setNotificationAlwaysShowPreview NOTIFY notificationAlwaysShowPreviewChanged)
     Q_PROPERTY(bool goToQuotedMessage READ goToQuotedMessage WRITE setGoToQuotedMessage NOTIFY goToQuotedMessageChanged)
+    Q_PROPERTY(bool showDeleteChat READ showDeleteChat WRITE setShowDeleteChat NOTIFY showDeleteChatChanged)
     Q_PROPERTY(bool storageOptimizer READ storageOptimizer WRITE setStorageOptimizer NOTIFY storageOptimizerChanged)
     Q_PROPERTY(bool allowInlineBotLocationAccess READ allowInlineBotLocationAccess WRITE setAllowInlineBotLocationAccess NOTIFY allowInlineBotLocationAccessChanged)
     Q_PROPERTY(int remainingInteractionHints READ remainingInteractionHints WRITE setRemainingInteractionHints NOTIFY remainingInteractionHintsChanged)
@@ -98,6 +99,8 @@ public:
     void setNotificationAlwaysShowPreview(bool enable);
 
     bool goToQuotedMessage() const;
+    void setShowDeleteChat(bool show);
+    bool showDeleteChat() const;
     void setGoToQuotedMessage(bool enable);
 
     bool storageOptimizer() const;
@@ -140,6 +143,7 @@ signals:
     void notificationFeedbackChanged();
     void notificationAlwaysShowPreviewChanged();
     void goToQuotedMessageChanged();
+    void showDeleteChatChanged();
     void storageOptimizerChanged();
     void allowInlineBotLocationAccessChanged();
     void remainingInteractionHintsChanged();

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -1629,6 +1629,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation>Beim Tippen auf eine zitierte Nachricht zu dieser springen anstatt es in einem Overlay anzuzeigen.</translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation>„Chat löschen“ im Chat-Menü anzeigen</translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation>Das Löschen eines Chats lässt sich nicht rückgängig machen und wird unterwegs selten gebraucht. Ausschalten, um den Eintrag aus dem Pulley-Menü herauszuhalten.</translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -1631,6 +1631,14 @@ messages</numerusform>
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation>Show &quot;Delete Chat&quot; in the chat menu</translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -1629,6 +1629,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation>Al Pulsar mensaje citado, abrirá en Charla en lugar de mostrarlo en una superposición.</translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -1630,6 +1630,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-fr.ts
+++ b/translations/harbour-fernschreiber-fr.ts
@@ -1629,6 +1629,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -1606,6 +1606,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation>Mikor rákoppintasz egy idézett üzenetre, megnyitja azt a csevegésben, ahelyett, hogy egy felugró ablakban mutatná.</translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -1629,6 +1629,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -1657,6 +1657,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation>Po dotknięciu cytowanej wiadomości, otwórz ją w czacie zamiast pokazywania jej w nakładce.</translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -1660,6 +1660,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation>По нажатию на цитируемое сообщение, переходить к нему в чате вместо отображения во всплывающем окне.</translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -1657,6 +1657,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation>Citovanú správu otvoriť v čete namiesto v náhľade.</translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -1629,6 +1629,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation>Vid tryck på ett citerat meddelande öppnas det i chatten istället för att visas i ett överlägg.</translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -1602,6 +1602,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -1629,6 +1629,14 @@
         <source>When tapping a quoted message, open it in chat instead of showing it in an overlay.</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Show &quot;Delete Chat&quot; in the chat menu</source>
+        <translation>Show &quot;Delete Chat&quot; in the chat menu</translation>
+    </message>
+    <message>
+        <source>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</source>
+        <translation>Deleting a chat is irreversible and rarely needed on the go. Turn this off to keep the entry out of the pulley menu.</translation>
+    </message>
 </context>
 <context>
     <name>SettingsPage</name>


### PR DESCRIPTION

Tiny change, and it follows on from a conversation we had a while ago about how
easy it is to delete a chat by accident.

0.18 already improved this a lot — the confirmation dialog you added on top of
the remorse timer was not there in 0.17. This is about the remaining case: the
entry being *present* at all.

## The reasoning

Deleting a chat is irreversible, and unlike everything else in that pulley menu
it is not something most people ever do from the phone — it is a desktop task.
Yet it sits in the same short menu as Mute Chat and Search in Chat, which are
daily actions. A confirmation only helps someone who registers what they
triggered; someone who did not mean to open that flow at all tends to dismiss
whatever appears.

Rather than change the behaviour for everyone, this just lets people who never
delete chats from the phone take the entry out of their way.

## What it does

New `AppSettings` property `showDeleteChat`, **default `true`** — without
touching the setting, nothing changes for anyone. A switch in
**Settings → Behavior**, next to the other chat-behaviour options:

> **Show "Delete Chat" in the chat menu**
> Deleting a chat is irreversible and rarely needed on the go. Turn this off to
> keep the entry out of the pulley menu.

The menu entry keeps its confirmation dialog and remorse timer unchanged when
shown. Four files plus translations; the property follows the exact shape of the
twelve existing boolean settings.

## Built

From this branch's exact commit with the Sailfish SDK (4.6.0.13):
**aarch64 OK (166 s)** and **armv7hl OK**. New strings are in the source `.ts`,
`-en` and `-de`; the other languages carry them as untranslated, exactly as the
build's own `lupdate` generated them.

## If you would rather not

Entirely understandable if you do not want another switch in Settings — the
alternative would be moving the entry to the bottom of the pulley menu, so that
the shortest pull no longer lands on the most destructive action. Happy to
rework it that way, or to drop it.
