### PR TITLE
Add Telegram voice & video calls (tgcalls + tg_owt)

### DIFF
--- a/doc/voicecalls.md
+++ b/doc/voicecalls.md
@@ -1,0 +1,188 @@
+# Voice and video calls
+
+Fernschreiber can be built with 1:1 voice and video calls. The feature is
+**opt-in at build time** (`qmake CONFIG+=voicecalls`); without that flag nothing
+in this document applies and the build is byte-for-byte the one you know.
+
+## Why an extra library is needed
+
+TDLib does call **signalling only** — `createCall` / `acceptCall` /
+`discardCall`, the DH key exchange, protocol negotiation and the relay list. It
+never produces or consumes a single audio or video frame. The media has to come
+from a separate library, and for Telegram that is **tgcalls**, which is built on
+Telegram's fork of webrtc.org (**tg_owt**). Both have to be compiled for the
+Sailfish target; there are no packages for them.
+
+That is the whole reason this is opt-in rather than always-on: a plain
+`mb2 build` must not suddenly require a WebRTC tree.
+
+## What has been built and tested
+
+| | |
+|---|---|
+| Architecture | **aarch64** for the media stack (the app itself also builds on armv7hl) |
+| Builds against | `SailfishOS-4.6.0.13-aarch64` and `SailfishOS-5.0.0.62-aarch64` |
+| Tested on | Xperia 10 III, Sailfish OS 5.1.0.11, from a 5.0.0.62 build |
+| Tested against | official Telegram clients (Android, Desktop), both call directions |
+| Scope | 1:1 calls, voice and video. **No group calls / voice chats.** |
+
+The **app** builds on armv7hl as well — verified, and with `voicecalls` off it is
+byte-for-byte the stock build. **Calls** are aarch64-only in practice: nobody has
+built the media stack for 32-bit ARM, which would mean compiling both tg_owt and
+openh264 for that target. `voip.pri` warns rather than pretending, and
+hard-errors with an actionable message when the tg_owt/tgcalls/openh264 trees are
+missing or unbuilt.
+
+Even with a tg_owt for armv7hl, expect video to be marginal there: both encoding
+(VP8/VP9) and decoding run in software. On a comparable 32-bit device a
+GStreamer-based WebRTC client did manage video, but only at poor quality — so
+voice would be the realistic target on armv7hl. i486 is untested entirely.
+
+## Dependencies
+
+Built from source, inside the SDK build engine, for the aarch64 target:
+
+| Component | Source | Revision used |
+|---|---|---|
+| tg_owt | `github.com/Michal-Szczepaniak/tg_owt` | `3215153` ("Add -fPIC") |
+| tgcalls | `github.com/Michal-Szczepaniak/tgcalls` | `8a5b4eb` ("Fix for sfos") |
+| openh264 | `github.com/cisco/openh264` | v2.6.0 |
+
+Those two forks are the ones used by
+[RooTelegram](https://github.com/RootGPT-YouTube/RooTelegram-SailfishOS) and
+Yottagram; they carry the Sailfish/Halium fixes that upstream tgcalls lacks.
+
+Taken from the target's own packages: openssl, opus, libvpx, ffmpeg
+(avcodec/avformat/avutil/swresample/swscale), libjpeg, pulseaudio, alsa-lib —
+plus their `-devel` packages in the build engine.
+
+**openh264 is different.** Sailfish packages it nowhere (patent reasons) but
+tg_owt hard-requires it, so it has to be built from source *and travel with the
+app*: `voip.pri` installs `libopenh264.so.8` into the binary's rpath directory
+next to `libtdjson`, and `__requires_exclude` in
+`rpm/harbour-fernschreiber.yaml` keeps it out of the RPM's dependencies. Without
+that the package would declare a dependency no Sailfish repository can satisfy —
+it would not install anywhere. Point `OPENH264_ROOT` at your build if it is not
+in the default sibling directory.
+
+**libvpx is deliberately not bundled.** It is a real, packaged Sailfish
+dependency, so the RPM requires it by soname (`libvpx.so.9` for the targets
+above) and a device of the same release line satisfies that. Mind the mismatch
+if the device is newer than your SDK: Sailfish 5.1 carries `libvpx.so.12`, so a
+5.0-built package will not resolve there. The clean fix is a target matching the
+device, not a second libvpx shipped beside the system's.
+
+## Building
+
+Everything below runs **inside the SDK build engine** so that the toolchain and
+sysroot are the target's:
+
+```sh
+sfdk -c target=SailfishOS-4.6.0.13-aarch64 build-shell bash
+```
+
+### 1. tg_owt
+
+```sh
+git clone --recursive https://github.com/Michal-Szczepaniak/tg_owt.git
+cd tg_owt && git checkout 3215153 && git submodule update --init --recursive
+mkdir out && cd out
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DTG_OWT_PACKAGED_BUILD=ON \
+    -DTG_OWT_BUILD_AUDIO_BACKENDS=ON \
+    -DTG_OWT_USE_X11=OFF \
+    -DTG_OWT_USE_PIPEWIRE=OFF \
+    -DTG_OWT_USE_PROTOBUF=OFF
+make -j$(nproc)
+```
+
+This produces `out/libtg_owt.a` (a static library — it is linked into the app,
+nothing extra is installed on the device). X11 and PipeWire are off because
+neither exists on the device; the audio backends stay on because tgcalls' own
+AudioDeviceModule drives PulseAudio.
+
+### 2. tgcalls
+
+Only a checkout is needed — the sources are compiled as part of Fernschreiber
+(see `voip.pri`), so they follow the app's own flags:
+
+```sh
+git clone https://github.com/Michal-Szczepaniak/tgcalls.git
+cd tgcalls && git checkout 8a5b4eb
+```
+
+### 3. Fernschreiber
+
+```sh
+mb2 -t SailfishOS-4.6.0.13-aarch64 build -- \
+    --with voicecalls \
+    --define "tg_owt_root /path/to/tg_owt" \
+    --define "tgcalls_root /path/to/tgcalls" \
+    --define "openh264_root /path/to/openh264"
+```
+
+`--with voicecalls` is a plain rpmbuild conditional; it is declared as
+`QMakeOptions` in `rpm/harbour-fernschreiber.yaml`, so the generated spec keeps
+it across regeneration. **Without `--with voicecalls` the build is exactly the
+one you have today** — the macros expand to nothing.
+
+Both roots default to a sibling `../tgcalls-build/` directory, so the two
+`--define`s can be omitted if the trees live next to the Fernschreiber checkout.
+
+Building without RPM packaging (faster while iterating) works too:
+
+```sh
+mb2 -t SailfishOS-4.6.0.13-aarch64 qmake CONFIG+=voicecalls
+mb2 -t SailfishOS-4.6.0.13-aarch64 make -j$(nproc)
+```
+
+## The PulseAudio policy rule
+
+`pulse/harbour-fernschreiber.conf` is installed to
+`/etc/pulse/xpolicy.conf.d/` and is **not optional** — without it the remote
+party is silent.
+
+tgcalls' WebRTC AudioDeviceModule names its streams `WEBRTC VoiceEngine`. The
+Sailfish audio policy sorts unknown streams into the `othermedia` group, which
+carries the `cork_stream` flag: as soon as the call's microphone capture starts,
+the policy **corks the incoming-audio playback stream**. The rule moves the
+WebRTC streams into the telephony `call` group (set_sink, set_source, and
+crucially no cork_stream), which is what a real call uses.
+
+**This needs a decision from the maintainer:** the file ships outside the app's
+own tree, which a Harbour store build would flag. It may be better placed in a
+separate configuration sub-package. The `INSTALLS` entry sits inside the
+`voicecalls {}` block in `harbour-fernschreiber.pro`, so a stock build is
+unaffected either way.
+
+## Sailjail
+
+The `.desktop` file gains one permission, `Camera`, next to the `Microphone` and
+`Audio` permissions that were already there. A missing Sailjail permission fails
+*silently* on the device — the app simply behaves as if the hardware were broken.
+
+## Code layout
+
+| Path | Role |
+|---|---|
+| `src/tdlibwrapper.*`, `src/tdlibreceiver.*` | TDLib call signalling: `createCall`/`acceptCall`/`discardCall`/`sendCallSignalingData`, `updateCall`/`updateNewCallSignalingData`. Deliberately media-library agnostic. |
+| `src/voip/voipmanager.*` | The bridge: tgcalls instance lifetime, descriptor (relays, encryption key, protocol), signalling relay, exposed to QML. |
+| `src/voip/sailfishinterface.*` | tgcalls `PlatformInterface` for Sailfish: codec factories, video capturer creation. |
+| `src/voip/callcameragrabber.*`, `videocapturer.*`, `videotracksource.h` | Camera capture: QtMultimedia → I420 → WebRTC, including device-orientation handling. |
+| `src/voip/videorenderer.*` | Incoming/outgoing frames → QML `VideoOutput`. |
+| `src/voip/callaudiorouter.*` | Moves the WebRTC playout stream to the call sink and unmutes it, via an in-process libpulse connection (Sailjail blocks an external `pactl`). |
+| `qml/components/CallOverlay.qml` | In-call UI: peer, state, SAS emojis, remote video + local PiP, mute/hang up/flip. |
+
+## Known limitations
+
+- 1:1 calls only. The group-call sources of tgcalls are deliberately excluded.
+- aarch64 only in practice (see above).
+- tg_owt and tgcalls are **not vendored** as submodules; they have to be
+  provided out-of-tree. Vendoring them would make the build reproducible for
+  everyone and is the obvious next step, but it is a packaging decision for the
+  maintainer rather than something to slip into this change.
+- The video encoder is software VP8/VP9. Decoding accepts everything the builtin
+  factory offers (including H264/H265) so that official clients — which prefer
+  H264 — are received reliably.

--- a/harbour-fernschreiber.desktop
+++ b/harbour-fernschreiber.desktop
@@ -6,6 +6,6 @@ Exec=harbour-fernschreiber
 Name=Fernschreiber
 
 [X-Sailjail]
-Permissions=Audio;Contacts;Documents;Downloads;Internet;Location;MediaIndexing;Microphone;Music;Pictures;Privileged;PublicDir;RemovableMedia;UserDirs;Videos
+Permissions=Audio;Contacts;Documents;Downloads;Internet;Location;MediaIndexing;Microphone;Music;Pictures;Privileged;PublicDir;RemovableMedia;UserDirs;Videos;Camera
 OrganizationName=de.ygriega
 ApplicationName=fernschreiber

--- a/harbour-fernschreiber.pro
+++ b/harbour-fernschreiber.pro
@@ -186,6 +186,20 @@ LIBS += -L$$PWD/tdlib/$${TARGET_ARCHITECTURE}/lib/ -ltdjson
 telegram.files = $$PWD/tdlib/$${TARGET_ARCHITECTURE}/lib
 telegram.path = /usr/share/$${TARGET}
 
+# Optional: Telegram voice/video calls via tgcalls + tg_owt (aarch64 only).
+# Enable with: qmake CONFIG+=voicecalls  (see voip.pri).
+voicecalls {
+    message("Fernschreiber: building WITH voice/video calls (tgcalls + tg_owt)")
+    include(voip.pri)
+    # SFOS PulseAudio policy rule so incoming call audio isn't corked by the
+    # "othermedia" group — routes our WebRTC streams into the "call" group.
+    # (Ships outside the app tree; a Harbour-store build would flag this — the
+    # maintainer may prefer a separate config sub-package.)
+    pulsepolicy.files = pulse/harbour-fernschreiber.conf
+    pulsepolicy.path = /etc/pulse/xpolicy.conf.d/
+    INSTALLS += pulsepolicy
+}
+
 gui.files = qml
 gui.path = /usr/share/$${TARGET}
 

--- a/pulse/harbour-fernschreiber.conf
+++ b/pulse/harbour-fernschreiber.conf
@@ -1,0 +1,17 @@
+# Sailfish OS PulseAudio policy rule for Fernschreiber's Telegram voice/video calls.
+#
+# tgcalls' WebRTC AudioDeviceModule creates its playout/capture streams with
+# application.name "WEBRTC VoiceEngine". Without this rule they land in the
+# default "othermedia" policy group, which carries the `cork_stream` flag: the
+# SFOS audio policy then CORKS the incoming-audio playback stream while the
+# call's microphone capture is active, so the remote party is inaudible.
+#
+# Routing them into the telephony "call" group (flags: set_sink, set_source, and
+# crucially NO cork_stream) makes the policy treat them as a real call: playback
+# and capture are routed to the primary output/input and never corked.
+#
+# Installed to /etc/pulse/xpolicy.conf.d/ ; picked up on the next PulseAudio start.
+
+[stream]
+property = application.name@equals:"WEBRTC VoiceEngine"
+group    = call

--- a/qml/components/CallOverlay.qml
+++ b/qml/components/CallOverlay.qml
@@ -1,0 +1,265 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    Global overlay for an active Telegram call, driven by the C++ VoipManager
+    (context property `voipManager`). Shows the peer, call state, SAS verification
+    emojis, remote/local video (for video calls) and the in-call controls.
+
+    The overlay is a direct child of the ApplicationWindow, so it does NOT rotate
+    with the page stack. To keep the displayed video upright when the phone is held
+    in landscape, the whole call UI is placed in a container that rotates to follow
+    the device orientation.
+*/
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+import QtMultimedia 5.6
+import QtSensors 5.0
+import Nemo.DBus 2.0
+
+Rectangle {
+    id: callOverlay
+
+    anchors.fill: parent
+    z: 10000
+    color: Theme.rgba(Theme.highlightDimmerColor, 0.97)
+    visible: voiceCallsAvailable && typeof voipManager !== "undefined" && voipManager.active
+
+    property bool videoCall: typeof voipManager !== "undefined" && voipManager.isVideo
+    property bool ready: typeof voipManager !== "undefined" && voipManager.callState === "callStateReady"
+    // Show the remote video whenever its renderer is actually receiving frames —
+    // more reliable than the remoteMediaStateUpdated callback.
+    property bool remoteShowing: videoCall && typeof voipManager !== "undefined"
+                                 && voipManager.remoteVideo && voipManager.remoteVideo.hasFrame
+    // Rotation applied to the whole call UI to match the device orientation.
+    property int uiRotation: 0
+
+    // An incoming call rings through ngfd's telephony event rather than through the
+    // chat notification settings: a call is not a message, and silencing message
+    // tones must not silence the phone ringing. Sound and vibration then follow the
+    // system profile, exactly like the built-in dialer. ngfd is on the system bus.
+    // Deliberately NOT tied to `visible`: Qt Quick reports effective visibility, so
+    // minimising the app to its cover makes this item invisible — and the phone has
+    // to ring precisely then. Only the call state may decide.
+    readonly property bool ringing: voiceCallsAvailable && typeof voipManager !== "undefined"
+                                    && voipManager.active
+                                    && !voipManager.isOutgoing
+                                    && voipManager.callState === "callStatePending"
+    property int _ringtoneEventId: 0
+
+    onRingingChanged: ringing ? startRingtone() : stopRingtone()
+    Component.onDestruction: stopRingtone()
+
+    DBusInterface {
+        id: callFeedback
+        bus: DBus.SystemBus
+        service: "com.nokia.NonGraphicFeedback1.Backend"
+        path: "/com/nokia/NonGraphicFeedback1"
+        iface: "com.nokia.NonGraphicFeedback1"
+    }
+
+    function startRingtone() {
+        if (callOverlay._ringtoneEventId !== 0) {
+            return;
+        }
+        callFeedback.typedCall("Play",
+            [ { "type": "s", "value": "voip_ringtone" }, { "type": "a{sv}", "value": {} } ],
+            function(eventId) {
+                // The call can be answered or dropped while Play is still in flight;
+                // without this the device would keep ringing through the conversation.
+                if (callOverlay.ringing) {
+                    callOverlay._ringtoneEventId = eventId;
+                } else {
+                    callFeedback.typedCall("Stop", [ { "type": "u", "value": eventId } ]);
+                }
+            },
+            function() { /* no ngfd: stay silent rather than break the call */ });
+    }
+
+    function stopRingtone() {
+        if (callOverlay._ringtoneEventId === 0) {
+            return;
+        }
+        callFeedback.typedCall("Stop", [ { "type": "u", "value": callOverlay._ringtoneEventId } ]);
+        callOverlay._ringtoneEventId = 0;
+    }
+
+    property string peerName: {
+        if (!visible || !voipManager.peerUserId) {
+            return "";
+        }
+        var info = tdLibWrapper.getUserInformation("" + voipManager.peerUserId);
+        if (!info) {
+            return qsTr("Unknown");
+        }
+        var name = ((info.first_name || "") + " " + (info.last_name || "")).trim();
+        return name.length > 0 ? name : qsTr("Unknown");
+    }
+
+    // Swallow touches on the background so the page underneath is inert.
+    MouseArea { anchors.fill: parent }
+
+    OrientationSensor {
+        active: callOverlay.visible
+        onReadingChanged: {
+            switch (reading.orientation) {
+            case OrientationReading.TopUp:    callOverlay.uiRotation = 0; break;
+            case OrientationReading.TopDown:  callOverlay.uiRotation = 180; break;
+            case OrientationReading.LeftUp:   callOverlay.uiRotation = 270; break;
+            case OrientationReading.RightUp:  callOverlay.uiRotation = 90; break;
+            // FaceUp/FaceDown: keep the previous orientation (phone lying flat).
+            }
+        }
+    }
+
+    Item {
+        id: content
+        anchors.centerIn: parent
+        width: (callOverlay.uiRotation % 180 === 0) ? parent.width : parent.height
+        height: (callOverlay.uiRotation % 180 === 0) ? parent.height : parent.width
+        rotation: callOverlay.uiRotation
+
+        // Up to three buttons are visible at once — size them to fit the width.
+        property real buttonWidth: (width - 2 * Theme.horizontalPageMargin - 2 * Theme.paddingMedium) / 3
+
+        // Remote video fills the UI. It stays visible for the whole video call so
+        // its video surface is assigned to the renderer immediately — otherwise
+        // frames arrive but are never presented (surface only exists while visible)
+        // and hasFrame never flips. The name/placeholder below is drawn on top
+        // until the first remote frame arrives.
+        VideoOutput {
+            anchors.fill: parent
+            fillMode: VideoOutput.PreserveAspectCrop
+            source: (typeof voipManager !== "undefined") ? voipManager.remoteVideo : null
+            visible: callOverlay.videoCall
+        }
+
+        // Peer name + state (shown when there is no remote video to show).
+        Column {
+            anchors {
+                verticalCenter: parent.verticalCenter
+                horizontalCenter: parent.horizontalCenter
+            }
+            width: parent.width - 2 * Theme.horizontalPageMargin
+            spacing: Theme.paddingLarge
+            visible: !callOverlay.remoteShowing
+
+            Label {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.Wrap
+                font.pixelSize: Theme.fontSizeLarge
+                color: Theme.primaryColor
+                text: callOverlay.peerName
+            }
+
+            Label {
+                width: parent.width
+                horizontalAlignment: Text.AlignHCenter
+                color: Theme.secondaryHighlightColor
+                text: {
+                    if (typeof voipManager === "undefined") {
+                        return "";
+                    }
+                    switch (voipManager.callState) {
+                    case "callStatePending":
+                        return voipManager.isOutgoing ? qsTr("Calling…") : (callOverlay.videoCall ? qsTr("Incoming video call") : qsTr("Incoming call"));
+                    case "callStateExchangingKeys":
+                        return qsTr("Exchanging encryption keys…");
+                    case "callStateReady":
+                        return qsTr("Ongoing call");
+                    case "callStateHangingUp":
+                        return qsTr("Hanging up…");
+                    default:
+                        return "";
+                    }
+                }
+            }
+
+            Row {
+                anchors.horizontalCenter: parent.horizontalCenter
+                spacing: Theme.paddingMedium
+                visible: callOverlay.ready
+                Repeater {
+                    model: visible && typeof voipManager !== "undefined" ? voipManager.emojis : []
+                    Label {
+                        text: modelData
+                        font.pixelSize: Theme.fontSizeExtraLarge
+                    }
+                }
+            }
+        }
+
+        // Local camera preview (picture-in-picture) during a video call. Size is
+        // tied to the short screen edge so it stays the same in portrait/landscape.
+        Rectangle {
+            width: Math.min(parent.width, parent.height) * 0.28
+            height: width * 4 / 3
+            anchors {
+                bottom: parent.bottom
+                right: parent.right
+                rightMargin: Theme.paddingLarge
+                bottomMargin: Theme.itemSizeLarge * 1.4
+            }
+            color: "black"
+            radius: Theme.paddingSmall
+            clip: true
+            visible: callOverlay.videoCall && callOverlay.ready
+            VideoOutput {
+                anchors.fill: parent
+                fillMode: VideoOutput.PreserveAspectCrop
+                source: (typeof voipManager !== "undefined") ? voipManager.localVideo : null
+            }
+        }
+
+        Row {
+            anchors {
+                horizontalCenter: parent.horizontalCenter
+                bottom: parent.bottom
+                bottomMargin: Theme.paddingLarge * 2
+            }
+            spacing: Theme.paddingMedium
+
+            Button {
+                width: content.buttonWidth
+                text: qsTr("Accept")
+                visible: typeof voipManager !== "undefined"
+                         && !voipManager.isOutgoing
+                         && voipManager.callState === "callStatePending"
+                onClicked: voipManager.acceptCall()
+            }
+
+            Button {
+                id: muteButton
+                width: content.buttonWidth
+                property bool muted: false
+                text: muted ? qsTr("Unmute") : qsTr("Mute")
+                visible: callOverlay.ready
+                onClicked: {
+                    muted = !muted;
+                    voipManager.setMicrophoneMuted(muted);
+                }
+            }
+
+            Button {
+                width: content.buttonWidth
+                text: qsTr("Flip")
+                visible: callOverlay.videoCall && callOverlay.ready
+                onClicked: voipManager.switchCamera()
+            }
+
+            Button {
+                width: content.buttonWidth
+                text: (typeof voipManager !== "undefined"
+                       && !voipManager.isOutgoing
+                       && voipManager.callState === "callStatePending")
+                      ? qsTr("Decline") : qsTr("Hang up")
+                onClicked: voipManager.hangUp()
+            }
+        }
+    }
+
+    onVisibleChanged: if (visible) { muteButton.muted = false; }
+}

--- a/qml/harbour-fernschreiber.qml
+++ b/qml/harbour-fernschreiber.qml
@@ -55,6 +55,16 @@ ApplicationWindow
         parent: pageStack.currentPage
     }
 
+    // Global overlay for an active call. Loaded only in a voicecalls build: the
+    // overlay imports QtMultimedia, QtSensors and Nemo.DBus, and a stock build has
+    // no reason to depend on those QML plugins being installed on the device.
+    Loader {
+        anchors.fill: parent
+        z: 10000
+        active: voiceCallsAvailable
+        source: Qt.resolvedUrl("components/CallOverlay.qml")
+    }
+
     Component.onCompleted: {
         Functions.setGlobals({
             tdLibWrapper: tdLibWrapper,

--- a/qml/js/functions.js
+++ b/qml/js/functions.js
@@ -162,6 +162,14 @@ function getMessageText(message, simple, currentUserId, ignoreEntities) {
         return simple ? (myself ? qsTr("sent a game", "myself") : qsTr("sent a game")) : "";
     case 'messageGameScore':
         return myself ? qsTr("scored %Ln points", "myself", message.content.score) : qsTr("scored %Ln points", "myself", message.content.score);
+    case 'messageCall':
+        var callLabel = message.content.is_video ? qsTr("Video call") : qsTr("Call");
+        if (message.content.duration > 0) {
+            var callMinutes = Math.floor(message.content.duration / 60);
+            var callSeconds = message.content.duration % 60;
+            return callLabel + " (" + callMinutes + ":" + (callSeconds < 10 ? "0" : "") + callSeconds + ")";
+        }
+        return callLabel;
     case 'messageUnsupported':
         return myself ? qsTr("sent an unsupported message", "myself") : qsTr("sent an unsupported message");
     default:

--- a/qml/pages/ChatPage.qml
+++ b/qml/pages/ChatPage.qml
@@ -923,6 +923,18 @@ Page {
                 visible: chatInformation.id !== chatPage.myUserId && !stickerPickerLoader.active && !voiceNoteOverlayLoader.active && !messageOverlayLoader.active && !stickerSetOverlayLoader.active
 
                 MenuItem {
+                    visible: voiceCallsAvailable && chatPage.isPrivateChat
+                    text: qsTr("Video Call")
+                    onClicked: voipManager.startCall(chatInformation.type.user_id, true)
+                }
+
+                MenuItem {
+                    visible: voiceCallsAvailable && chatPage.isPrivateChat
+                    text: qsTr("Call")
+                    onClicked: voipManager.startCall(chatInformation.type.user_id, false)
+                }
+
+                MenuItem {
                     id: deleteChatMenuItem
                     visible: chatPage.isPrivateChat
                     onClicked: {
@@ -1428,6 +1440,7 @@ Page {
                                                                        "messagePinMessage",
                                                                        "messageScreenshotTaken",
                                                                        "messageSupergroupChatCreate",
+                                                                       "messageCall",
                                                                        "messageUnsupported"]
                         delegate: Loader {
                             width: chatView.width

--- a/rpm/harbour-fernschreiber.spec
+++ b/rpm/harbour-fernschreiber.spec
@@ -8,7 +8,7 @@ Name:       harbour-fernschreiber
 # >> macros
 # << macros
 %define __provides_exclude_from ^%{_datadir}/.*$
-%define __requires_exclude ^libtdjson.*$
+%define __requires_exclude ^(libtdjson|libopenh264).*$
 %define _binary_payload w6.xzdio
 
 Summary:    Fernschreiber is a Telegram client for Sailfish OS
@@ -48,7 +48,8 @@ Fernschreiber is a Telegram client for Sailfish OS
 # >> build pre
 # << build pre
 
-%qmake5 
+%qmake5  \
+    %{?_with_voicecalls:CONFIG+=voicecalls} %{?tg_owt_root:TG_OWT_ROOT=%{tg_owt_root}} %{?tgcalls_root:TGCALLS_ROOT=%{tgcalls_root}} %{?openh264_root:OPENH264_ROOT=%{openh264_root}}
 
 make %{?_smp_mflags}
 
@@ -75,4 +76,9 @@ desktop-file-install --delete-original       \
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/icons/hicolor/*/apps/%{name}.png
 # >> files
+# Only built with "--with voicecalls": the PulseAudio policy rule that keeps the
+# WebRTC call streams out of the corking "othermedia" group (doc/voicecalls.md).
+%if 0%{?_with_voicecalls:1}
+%config %{_sysconfdir}/pulse/xpolicy.conf.d/%{name}.conf
+%endif
 # << files

--- a/rpm/harbour-fernschreiber.yaml
+++ b/rpm/harbour-fernschreiber.yaml
@@ -15,6 +15,9 @@ Description: |
   Fernschreiber is a Telegram client for Sailfish OS
 Configure: none
 Builder: qmake5
+# Voice/video calls are opt-in: rpmbuild --with voicecalls (see doc/voicecalls.md).
+# tg_owt_root / tgcalls_root override where the media libraries are looked for.
+QMakeOptions: '%{?_with_voicecalls:CONFIG+=voicecalls} %{?tg_owt_root:TG_OWT_ROOT=%{tg_owt_root}} %{?tgcalls_root:TGCALLS_ROOT=%{tgcalls_root}} %{?openh264_root:OPENH264_ROOT=%{openh264_root}}'
 
 # This section specifies build dependencies that are resolved using pkgconfig.
 # This is the preferred way of specifying build dependencies for your package.
@@ -33,7 +36,9 @@ PkgConfigBR:
 # NB: spectacle has a bug where it will remove custom "#<< macros" lines, so define them here:
 Macros:
   - '__provides_exclude_from;^%{_datadir}/.*$'
-  - '__requires_exclude;^libtdjson.*$'
+  # libtdjson and (with voicecalls) libopenh264 ship inside the package, in the
+  # binary's rpath dir — neither is provided by any Sailfish repository.
+  - '__requires_exclude;^(libtdjson|libopenh264).*$'
   - '_binary_payload;w6.xzdio'
 
 # Build dependencies without a pkgconfig setup can be listed here

--- a/src/fernschreiberutils.cpp
+++ b/src/fernschreiberutils.cpp
@@ -139,6 +139,15 @@ QString FernschreiberUtils::getMessageShortText(TDLibWrapper *tdLibWrapper, cons
     if (contentType == MESSAGE_CONTENT_TYPE_VOICE_NOTE) {
         return myself ? tr("sent a voice note", "myself") : tr("sent a voice note");
     }
+    if (contentType == "messageCall") {
+        const bool isVideo = messageContent.value("is_video").toBool();
+        const int duration = messageContent.value("duration").toInt();
+        const QString label = isVideo ? tr("Video call") : tr("Call");
+        if (duration > 0) {
+            return label + QString(" (%1:%2)").arg(duration / 60).arg(duration % 60, 2, 10, QChar('0'));
+        }
+        return label;
+    }
     if (contentType == MESSAGE_CONTENT_TYPE_DOCUMENT) {
         return myself ? tr("sent a document", "myself") : tr("sent a document");
     }

--- a/src/harbour-fernschreiber.cpp
+++ b/src/harbour-fernschreiber.cpp
@@ -56,6 +56,9 @@
 #include "fernschreiberutils.h"
 #include "knownusersmodel.h"
 #include "contactsmodel.h"
+#ifdef FERNSCHREIBER_VOIP
+#include "voip/voipmanager.h"
+#endif
 
 // The default filter can be overridden by QT_LOGGING_RULES envinronment variable, e.g.
 // QT_LOGGING_RULES="fernschreiber.*=true" harbour-fernschreiber
@@ -143,6 +146,13 @@ int main(int argc, char *argv[])
     TDLibWrapper *tdLibWrapper = new TDLibWrapper(appSettings, mceInterface, view.data());
     context->setContextProperty("tdLibWrapper", tdLibWrapper);
     qmlRegisterUncreatableType<TDLibWrapper>(uri, 1, 0, "TelegramAPI", QString());
+#ifdef FERNSCHREIBER_VOIP
+    VoipManager *voipManager = new VoipManager(tdLibWrapper, view.data());
+    context->setContextProperty("voipManager", voipManager);
+    context->setContextProperty("voiceCallsAvailable", true);
+#else
+    context->setContextProperty("voiceCallsAvailable", false);
+#endif
 
     FernschreiberUtils *fernschreiberUtils = new FernschreiberUtils(view.data());
     context->setContextProperty("fernschreiberUtils", fernschreiberUtils);

--- a/src/tdlibreceiver.cpp
+++ b/src/tdlibreceiver.cpp
@@ -112,6 +112,8 @@ TDLibReceiver::TDLibReceiver(void *tdLibClient, QObject *parent) : QThread(paren
     handlers.insert("updateOption", &TDLibReceiver::processUpdateOption);
     handlers.insert("updateAuthorizationState", &TDLibReceiver::processUpdateAuthorizationState);
     handlers.insert("updateConnectionState", &TDLibReceiver::processUpdateConnectionState);
+    handlers.insert("updateCall", &TDLibReceiver::processUpdateCall);
+    handlers.insert("updateNewCallSignalingData", &TDLibReceiver::processUpdateNewCallSignalingData);
     handlers.insert("updateUser", &TDLibReceiver::processUpdateUser);
     handlers.insert("updateUserStatus", &TDLibReceiver::processUpdateUserStatus);
     handlers.insert("updateFile", &TDLibReceiver::processUpdateFile);
@@ -937,4 +939,18 @@ const QVariantList TDLibReceiver::cleanupList(const QVariantList& list, bool *up
     } else {
         return list;
     }
+}
+
+void TDLibReceiver::processUpdateCall(const QVariantMap &receivedInformation)
+{
+    LOG("Call updated");
+    emit callUpdated(receivedInformation.value("call").toMap());
+}
+
+void TDLibReceiver::processUpdateNewCallSignalingData(const QVariantMap &receivedInformation)
+{
+    const qlonglong callId = receivedInformation.value("call_id").toLongLong();
+    const QByteArray data = QByteArray::fromBase64(receivedInformation.value("data").toString().toLatin1());
+    LOG("New call signaling data received for call" << callId << "size" << data.size());
+    emit callSignalingDataReceived(callId, data);
 }

--- a/src/tdlibreceiver.h
+++ b/src/tdlibreceiver.h
@@ -108,6 +108,8 @@ signals:
     void chatUnreadMentionCountUpdated(qlonglong chatId, int unreadMentionCount);
     void chatUnreadReactionCountUpdated(qlonglong chatId, int unreadReactionCount);
     void activeEmojiReactionsUpdated(const QStringList& emojis);
+    void callUpdated(const QVariantMap &callInformation);
+    void callSignalingDataReceived(qlonglong callId, const QByteArray &data);
 
 private:
     typedef void (TDLibReceiver::*Handler)(const QVariantMap &);
@@ -194,6 +196,8 @@ private:
     void processUpdateChatUnreadMentionCount(const QVariantMap &receivedInformation);
     void processUpdateChatUnreadReactionCount(const QVariantMap &receivedInformation);
     void processUpdateActiveEmojiReactions(const QVariantMap &receivedInformation);
+    void processUpdateCall(const QVariantMap &receivedInformation);
+    void processUpdateNewCallSignalingData(const QVariantMap &receivedInformation);
 };
 
 #endif // TDLIBRECEIVER_H

--- a/src/tdlibwrapper.cpp
+++ b/src/tdlibwrapper.cpp
@@ -127,6 +127,8 @@ void TDLibWrapper::initializeTDLibReceiver() {
     connect(this->tdLibReceiver, SIGNAL(authorizationStateChanged(QString, QVariantMap)), this, SLOT(handleAuthorizationStateChanged(QString, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(optionUpdated(QString, QVariant)), this, SLOT(handleOptionUpdated(QString, QVariant)));
     connect(this->tdLibReceiver, SIGNAL(connectionStateChanged(QString)), this, SLOT(handleConnectionStateChanged(QString)));
+    connect(this->tdLibReceiver, SIGNAL(callUpdated(QVariantMap)), this, SLOT(handleCallUpdated(QVariantMap)));
+    connect(this->tdLibReceiver, SIGNAL(callSignalingDataReceived(qlonglong, QByteArray)), this, SLOT(handleCallSignalingDataReceived(qlonglong, QByteArray)));
     connect(this->tdLibReceiver, SIGNAL(userUpdated(QVariantMap)), this, SLOT(handleUserUpdated(QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(userStatusUpdated(QString, QVariantMap)), this, SLOT(handleUserStatusUpdated(QString, QVariantMap)));
     connect(this->tdLibReceiver, SIGNAL(fileUpdated(QVariantMap)), this, SLOT(handleFileUpdated(QVariantMap)));
@@ -2436,4 +2438,64 @@ TDLibWrapper::ChatMemberStatus TDLibWrapper::Group::chatMemberStatus() const
 {
     const QString statusType(groupInfo.value(STATUS).toMap().value(_TYPE).toString());
     return statusType.isEmpty() ? ChatMemberStatusUnknown : chatMemberStatusFromString(statusType);
+}
+
+// ── Voice/video calls: TDLib signalling bridge ──────────────────────────────
+// TDLib only does call setup/DH/relay selection and passes opaque media
+// signalling bytes through; the actual audio/video runs in tgcalls (VoipManager).
+
+void TDLibWrapper::createCall(qlonglong userId, const QVariantMap &protocol, bool isVideo)
+{
+    LOG("Creating call to user" << userId << "video:" << isVideo);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "createCall");
+    requestObject.insert("user_id", userId);
+    requestObject.insert("protocol", protocol);
+    requestObject.insert("is_video", isVideo);
+    this->sendRequest(requestObject);
+}
+
+void TDLibWrapper::acceptCall(qlonglong callId, const QVariantMap &protocol)
+{
+    LOG("Accepting call" << callId);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "acceptCall");
+    requestObject.insert("call_id", callId);
+    requestObject.insert("protocol", protocol);
+    this->sendRequest(requestObject);
+}
+
+void TDLibWrapper::discardCall(qlonglong callId, bool isDisconnected, int duration, bool isVideo, qlonglong connectionId)
+{
+    LOG("Discarding call" << callId);
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "discardCall");
+    requestObject.insert("call_id", callId);
+    requestObject.insert("is_disconnected", isDisconnected);
+    requestObject.insert("duration", duration);
+    requestObject.insert("is_video", isVideo);
+    requestObject.insert("connection_id", connectionId);
+    this->sendRequest(requestObject);
+}
+
+void TDLibWrapper::sendCallSignalingData(qlonglong callId, const QByteArray &data)
+{
+    if (callId <= 0 || data.isEmpty()) {
+        return;
+    }
+    QVariantMap requestObject;
+    requestObject.insert(_TYPE, "sendCallSignalingData");
+    requestObject.insert("call_id", callId);
+    requestObject.insert("data", QString::fromLatin1(data.toBase64()));
+    this->sendRequest(requestObject);
+}
+
+void TDLibWrapper::handleCallUpdated(const QVariantMap &callInformation)
+{
+    emit callUpdated(callInformation);
+}
+
+void TDLibWrapper::handleCallSignalingDataReceived(qlonglong callId, const QByteArray &data)
+{
+    emit callSignalingDataReceived(callId, data);
 }

--- a/src/tdlibwrapper.h
+++ b/src/tdlibwrapper.h
@@ -209,6 +209,13 @@ public:
     Q_INVOKABLE void createBasicGroupChat(const QString &basicGroupId, const QString &extra);
     Q_INVOKABLE void getGroupsInCommon(const QString &userId, int limit, int offset);
     Q_INVOKABLE void getUserProfilePhotos(const QString &userId, int limit, int offset);
+    // Voice/video calls: signalling only (TDLib). The media runs in tgcalls,
+    // driven by VoipManager; the callProtocol (incl. tgcalls library_versions) is
+    // supplied by the caller so this layer stays media-library agnostic.
+    Q_INVOKABLE void createCall(qlonglong userId, const QVariantMap &protocol, bool isVideo);
+    Q_INVOKABLE void acceptCall(qlonglong callId, const QVariantMap &protocol);
+    Q_INVOKABLE void discardCall(qlonglong callId, bool isDisconnected, int duration, bool isVideo, qlonglong connectionId);
+    Q_INVOKABLE void sendCallSignalingData(qlonglong callId, const QByteArray &data);
     Q_INVOKABLE void setChatPermissions(const QString &chatId, const QVariantMap &chatPermissions);
     Q_INVOKABLE void setChatSlowModeDelay(const QString &chatId, int delay);
     Q_INVOKABLE void setChatDescription(const QString &chatId, const QString &description);
@@ -342,12 +349,16 @@ signals:
     void chatUnreadReactionCountUpdated(qlonglong chatId, int unreadReactionCount);
     void tgUrlFound(const QString &tgUrl);
     void reactionsUpdated();
+    void callUpdated(const QVariantMap &callInformation);
+    void callSignalingDataReceived(qlonglong callId, const QByteArray &data);
 
 public slots:
     void handleVersionDetected(const QString &version);
     void handleAuthorizationStateChanged(const QString &authorizationState, const QVariantMap authorizationStateData);
     void handleOptionUpdated(const QString &optionName, const QVariant &optionValue);
     void handleConnectionStateChanged(const QString &connectionState);
+    void handleCallUpdated(const QVariantMap &callInformation);
+    void handleCallSignalingDataReceived(qlonglong callId, const QByteArray &data);
     void handleUserUpdated(const QVariantMap &updatedUserInformation);
     void handleUserStatusUpdated(const QString &userId, const QVariantMap &userStatusInformation);
     void handleFileUpdated(const QVariantMap &fileInformation);

--- a/src/voip/callaudiorouter.cpp
+++ b/src/voip/callaudiorouter.cpp
@@ -1,0 +1,338 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE). Adapted from RooTelegram (GPL-3.0).
+*/
+#include "callaudiorouter.h"
+
+#include <QTimer>
+#include <QStringList>
+#include <cstring>
+#include <pulse/pulseaudio.h>
+
+namespace {
+
+struct SinkScan {
+    pa_threaded_mainloop *ml = nullptr;
+    QString sink;
+    QString speaker;
+    QString earpiece;
+};
+
+void ctxStateCb(pa_context * /*c*/, void *userdata)
+{
+    pa_threaded_mainloop_signal(static_cast<pa_threaded_mainloop *>(userdata), 0);
+}
+
+// First sink that has BOTH a "speaker" and an "earpiece/handset/receiver" port
+// (so it skips sink.null). Keyword match on port name/description -> device-agnostic.
+void sinkInfoCb(pa_context * /*c*/, const pa_sink_info *info, int eol, void *userdata)
+{
+    SinkScan *scan = static_cast<SinkScan *>(userdata);
+    if (eol) {
+        pa_threaded_mainloop_signal(scan->ml, 0);
+        return;
+    }
+    if (!info || !scan->sink.isEmpty()) {
+        return;
+    }
+    QString speaker, earpiece;
+    for (uint32_t p = 0; p < info->n_ports; ++p) {
+        const pa_sink_port_info *port = info->ports[p];
+        if (!port || !port->name) {
+            continue;
+        }
+        const QString name = QString::fromUtf8(port->name).toLower();
+        const QString desc = QString::fromUtf8(port->description ? port->description : "").toLower();
+        if (speaker.isEmpty() && (name.contains("speaker") || desc.contains("speaker"))) {
+            speaker = QString::fromUtf8(port->name);
+        }
+        if (earpiece.isEmpty()
+                && (name.contains("earpiece") || name.contains("handset") || name.contains("receiver")
+                    || desc.contains("earpiece") || desc.contains("handset") || desc.contains("receiver"))) {
+            earpiece = QString::fromUtf8(port->name);
+        }
+    }
+    if (!speaker.isEmpty() && !earpiece.isEmpty()) {
+        scan->sink = QString::fromUtf8(info->name);
+        scan->speaker = speaker;
+        scan->earpiece = earpiece;
+    }
+}
+
+struct SinkInputScan {
+    pa_threaded_mainloop *ml = nullptr;
+    uint32_t index = PA_INVALID_INDEX;
+    bool found = false;
+    uint8_t channels = 2;
+    int mute = 0;
+};
+
+// Probe fast until the stream shows up, then keep watching at a calmer pace.
+const int PROBE_INTERVAL_MS = 500;
+const int WATCHDOG_INTERVAL_MS = 2000;
+
+void sinkInputInfoCb(pa_context * /*c*/, const pa_sink_input_info *info, int eol, void *userdata)
+{
+    SinkInputScan *scan = static_cast<SinkInputScan *>(userdata);
+    if (eol) {
+        pa_threaded_mainloop_signal(scan->ml, 0);
+        return;
+    }
+    if (!info || !info->proplist) {
+        return;
+    }
+    const char *app = pa_proplist_gets(info->proplist, "application.name");
+    if (app && (std::strstr(app, "WEBRTC") || std::strstr(app, "VoiceEngine"))) {
+        scan->index = info->index;
+        scan->channels = info->volume.channels > 0 ? info->volume.channels : 2;
+        scan->mute = info->mute;
+        scan->found = true;
+    }
+}
+
+struct SinkVolumeScan {
+    pa_threaded_mainloop *ml = nullptr;
+    pa_cvolume volume;
+    bool found = false;
+};
+
+void sinkVolumeInfoCb(pa_context * /*c*/, const pa_sink_info *info, int eol, void *userdata)
+{
+    SinkVolumeScan *scan = static_cast<SinkVolumeScan *>(userdata);
+    if (eol) {
+        pa_threaded_mainloop_signal(scan->ml, 0);
+        return;
+    }
+    if (!info) {
+        return;
+    }
+    scan->volume = info->volume;
+    scan->found = true;
+}
+
+} // namespace
+
+CallAudioRouter::CallAudioRouter(QObject *parent)
+    : QObject(parent)
+    , m_retryTimer(new QTimer(this))
+    , m_mainloop(nullptr)
+    , m_context(nullptr)
+    , m_speakerOn(true)   // hands-free by default (audible for video calls on a desk)
+    , m_sinkVolumeSaved(false)
+    , m_routedIndex(PA_INVALID_INDEX)
+{
+    // The WebRTC stream appears shortly after the call connects — retry until found.
+    // Once it is routed the timer keeps running as a watchdog rather than stopping:
+    // tgcalls tears the playout stream down and builds a new one when the media
+    // configuration changes (switching camera does this), and the replacement is
+    // born muted on the media sink like the first one. Without the watchdog the
+    // remote party goes silent mid-call while the microphone keeps working.
+    m_retryTimer->setInterval(PROBE_INTERVAL_MS);
+    connect(m_retryTimer, &QTimer::timeout, this, [this]() {
+        const quint32 previous = m_routedIndex;
+        if (routeWebrtcToCallSink() && m_routedIndex != previous) {
+            // Set the call sink's port (speaker/earpiece). This also WAKES the
+            // primary_output sink out of SUSPENDED, so the moved stream plays.
+            setSpeakerphone(m_speakerOn);
+            m_retryTimer->setInterval(WATCHDOG_INTERVAL_MS);
+        }
+    });
+}
+
+CallAudioRouter::~CallAudioRouter()
+{
+    stop();
+    if (m_context) {
+        pa_context_unref(static_cast<pa_context *>(m_context));
+        m_context = nullptr;
+    }
+    if (m_mainloop) {
+        pa_threaded_mainloop_stop(static_cast<pa_threaded_mainloop *>(m_mainloop));
+        pa_threaded_mainloop_free(static_cast<pa_threaded_mainloop *>(m_mainloop));
+        m_mainloop = nullptr;
+    }
+}
+
+void CallAudioRouter::start()
+{
+    m_routedIndex = PA_INVALID_INDEX;
+    m_retryTimer->setInterval(PROBE_INTERVAL_MS);
+    ensurePulseConnection();
+    // The stream is rarely there this early, but if it is, finish the job here —
+    // otherwise the watchdog below would see no change and never set the port.
+    if (routeWebrtcToCallSink() && m_routedIndex != PA_INVALID_INDEX) {
+        setSpeakerphone(m_speakerOn);
+        m_retryTimer->setInterval(WATCHDOG_INTERVAL_MS);
+    }
+    m_retryTimer->start();
+}
+
+void CallAudioRouter::ensurePulseConnection()
+{
+    if (m_context) {
+        return;
+    }
+    pa_threaded_mainloop *ml = pa_threaded_mainloop_new();
+    if (!ml) {
+        return;
+    }
+    pa_threaded_mainloop_start(ml);
+    pa_threaded_mainloop_lock(ml);
+    pa_context *ctx = pa_context_new(pa_threaded_mainloop_get_api(ml), "harbour-fernschreiber");
+    pa_context_set_state_callback(ctx, &ctxStateCb, ml);
+    pa_context_connect(ctx, nullptr, PA_CONTEXT_NOFLAGS, nullptr);
+    for (;;) {
+        const pa_context_state_t st = pa_context_get_state(ctx);
+        if (st == PA_CONTEXT_READY) {
+            break;
+        }
+        if (st == PA_CONTEXT_FAILED || st == PA_CONTEXT_TERMINATED) {
+            pa_threaded_mainloop_unlock(ml);
+            pa_context_unref(ctx);
+            pa_threaded_mainloop_stop(ml);
+            pa_threaded_mainloop_free(ml);
+            return;
+        }
+        pa_threaded_mainloop_wait(ml);
+    }
+    SinkScan scan;
+    scan.ml = ml;
+    pa_operation *op = pa_context_get_sink_info_list(ctx, &sinkInfoCb, &scan);
+    if (op) {
+        while (pa_operation_get_state(op) == PA_OPERATION_RUNNING) {
+            pa_threaded_mainloop_wait(ml);
+        }
+        pa_operation_unref(op);
+    }
+    pa_threaded_mainloop_unlock(ml);
+
+    m_mainloop = ml;
+    m_context = ctx;
+    m_sink = scan.sink;
+    m_speakerPort = scan.speaker;
+    m_earpiecePort = scan.earpiece;
+    if (m_sink.isEmpty()) {
+        // Droid (Xperia) fallback names if port enumeration didn't match.
+        m_sink = QStringLiteral("sink.primary_output");
+        m_speakerPort = QStringLiteral("output-speaker");
+        m_earpiecePort = QStringLiteral("output-earpiece");
+    }
+}
+
+void CallAudioRouter::setSpeakerphone(bool on)
+{
+    m_speakerOn = on;
+    ensurePulseConnection();
+    pa_context *ctx = static_cast<pa_context *>(m_context);
+    pa_threaded_mainloop *ml = static_cast<pa_threaded_mainloop *>(m_mainloop);
+    if (!ctx || !ml || m_sink.isEmpty() || pa_context_get_state(ctx) != PA_CONTEXT_READY) {
+        return;
+    }
+    const QString port = on ? m_speakerPort : m_earpiecePort;
+    if (port.isEmpty()) {
+        return;
+    }
+    pa_threaded_mainloop_lock(ml);
+    pa_operation *op = pa_context_set_sink_port_by_name(ctx, m_sink.toUtf8().constData(),
+                                                        port.toUtf8().constData(), nullptr, nullptr);
+    if (op) {
+        pa_operation_unref(op);
+    }
+    pa_threaded_mainloop_unlock(ml);
+    routeWebrtcToCallSink();
+}
+
+bool CallAudioRouter::routeWebrtcToCallSink()
+{
+    ensurePulseConnection();
+    pa_context *ctx = static_cast<pa_context *>(m_context);
+    pa_threaded_mainloop *ml = static_cast<pa_threaded_mainloop *>(m_mainloop);
+    if (!ctx || !ml || pa_context_get_state(ctx) != PA_CONTEXT_READY) {
+        return false;
+    }
+    SinkInputScan scan;
+    scan.ml = ml;
+    pa_threaded_mainloop_lock(ml);
+    pa_operation *op = pa_context_get_sink_input_info_list(ctx, &sinkInputInfoCb, &scan);
+    if (op) {
+        while (pa_operation_get_state(op) == PA_OPERATION_RUNNING) {
+            pa_threaded_mainloop_wait(ml);
+        }
+        pa_operation_unref(op);
+    }
+    if (scan.found) {
+        // Nothing to do while the stream we already routed is still there and audible.
+        // A different index means tgcalls replaced the stream; a muted one means the
+        // policy or a fresh stream muted it again.
+        if (scan.index == m_routedIndex && !scan.mute) {
+            pa_threaded_mainloop_unlock(ml);
+            return true;
+        }
+        // Move the WebRTC playout onto the call sink (primary_output). The sink's
+        // speaker/earpiece ports then route it like a real call; the port set in
+        // setSpeakerphone() also wakes that sink from SUSPENDED so it plays.
+        if (!m_sink.isEmpty()) {
+            pa_operation *om = pa_context_move_sink_input_by_name(
+                ctx, scan.index, m_sink.toUtf8().constData(), nullptr, nullptr);
+            if (om) {
+                pa_operation_unref(om);
+            }
+        }
+        // Unmute (born muted on Halium).
+        pa_operation *o2 = pa_context_set_sink_input_mute(ctx, scan.index, 0, nullptr, nullptr);
+        if (o2) {
+            pa_operation_unref(o2);
+        }
+        // flat-volumes couples the stream volume to the sink: save the sink's clean
+        // volume once before boosting, so stop() can restore it after the call.
+        if (!m_sinkVolumeSaved && !m_sink.isEmpty()) {
+            SinkVolumeScan vscan;
+            vscan.ml = ml;
+            pa_operation *ov = pa_context_get_sink_info_by_name(
+                ctx, m_sink.toUtf8().constData(), &sinkVolumeInfoCb, &vscan);
+            if (ov) {
+                while (pa_operation_get_state(ov) == PA_OPERATION_RUNNING) {
+                    pa_threaded_mainloop_wait(ml);
+                }
+                pa_operation_unref(ov);
+            }
+            if (vscan.found) {
+                m_savedSinkVolume = vscan.volume;
+                m_sinkVolumeSaved = true;
+            }
+        }
+        // Guard against the stream being born at 0% / -inf dB on some SFOS builds.
+        pa_cvolume cv;
+        pa_cvolume_set(&cv, scan.channels, (PA_VOLUME_NORM * 9) / 10);
+        pa_operation *o3 = pa_context_set_sink_input_volume(ctx, scan.index, &cv, nullptr, nullptr);
+        if (o3) {
+            pa_operation_unref(o3);
+        }
+        m_routedIndex = scan.index;
+    }
+    pa_threaded_mainloop_unlock(ml);
+    return scan.found;
+}
+
+void CallAudioRouter::stop()
+{
+    m_retryTimer->stop();
+    m_retryTimer->setInterval(PROBE_INTERVAL_MS);
+    m_routedIndex = PA_INVALID_INDEX;
+    if (m_sinkVolumeSaved) {
+        pa_context *ctx = static_cast<pa_context *>(m_context);
+        pa_threaded_mainloop *ml = static_cast<pa_threaded_mainloop *>(m_mainloop);
+        if (ctx && ml && !m_sink.isEmpty() && pa_context_get_state(ctx) == PA_CONTEXT_READY) {
+            pa_threaded_mainloop_lock(ml);
+            pa_operation *o = pa_context_set_sink_volume_by_name(
+                ctx, m_sink.toUtf8().constData(), &m_savedSinkVolume, nullptr, nullptr);
+            if (o) {
+                pa_operation_unref(o);
+            }
+            pa_threaded_mainloop_unlock(ml);
+        }
+        m_sinkVolumeSaved = false;
+    }
+}

--- a/src/voip/callaudiorouter.h
+++ b/src/voip/callaudiorouter.h
@@ -1,0 +1,57 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    Routes the WebRTC call audio on Sailfish/Halium. The incoming-audio stream
+    ("WEBRTC VoiceEngine") is created MUTED on the media sink (deep_buffer); it
+    must be moved to the call sink (primary_output, which carries the speaker /
+    earpiece ports) and unmuted, or the remote party is inaudible. Uses an
+    in-process libpulse connection because Sailjail blocks an external pactl but
+    allows the app's own PulseAudio access. Adapted from RooTelegram (GPL-3.0,
+    github.com/RootGPT-YouTube/RooTelegram-SailfishOS).
+*/
+#ifndef FERNSCHREIBER_CALLAUDIOROUTER_H
+#define FERNSCHREIBER_CALLAUDIOROUTER_H
+
+#include <QObject>
+#include <QString>
+#include <pulse/volume.h>
+
+class QTimer;
+
+class CallAudioRouter : public QObject
+{
+    Q_OBJECT
+public:
+    explicit CallAudioRouter(QObject *parent = nullptr);
+    ~CallAudioRouter() override;
+
+    // Begin routing: retries until the WebRTC playout stream appears, then moves
+    // it to the call sink and unmutes it. Keeps watching for the rest of the call —
+    // tgcalls recreates the playout stream on events like a camera switch, and the
+    // replacement is born muted on the media sink again.
+    void start();
+    // Stop routing and restore the system sink volume.
+    void stop();
+    // Toggle speaker vs earpiece (ports of the single call sink).
+    void setSpeakerphone(bool on);
+
+private:
+    void ensurePulseConnection();
+    bool routeWebrtcToCallSink();
+
+    QTimer *m_retryTimer;
+    void *m_mainloop;   // pa_threaded_mainloop*
+    void *m_context;    // pa_context*
+    QString m_sink;
+    QString m_speakerPort;
+    QString m_earpiecePort;
+    bool m_speakerOn;
+    pa_cvolume m_savedSinkVolume;
+    bool m_sinkVolumeSaved;
+    quint32 m_routedIndex;   // sink input we last routed, PA_INVALID_INDEX if none
+};
+
+#endif // FERNSCHREIBER_CALLAUDIOROUTER_H

--- a/src/voip/callcameragrabber.cpp
+++ b/src/voip/callcameragrabber.cpp
@@ -1,0 +1,292 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE). See callcameragrabber.h for the origin
+    (adapted from RooTelegram, GPL-3.0). QtMultimedia camera -> I420 (libyuv).
+*/
+#include "callcameragrabber.h"
+
+#include <QCamera>
+#include <QCameraInfo>
+#include <QCameraViewfinderSettings>
+#include <QCameraExposure>
+#include <QCameraImageProcessing>
+#include <QAbstractVideoSurface>
+#include <QOrientationSensor>
+#include <QOrientationReading>
+#include <QVideoSurfaceFormat>
+#include <QVideoFrame>
+#include <QList>
+#include <QDebug>
+
+#include "libyuv.h"
+#include "api/video/video_frame.h"
+#include "api/video/i420_buffer.h"
+#include "rtc_base/time_utils.h"
+
+namespace fernschreiber {
+
+// Headless viewfinder surface: forwards every frame to the grabber.
+class CallCameraSurface : public QAbstractVideoSurface
+{
+public:
+    explicit CallCameraSurface(CallCameraGrabber *grabber, QObject *parent = nullptr)
+        : QAbstractVideoSurface(parent), m_grabber(grabber) {}
+
+    QList<QVideoFrame::PixelFormat> supportedPixelFormats(
+        QAbstractVideoBuffer::HandleType /*handleType*/) const override
+    {
+        QList<QVideoFrame::PixelFormat> f;
+        f << QVideoFrame::Format_NV21 << QVideoFrame::Format_NV12
+          << QVideoFrame::Format_YUV420P << QVideoFrame::Format_YV12
+          << QVideoFrame::Format_UYVY << QVideoFrame::Format_YUYV
+          << QVideoFrame::Format_RGB32 << QVideoFrame::Format_ARGB32
+          << QVideoFrame::Format_BGR32 << QVideoFrame::Format_BGRA32;
+        return f;
+    }
+
+    bool present(const QVideoFrame &frame) override
+    {
+        if (m_grabber) {
+            m_grabber->handleFrame(frame);
+        }
+        return true;
+    }
+
+private:
+    CallCameraGrabber *m_grabber;
+};
+
+namespace {
+// Plane pointer with bounds-check: multi-planar via bits(plane), else a verified
+// contiguous offset — avoids crashing on the various Halium frame layouts.
+const uint8_t *planePtr(QVideoFrame &f, int plane, int contiguousOffset,
+                        int needBytes, int *outStride, int contiguousStride)
+{
+    if (plane < f.planeCount()) {
+        *outStride = f.bytesPerLine(plane);
+        return reinterpret_cast<const uint8_t *>(f.bits(plane));
+    }
+    const uchar *base = f.bits();
+    if (!base || contiguousOffset + needBytes > f.mappedBytes()) {
+        return nullptr;
+    }
+    *outStride = contiguousStride;
+    return reinterpret_cast<const uint8_t *>(base) + contiguousOffset;
+}
+} // namespace
+
+int CallCameraGrabber::rotationFor(int orientationReading, bool front)
+{
+    // Indexed by QOrientationReading::Orientation: 0=Undefined 1=TopUp 2=TopDown
+    // 3=LeftUp 4=RightUp 5=FaceUp 6=FaceDown. Values are LabCam's per-device photo
+    // rotations +180 (WebRTC rotation is the receiver-side inverse), tested on the
+    // Xperia 10 III (front portrait 270, back portrait 90).
+    static const int frontArr[7] = { 270, 270, 90, 180, 0, 270, 270 };
+    static const int backArr[7]  = {  90,  90, 270, 180, 0,  90,  90 };
+    if (orientationReading < 0 || orientationReading > 6) {
+        orientationReading = 1;
+    }
+    return front ? frontArr[orientationReading] : backArr[orientationReading];
+}
+
+CallCameraGrabber::CallCameraGrabber(QObject *parent)
+    : QObject(parent)
+    , m_surface(nullptr)
+    , m_orientationSensor(nullptr)
+    , m_front(true)
+    , m_width(0)
+    , m_height(0)
+    , m_rotation(270)
+{
+}
+
+CallCameraGrabber::~CallCameraGrabber()
+{
+    stop();
+}
+
+void CallCameraGrabber::setFrameCallback(std::function<void(const webrtc::VideoFrame &)> cb)
+{
+    QMutexLocker lock(&m_cbMutex);
+    m_cb = std::move(cb);
+}
+
+std::pair<int, int> CallCameraGrabber::resolution() const
+{
+    return { m_width.load(), m_height.load() };
+}
+
+void CallCameraGrabber::start(bool front)
+{
+    if (m_camera) {
+        return;
+    }
+    m_front = front;
+    // Follow the live device orientation so the transmitted image stays upright.
+    if (!m_orientationSensor) {
+        m_orientationSensor = new QOrientationSensor(this);
+        connect(m_orientationSensor, &QOrientationSensor::readingChanged, this, [this]() {
+            if (QOrientationReading *r = m_orientationSensor->reading()) {
+                const int reading = int(r->orientation());
+                // Only react to the four in-plane orientations (TopUp/TopDown/
+                // LeftUp/RightUp = 1..4). Ignore Undefined/FaceUp/FaceDown so a
+                // tilted phone during a call keeps the last sensible rotation.
+                if (reading < 1 || reading > 4) {
+                    return;
+                }
+                m_rotation.store(rotationFor(reading, m_front));
+            }
+        });
+    }
+    m_orientationSensor->start();
+    QOrientationReading *initialReading = m_orientationSensor->reading();
+    m_rotation.store(rotationFor(initialReading ? int(initialReading->orientation()) : 1, front));
+    QCameraInfo chosen = QCameraInfo::defaultCamera();
+    const QList<QCameraInfo> cams = QCameraInfo::availableCameras();
+    const QCamera::Position wanted = front ? QCamera::FrontFace : QCamera::BackFace;
+    for (const QCameraInfo &ci : cams) {
+        if (ci.position() == wanted) { chosen = ci; break; }
+    }
+    if (chosen.isNull()) {
+        qWarning() << "CallCameraGrabber: no camera available";
+        return;
+    }
+
+    m_surface = new CallCameraSurface(this, this);
+    m_camera = new QCamera(chosen, this);
+    m_camera->setViewfinder(m_surface);
+    m_camera->setCaptureMode(QCamera::CaptureVideo);
+    // The camera defaults to a huge resolution (1920x1440 on the Xperia front cam),
+    // which the software VP8 encoder can't sustain — it starves the incoming-video
+    // decode and the remote picture vanishes. Pin a sane 720p (supported).
+    {
+        QCameraViewfinderSettings vf;
+        vf.setResolution(1280, 720);
+        m_camera->setViewfinderSettings(vf);
+    }
+    m_camera->start();
+    // Tune the transmitted image: slight exposure lift (front cameras are often
+    // dark) and a touch more saturation for punchier colour.
+    if (m_camera->exposure()) {
+        m_camera->exposure()->setExposureCompensation(0.7);
+    }
+    if (m_camera->imageProcessing()) {
+        // Saturation range is -1.0..+1.0 (0 = default); +0.1 ≈ 10% more colour.
+        m_camera->imageProcessing()->setSaturation(0.1);
+    }
+}
+
+void CallCameraGrabber::stop()
+{
+    if (m_orientationSensor) {
+        m_orientationSensor->stop();
+    }
+    if (m_camera) {
+        m_camera->stop();
+        m_camera->deleteLater();
+        m_camera.clear();
+    }
+    if (m_surface) {
+        m_surface->deleteLater();
+        m_surface = nullptr;
+    }
+}
+
+void CallCameraGrabber::handleFrame(const QVideoFrame &frame)
+{
+    // Only CPU-mappable frames (true on Xperia/Halium).
+    if (frame.handleType() != QAbstractVideoBuffer::NoHandle) {
+        return;
+    }
+    const int w = frame.width();
+    const int h = frame.height();
+    if (w <= 0 || h <= 0) {
+        return;
+    }
+    QVideoFrame f(frame);
+    if (!f.map(QAbstractVideoBuffer::ReadOnly)) {
+        return;
+    }
+
+    auto i420 = webrtc::I420Buffer::Create(w, h);
+    int sy = 0;
+    const uint8_t *y = planePtr(f, 0, 0, f.bytesPerLine() * h, &sy, f.bytesPerLine());
+    int rc = -1;
+    if (y) {
+        const QVideoFrame::PixelFormat fmt = f.pixelFormat();
+        switch (fmt) {
+        case QVideoFrame::Format_NV21:
+        case QVideoFrame::Format_NV12: {
+            int sc = 0;
+            const uint8_t *c = planePtr(f, 1, sy * h, sy * (h / 2), &sc, sy);
+            if (c) {
+                rc = (fmt == QVideoFrame::Format_NV21)
+                     ? libyuv::NV21ToI420(y, sy, c, sc,
+                           i420->MutableDataY(), i420->StrideY(), i420->MutableDataU(), i420->StrideU(),
+                           i420->MutableDataV(), i420->StrideV(), w, h)
+                     : libyuv::NV12ToI420(y, sy, c, sc,
+                           i420->MutableDataY(), i420->StrideY(), i420->MutableDataU(), i420->StrideU(),
+                           i420->MutableDataV(), i420->StrideV(), w, h);
+            }
+            break;
+        }
+        case QVideoFrame::Format_YUV420P:
+        case QVideoFrame::Format_YV12: {
+            int s1 = 0, s2 = 0;
+            const uint8_t *p1 = planePtr(f, 1, sy * h, (sy / 2) * (h / 2), &s1, sy / 2);
+            const uint8_t *p2 = planePtr(f, 2, sy * h + (sy / 2) * (h / 2), (sy / 2) * (h / 2), &s2, sy / 2);
+            if (p1 && p2) {
+                const uint8_t *u = (fmt == QVideoFrame::Format_YV12) ? p2 : p1;
+                const uint8_t *v = (fmt == QVideoFrame::Format_YV12) ? p1 : p2;
+                const int su = (fmt == QVideoFrame::Format_YV12) ? s2 : s1;
+                const int sv = (fmt == QVideoFrame::Format_YV12) ? s1 : s2;
+                rc = libyuv::I420Copy(y, sy, u, su, v, sv,
+                         i420->MutableDataY(), i420->StrideY(), i420->MutableDataU(), i420->StrideU(),
+                         i420->MutableDataV(), i420->StrideV(), w, h);
+            }
+            break;
+        }
+        case QVideoFrame::Format_YUYV:
+            rc = libyuv::YUY2ToI420(y, sy, i420->MutableDataY(), i420->StrideY(),
+                     i420->MutableDataU(), i420->StrideU(), i420->MutableDataV(), i420->StrideV(), w, h);
+            break;
+        case QVideoFrame::Format_UYVY:
+            rc = libyuv::UYVYToI420(y, sy, i420->MutableDataY(), i420->StrideY(),
+                     i420->MutableDataU(), i420->StrideU(), i420->MutableDataV(), i420->StrideV(), w, h);
+            break;
+        case QVideoFrame::Format_RGB32:
+        case QVideoFrame::Format_ARGB32:
+        case QVideoFrame::Format_BGR32:
+        case QVideoFrame::Format_BGRA32:
+            rc = libyuv::ARGBToI420(y, sy, i420->MutableDataY(), i420->StrideY(),
+                     i420->MutableDataU(), i420->StrideU(), i420->MutableDataV(), i420->StrideV(), w, h);
+            break;
+        default:
+            break;
+        }
+    }
+    f.unmap();
+    if (rc != 0) {
+        return;
+    }
+
+    m_width.store(w);
+    m_height.store(h);
+
+    // Camera-dependent rotation (270 front / 90 back); receiver + local PiP
+    // straighten the frame.
+    webrtc::VideoFrame videoFrame = webrtc::VideoFrame::Builder()
+            .set_video_frame_buffer(i420)
+            .set_rotation(static_cast<webrtc::VideoRotation>(m_rotation.load()))
+            .set_timestamp_us(rtc::TimeMicros())
+            .build();
+
+    QMutexLocker lock(&m_cbMutex);
+    if (m_cb) {
+        m_cb(videoFrame);
+    }
+}
+
+} // namespace fernschreiber

--- a/src/voip/callcameragrabber.h
+++ b/src/voip/callcameragrabber.h
@@ -1,0 +1,67 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    Captures camera frames via QtMultimedia (headless viewfinder surface),
+    converts them to WebRTC I420 (libyuv) and hands them to a callback. Adapted
+    from RooTelegram's CallCameraGrabber (GPL-3.0,
+    github.com/RootGPT-YouTube/RooTelegram-SailfishOS) — the device-specific
+    pixel-format/rotation handling is kept as-is because it is hard-won on Halium.
+*/
+#ifndef FERNSCHREIBER_CALLCAMERAGRABBER_H
+#define FERNSCHREIBER_CALLCAMERAGRABBER_H
+
+#include <QObject>
+#include <QPointer>
+#include <QMutex>
+#include <QVideoFrame>
+#include <atomic>
+#include <functional>
+#include <utility>
+
+class QCamera;
+class QAbstractVideoSurface;
+class QOrientationSensor;
+namespace webrtc { class VideoFrame; }
+
+namespace fernschreiber {
+
+class CallCameraGrabber : public QObject
+{
+    Q_OBJECT
+public:
+    explicit CallCameraGrabber(QObject *parent = nullptr);
+    ~CallCameraGrabber() override;
+
+    void setFrameCallback(std::function<void(const webrtc::VideoFrame &)> cb);
+    std::pair<int, int> resolution() const;
+
+    // Called (queued) on the GUI thread — QCamera needs a Qt event loop.
+    Q_INVOKABLE void start(bool front);
+    Q_INVOKABLE void stop();
+
+    // Called on the camera delivery thread by the viewfinder surface.
+    void handleFrame(const QVideoFrame &frame);
+
+private:
+    // WebRTC frame rotation for the current device orientation + camera. Values
+    // derived from LabCam's tested per-device rotation, +180 (WebRTC signals the
+    // receiver how to rotate, which is the inverse of the capture rotation).
+    static int rotationFor(int orientationReading, bool front);
+
+    QPointer<QCamera> m_camera;
+    QAbstractVideoSurface *m_surface;
+    QOrientationSensor *m_orientationSensor;
+    bool m_front;
+    std::atomic<int> m_width;
+    std::atomic<int> m_height;
+    std::atomic<int> m_rotation;
+    QMutex m_cbMutex;
+    std::function<void(const webrtc::VideoFrame &)> m_cb;
+};
+
+} // namespace fernschreiber
+
+#endif // FERNSCHREIBER_CALLCAMERAGRABBER_H

--- a/src/voip/sailfishinterface.cpp
+++ b/src/voip/sailfishinterface.cpp
@@ -1,0 +1,96 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    See sailfishinterface.h. tgcalls platform interface for SFOS: codec factories
+    from tg_owt's builtin (VP8/VP9, H264 not offered), and camera capture via
+    QtMultimedia (VideoCapturer + VideoTrackSource). Video wiring adapted from
+    RooTelegram (GPL-3.0).
+*/
+#include "sailfishinterface.h"
+#include "videotracksource.h"
+#include "videocapturer.h"
+
+// Asymmetric codecs: ENCODE VP8/VP9 only (consistent with supportsEncoding, and
+// avoids the struggling OpenH264 encoder), but DECODE everything the builtin
+// factory offers (incl. H264/H265) so official Telegram clients — which prefer
+// H264 — are received reliably.
+#include "api/video_codecs/video_encoder_factory_template.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp8_adapter.h"
+#include "api/video_codecs/video_encoder_factory_template_libvpx_vp9_adapter.h"
+#include "api/video_codecs/builtin_video_decoder_factory.h"
+#include "tgcalls/VideoCaptureInterface.h"
+#include "pc/video_track_source_proxy.h"
+#include "rtc_base/ref_counted_object.h"
+
+namespace fernschreiber {
+
+namespace {
+// Recover the broadcaster sink from the proxied track source so the capturer
+// can push camera frames into it.
+std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> GetSink(
+        const webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> &nativeSource)
+{
+    auto *proxy = static_cast<webrtc::VideoTrackSourceProxy *>(nativeSource.get());
+    auto *internal = static_cast<VideoTrackSource *>(proxy->internal());
+    return internal->sink();
+}
+} // namespace
+
+std::unique_ptr<webrtc::VideoEncoderFactory> SailfishInterface::makeVideoEncoderFactory(bool /*preferHardwareEncoding*/, bool /*isScreencast*/)
+{
+    return std::make_unique<webrtc::VideoEncoderFactoryTemplate<
+        webrtc::LibvpxVp8EncoderTemplateAdapter,
+        webrtc::LibvpxVp9EncoderTemplateAdapter>>();
+}
+
+std::unique_ptr<webrtc::VideoDecoderFactory> SailfishInterface::makeVideoDecoderFactory()
+{
+    return webrtc::CreateBuiltinVideoDecoderFactory();
+}
+
+bool SailfishInterface::supportsEncoding(const std::string &codecName)
+{
+    // VP8/VP9 via libvpx; native H264 is a stub, so not offered.
+    return codecName == "VP8" || codecName == "VP9";
+}
+
+webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> SailfishInterface::makeVideoSource(rtc::Thread *signalingThread, rtc::Thread *workerThread)
+{
+    const auto trackSource = webrtc::scoped_refptr<VideoTrackSource>(
+        new rtc::RefCountedObject<VideoTrackSource>());
+    return trackSource
+        ? webrtc::VideoTrackSourceProxy::Create(signalingThread, workerThread, trackSource)
+        : nullptr;
+}
+
+void SailfishInterface::adaptVideoSource(webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> /*videoSource*/, int /*width*/, int /*height*/, int /*fps*/)
+{
+}
+
+std::unique_ptr<tgcalls::VideoCapturerInterface> SailfishInterface::makeVideoCapturer(
+    webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> source,
+    std::string deviceId,
+    std::function<void(tgcalls::VideoState)> stateUpdated,
+    std::function<void(tgcalls::PlatformCaptureInfo)> /*captureInfoUpdated*/,
+    std::shared_ptr<tgcalls::PlatformContext> /*platformContext*/,
+    std::pair<int, int> &outResolution)
+{
+    // deviceId "back" -> rear camera; otherwise front (video-call default).
+    const bool front = (deviceId != "back");
+    return std::unique_ptr<tgcalls::VideoCapturerInterface>(
+        new VideoCapturer(source, GetSink(source), front, std::move(stateUpdated), outResolution));
+}
+
+} // namespace fernschreiber
+
+namespace tgcalls {
+
+std::unique_ptr<PlatformInterface> CreatePlatformInterface()
+{
+    return std::make_unique<fernschreiber::SailfishInterface>();
+}
+
+} // namespace tgcalls

--- a/src/voip/sailfishinterface.h
+++ b/src/voip/sailfishinterface.h
@@ -1,0 +1,41 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    tgcalls PlatformInterface implementation for Sailfish OS. This replaces
+    tgcalls' FakeInterface / platform-specific interfaces and is the single
+    entry point tgcalls resolves via CreatePlatformInterface().
+
+    Concept adapted from RooTelegram's SailfishInterface (GPL-3.0,
+    github.com/RootGPT-YouTube/RooTelegram-SailfishOS) and Yottagram, but
+    re-implemented: this initial version is voice-first — video capture/render
+    is added in a later step, so makeVideoSource/makeVideoCapturer return null.
+*/
+#ifndef FERNSCHREIBER_SAILFISHINTERFACE_H
+#define FERNSCHREIBER_SAILFISHINTERFACE_H
+
+#include "platform/PlatformInterface.h"
+
+namespace fernschreiber {
+
+class SailfishInterface : public tgcalls::PlatformInterface {
+public:
+    std::unique_ptr<webrtc::VideoEncoderFactory> makeVideoEncoderFactory(bool preferHardwareEncoding = false, bool isScreencast = false) override;
+    std::unique_ptr<webrtc::VideoDecoderFactory> makeVideoDecoderFactory() override;
+    bool supportsEncoding(const std::string &codecName) override;
+    webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> makeVideoSource(rtc::Thread *signalingThread, rtc::Thread *workerThread) override;
+    void adaptVideoSource(webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> videoSource, int width, int height, int fps) override;
+    std::unique_ptr<tgcalls::VideoCapturerInterface> makeVideoCapturer(
+        webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> source,
+        std::string deviceId,
+        std::function<void(tgcalls::VideoState)> stateUpdated,
+        std::function<void(tgcalls::PlatformCaptureInfo)> captureInfoUpdated,
+        std::shared_ptr<tgcalls::PlatformContext> platformContext,
+        std::pair<int, int> &outResolution) override;
+};
+
+} // namespace fernschreiber
+
+#endif // FERNSCHREIBER_SAILFISHINTERFACE_H

--- a/src/voip/videocapturer.cpp
+++ b/src/voip/videocapturer.cpp
@@ -1,0 +1,99 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE). Adapted from RooTelegram (GPL-3.0).
+*/
+#include "videocapturer.h"
+#include "callcameragrabber.h"
+
+#include "VideoCaptureInterface.h"  // tgcalls::VideoState enum values
+
+#include <QCoreApplication>
+#include <QMetaObject>
+#include <QThread>
+
+namespace fernschreiber {
+
+VideoCapturer::VideoCapturer(
+        webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> source,
+        std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> sink,
+        bool front,
+        std::function<void(tgcalls::VideoState)> stateUpdated,
+        std::pair<int, int> &outResolution)
+    : _source(source)
+    , _sink(sink)
+    , _grabber(new CallCameraGrabber())
+    , _front(front)
+    , _state(tgcalls::VideoState::Inactive)
+    , _stateUpdated(std::move(stateUpdated))
+{
+    // Captured frames (on the camera delivery thread) are pushed into the track
+    // source's broadcaster -> encoder. The sink is thread-safe.
+    auto sinkCopy = _sink;
+    _grabber->setFrameCallback([sinkCopy](const webrtc::VideoFrame &frame) {
+        if (sinkCopy) {
+            sinkCopy->OnFrame(frame);
+        }
+    });
+
+    // The grabber must live on the GUI thread (QCamera needs a Qt event loop):
+    // it is constructed here (a tgcalls media thread) and moved to qApp's thread.
+    if (QCoreApplication::instance()) {
+        _grabber->moveToThread(QCoreApplication::instance()->thread());
+    }
+
+    // Declared initial resolution (camera is 4:3); the real one arrives with frames.
+    outResolution = { 1280, 960 };
+}
+
+VideoCapturer::~VideoCapturer()
+{
+    if (_grabber) {
+        _grabber->setFrameCallback(nullptr);
+        QMetaObject::invokeMethod(_grabber, "stop", Qt::QueuedConnection);
+        _grabber->deleteLater(); // destroyed on its own (GUI) thread
+        _grabber = nullptr;
+    }
+}
+
+void VideoCapturer::setState(tgcalls::VideoState state)
+{
+    _state = state;
+    if (!_grabber) {
+        return;
+    }
+    if (state == tgcalls::VideoState::Active) {
+        QMetaObject::invokeMethod(_grabber, "start", Qt::QueuedConnection,
+                                  Q_ARG(bool, _front));
+    } else {
+        QMetaObject::invokeMethod(_grabber, "stop", Qt::QueuedConnection);
+    }
+    if (_stateUpdated) {
+        _stateUpdated(state);
+    }
+}
+
+void VideoCapturer::setPreferredCaptureAspectRatio(float /*aspectRatio*/)
+{
+}
+
+void VideoCapturer::setUncroppedOutput(
+        std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> sink)
+{
+    // Extra sink attached directly to the source (local preview).
+    if (_uncroppedSink) {
+        _source->RemoveSink(_uncroppedSink.get());
+    }
+    _uncroppedSink = sink;
+    if (_uncroppedSink) {
+        _source->AddOrUpdateSink(_uncroppedSink.get(), rtc::VideoSinkWants());
+    }
+}
+
+int VideoCapturer::getRotation()
+{
+    return 0;
+}
+
+} // namespace fernschreiber

--- a/src/voip/videocapturer.h
+++ b/src/voip/videocapturer.h
@@ -1,0 +1,55 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    tgcalls::VideoCapturerInterface for Sailfish: owns a CallCameraGrabber (a
+    QObject living on the GUI thread, as QCamera requires a Qt event loop) and
+    routes its I420 frames into the track source's broadcaster sink so the encoder
+    sends them. Adapted from RooTelegram (GPL-3.0).
+*/
+#ifndef FERNSCHREIBER_VIDEOCAPTURER_H
+#define FERNSCHREIBER_VIDEOCAPTURER_H
+
+#include "VideoCapturerInterface.h"  // tgcalls
+#include "api/media_stream_interface.h"
+#include "api/video/video_sink_interface.h"
+#include "api/scoped_refptr.h"
+
+#include <memory>
+#include <utility>
+#include <functional>
+
+namespace fernschreiber {
+
+class CallCameraGrabber;
+
+class VideoCapturer : public tgcalls::VideoCapturerInterface {
+public:
+    VideoCapturer(
+        webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> source,
+        std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> sink,
+        bool front,
+        std::function<void(tgcalls::VideoState)> stateUpdated,
+        std::pair<int, int> &outResolution);
+    ~VideoCapturer() override;
+
+    void setState(tgcalls::VideoState state) override;
+    void setPreferredCaptureAspectRatio(float aspectRatio) override;
+    void setUncroppedOutput(std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> sink) override;
+    int getRotation() override;
+
+private:
+    webrtc::scoped_refptr<webrtc::VideoTrackSourceInterface> _source;
+    std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> _sink;
+    std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> _uncroppedSink;
+    CallCameraGrabber *_grabber;
+    bool _front;
+    tgcalls::VideoState _state;
+    std::function<void(tgcalls::VideoState)> _stateUpdated;
+};
+
+} // namespace fernschreiber
+
+#endif // FERNSCHREIBER_VIDEOCAPTURER_H

--- a/src/voip/videorenderer.cpp
+++ b/src/voip/videorenderer.cpp
@@ -1,0 +1,134 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE). Adapted from RooTelegram (GPL-3.0).
+*/
+#include "videorenderer.h"
+
+#include <QAbstractVideoSurface>
+#include <QVideoSurfaceFormat>
+#include <QVideoFrame>
+#include <QPointer>
+#include <QMetaObject>
+#include <QTransform>
+
+#include "api/video/video_frame.h"
+#include "api/video/video_sink_interface.h"
+#include "api/video/i420_buffer.h"
+#include "libyuv.h"
+
+#include <QDebug>
+
+namespace fernschreiber {
+
+// webrtc sink: receives frames (webrtc thread), converts I420->RGB and marshals
+// to the renderer (GUI thread). QPointer so a dead renderer doesn't crash.
+class VideoRenderer::SinkBridge : public rtc::VideoSinkInterface<webrtc::VideoFrame>
+{
+public:
+    explicit SinkBridge(VideoRenderer *renderer) : m_renderer(renderer) {}
+
+    void OnFrame(const webrtc::VideoFrame &frame) override
+    {
+        webrtc::scoped_refptr<webrtc::I420BufferInterface> buf = frame.video_frame_buffer()->ToI420();
+        if (!buf) {
+            return;
+        }
+        const int w = buf->width();
+        const int h = buf->height();
+        if (w <= 0 || h <= 0) {
+            return;
+        }
+        QImage img(w, h, QImage::Format_RGB32);
+        libyuv::I420ToARGB(buf->DataY(), buf->StrideY(),
+                           buf->DataU(), buf->StrideU(),
+                           buf->DataV(), buf->StrideV(),
+                           img.bits(), img.bytesPerLine(), w, h);
+        // Apply rotation: a fixed override (local self-view) if set, else the
+        // rotation signalled by the frame (remote / transmitted orientation).
+        const int rot = (m_renderer && m_renderer->m_fixedRotation >= 0)
+                ? m_renderer->m_fixedRotation
+                : int(frame.rotation());
+        if (rot != 0) {
+            QTransform t;
+            t.rotate(rot);
+            img = img.transformed(t);
+        }
+        if (m_renderer) {
+            QMetaObject::invokeMethod(m_renderer, "presentImage", Qt::QueuedConnection,
+                                      Q_ARG(QImage, img));
+        }
+    }
+
+private:
+    QPointer<VideoRenderer> m_renderer;
+};
+
+VideoRenderer::VideoRenderer(QObject *parent)
+    : QObject(parent)
+    , m_surface(nullptr)
+    , m_hasFrame(false)
+{
+}
+
+VideoRenderer::~VideoRenderer()
+{
+    reset();
+}
+
+void VideoRenderer::setVideoSurface(QAbstractVideoSurface *surface)
+{
+    if (m_surface == surface) {
+        return;
+    }
+    if (m_surface && m_surface->isActive()) {
+        m_surface->stop();
+    }
+    m_surface = surface;
+    m_size = QSize();
+    emit videoSurfaceChanged();
+}
+
+std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> VideoRenderer::sink()
+{
+    if (!m_sink) {
+        m_sink = std::make_shared<SinkBridge>(this);
+    }
+    return m_sink;
+}
+
+void VideoRenderer::reset()
+{
+    m_sink.reset();
+    if (m_surface && m_surface->isActive()) {
+        m_surface->stop();
+    }
+    m_size = QSize();
+    if (m_hasFrame) {
+        m_hasFrame = false;
+        emit hasFrameChanged();
+    }
+}
+
+void VideoRenderer::presentImage(const QImage &image)
+{
+    if (!m_surface || image.isNull()) {
+        return;
+    }
+    if (!m_surface->isActive() || m_size != image.size()) {
+        if (m_surface->isActive()) {
+            m_surface->stop();
+        }
+        QVideoSurfaceFormat fmt(image.size(), QVideoFrame::Format_RGB32);
+        m_surface->start(fmt);
+        m_size = image.size();
+    }
+    m_surface->present(QVideoFrame(image));
+    if (!m_hasFrame) {
+        m_hasFrame = true;
+        emit hasFrameChanged();
+    }
+}
+
+} // namespace fernschreiber

--- a/src/voip/videorenderer.h
+++ b/src/voip/videorenderer.h
@@ -1,0 +1,73 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    Renders one video stream (remote or local preview) into QML. It is a video
+    producer (exposes videoSurface -> QML VideoOutput) and provides a webrtc sink
+    (rtc::VideoSinkInterface) to hook into tgcalls (setIncomingVideoOutput for the
+    remote, VideoCapturer::setUncroppedOutput for the local preview). Incoming
+    I420 frames are converted to RGB and presented on the GUI thread. Adapted from
+    RooTelegram's CallVideoRenderer (GPL-3.0).
+*/
+#ifndef FERNSCHREIBER_VIDEORENDERER_H
+#define FERNSCHREIBER_VIDEORENDERER_H
+
+#include <QObject>
+#include <QImage>
+#include <QSize>
+#include <memory>
+
+class QAbstractVideoSurface;
+
+namespace rtc {
+template <typename T> class VideoSinkInterface;
+}
+namespace webrtc { class VideoFrame; }
+
+namespace fernschreiber {
+
+class VideoRenderer : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QAbstractVideoSurface* videoSurface READ videoSurface WRITE setVideoSurface NOTIFY videoSurfaceChanged)
+    Q_PROPERTY(bool hasFrame READ hasFrame NOTIFY hasFrameChanged)
+
+public:
+    explicit VideoRenderer(QObject *parent = nullptr);
+    ~VideoRenderer() override;
+
+    QAbstractVideoSurface *videoSurface() const { return m_surface; }
+    void setVideoSurface(QAbstractVideoSurface *surface);
+    bool hasFrame() const { return m_hasFrame; }
+
+    // webrtc sink to pass to tgcalls (shared: kept alive by the caller).
+    std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> sink();
+    // Clear state at call end: stop the surface, hasFrame=false.
+    void reset();
+    // Override the per-frame rotation with a fixed value (>=0), or -1 to honour
+    // frame.rotation(). Used for the local self-view: the app UI already rotates
+    // with the device, so applying the frame's device-dependent rotation too would
+    // rotate the preview twice.
+    void setFixedRotation(int degrees) { m_fixedRotation = degrees; }
+
+signals:
+    void videoSurfaceChanged();
+    void hasFrameChanged();
+
+private slots:
+    void presentImage(const QImage &image);
+
+private:
+    class SinkBridge;
+    QAbstractVideoSurface *m_surface;
+    std::shared_ptr<SinkBridge> m_sink;
+    QSize m_size;
+    bool m_hasFrame;
+    int m_fixedRotation = -1;
+};
+
+} // namespace fernschreiber
+
+#endif // FERNSCHREIBER_VIDEORENDERER_H

--- a/src/voip/videotracksource.h
+++ b/src/voip/videotracksource.h
@@ -1,0 +1,45 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    Outgoing-video track source: a webrtc::VideoTrackSource exposing an
+    rtc::VideoBroadcaster. The capturer (QtMultimedia camera) pushes I420 frames
+    into sink()->OnFrame(); the broadcaster forwards them to the encoder. Kept
+    in-tree to avoid tgcalls/tdesktop's desktop V4L2 dependencies. Adapted from
+    RooTelegram (GPL-3.0).
+*/
+#ifndef FERNSCHREIBER_VIDEOTRACKSOURCE_H
+#define FERNSCHREIBER_VIDEOTRACKSOURCE_H
+
+#include "pc/video_track_source.h"
+#include "api/video/video_sink_interface.h"
+#include "media/base/video_broadcaster.h"
+
+#include <memory>
+
+namespace fernschreiber {
+
+class VideoTrackSource : public webrtc::VideoTrackSource {
+public:
+    VideoTrackSource()
+        : webrtc::VideoTrackSource(/*remote=*/false)
+        , _broadcaster(std::make_shared<rtc::VideoBroadcaster>()) {}
+
+    std::shared_ptr<rtc::VideoSinkInterface<webrtc::VideoFrame>> sink() {
+        return _broadcaster;
+    }
+
+protected:
+    rtc::VideoSourceInterface<webrtc::VideoFrame> *source() override {
+        return _broadcaster.get();
+    }
+
+private:
+    std::shared_ptr<rtc::VideoBroadcaster> _broadcaster;
+};
+
+} // namespace fernschreiber
+
+#endif // FERNSCHREIBER_VIDEOTRACKSOURCE_H

--- a/src/voip/voipmanager.cpp
+++ b/src/voip/voipmanager.cpp
@@ -1,0 +1,477 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE). See voipmanager.h for the design and the
+    attribution of the Descriptor logic (RooTelegram / Yottagram, GPL-3.0).
+*/
+#include "voipmanager.h"
+#include "tdlibwrapper.h"
+
+#define DEBUG_MODULE VoipManager
+#include "debuglog.h"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <thread>
+#include <QMetaObject>
+#include <QVariantList>
+
+#include <tgcalls/Instance.h>
+#include <tgcalls/InstanceImpl.h>
+#include <tgcalls/StaticThreads.h>
+#include <tgcalls/VideoCaptureInterface.h>
+#include <tgcalls/v2/InstanceV2Impl.h>
+#include <tgcalls/v2/InstanceV2ReferenceImpl.h>
+
+#include "videorenderer.h"
+#include "callaudiorouter.h"
+
+namespace {
+// Self-registering call implementations; Meta::Create() dispatches by version.
+const auto RegisterLegacy = tgcalls::Register<tgcalls::InstanceImpl>();
+const auto RegisterV2 = tgcalls::Register<tgcalls::InstanceV2Impl>();
+const auto RegisterV2Reference = tgcalls::Register<tgcalls::InstanceV2ReferenceImpl>();
+}
+
+VoipManager::VoipManager(TDLibWrapper *tdLibWrapper, QObject *parent)
+    : QObject(parent)
+    , m_tdLibWrapper(tdLibWrapper)
+    , m_audioRouter(new CallAudioRouter(this))
+    , m_remoteVideoRenderer(new fernschreiber::VideoRenderer(this))
+    , m_localVideoRenderer(new fernschreiber::VideoRenderer(this))
+    // (objectNames set below for diagnostic frame logging)
+    , m_currentCallId(0)
+    , m_peerUserId(0)
+    , m_isOutgoing(false)
+    , m_isVideo(false)
+    , m_frontCamera(true)
+    , m_remoteVideoActive(false)
+{
+    Q_UNUSED(RegisterLegacy)
+    Q_UNUSED(RegisterV2)
+    Q_UNUSED(RegisterV2Reference)
+    m_remoteVideoRenderer->setObjectName(QStringLiteral("remote"));
+    m_localVideoRenderer->setObjectName(QStringLiteral("local"));
+    if (m_tdLibWrapper) {
+        connect(m_tdLibWrapper, &TDLibWrapper::callUpdated, this, &VoipManager::handleCallUpdated);
+        connect(m_tdLibWrapper, &TDLibWrapper::callSignalingDataReceived, this, &VoipManager::handleCallSignalingDataReceived);
+    }
+}
+
+QObject *VoipManager::remoteVideo() const
+{
+    return m_remoteVideoRenderer;
+}
+
+QObject *VoipManager::localVideo() const
+{
+    return m_localVideoRenderer;
+}
+
+VoipManager::~VoipManager()
+{
+    stopInstance();
+}
+
+QVariantMap VoipManager::buildProtocol() const
+{
+    QVariantMap protocol;
+    protocol.insert("@type", "callProtocol");
+    protocol.insert("udp_p2p", true);
+    protocol.insert("udp_reflector", true);
+    protocol.insert("min_layer", 65);
+    protocol.insert("max_layer", 92);
+    std::vector<std::string> versions = tgcalls::Meta::Versions();
+    std::reverse(versions.begin(), versions.end());
+    QVariantList versionList;
+    for (std::vector<std::string>::const_iterator it = versions.cbegin(); it != versions.cend(); ++it) {
+        versionList.append(QString::fromStdString(*it));
+    }
+    protocol.insert("library_versions", versionList);
+    return protocol;
+}
+
+void VoipManager::startCall(qlonglong userId, bool isVideo)
+{
+    if (m_currentCallId != 0 || !m_tdLibWrapper) {
+        return;
+    }
+    LOG("Starting call to user" << userId << "video:" << isVideo);
+    m_tdLibWrapper->createCall(userId, buildProtocol(), isVideo);
+}
+
+void VoipManager::acceptCall()
+{
+    if (m_currentCallId == 0 || !m_tdLibWrapper) {
+        return;
+    }
+    LOG("Accepting call" << m_currentCallId);
+    m_tdLibWrapper->acceptCall(m_currentCallId, buildProtocol());
+}
+
+void VoipManager::hangUp()
+{
+    if (m_currentCallId == 0 || !m_tdLibWrapper) {
+        return;
+    }
+    LOG("Hanging up call" << m_currentCallId);
+    m_tdLibWrapper->discardCall(m_currentCallId, false, 0, m_isVideo, 0);
+}
+
+void VoipManager::setMicrophoneMuted(bool muted)
+{
+    if (m_instance) {
+        m_instance->setMuteMicrophone(muted);
+    }
+}
+
+void VoipManager::switchCamera()
+{
+    if (!m_videoCapture) {
+        return;
+    }
+    m_frontCamera = !m_frontCamera;
+    // deviceId "" -> front, "back" -> rear (see SailfishInterface::makeVideoCapturer).
+    m_videoCapture->switchToDevice(m_frontCamera ? std::string() : std::string("back"), false);
+    emit frontCameraChanged();
+}
+
+void VoipManager::setVideoEnabled(bool enabled)
+{
+    if (!m_videoCapture || !m_instance) {
+        return;
+    }
+    if (enabled) {
+        m_videoCapture->setState(tgcalls::VideoState::Active);
+        m_instance->setVideoCapture(m_videoCapture);
+    } else {
+        // Detach so tgcalls signals the peer that video is off (instead of a frozen
+        // last frame), and stop the camera.
+        m_instance->setVideoCapture(nullptr);
+        m_videoCapture->setState(tgcalls::VideoState::Inactive);
+    }
+}
+
+void VoipManager::setRemoteVideoActive(bool active)
+{
+    if (m_remoteVideoActive != active) {
+        m_remoteVideoActive = active;
+        emit remoteVideoActiveChanged();
+    }
+    // Do NOT reset the remote renderer here: reset() destroys the webrtc sink that
+    // tgcalls holds (as a weak_ptr) via setIncomingVideoOutput. An early
+    // remoteMediaStateUpdated(Inactive) would then permanently kill incoming video.
+    // The sink is only torn down at call end (stopInstance).
+}
+
+void VoipManager::handleCallUpdated(const QVariantMap &call)
+{
+    const qlonglong callId = call.value("id").toLongLong();
+    if (callId <= 0) {
+        return;
+    }
+    m_currentCallId = callId;
+    m_peerUserId = call.value("user_id").toLongLong();
+    m_isOutgoing = call.value("is_outgoing").toBool();
+    m_isVideo = call.value("is_video").toBool();
+    emit callChanged();
+
+    const QVariantMap state = call.value("state").toMap();
+    const QString stateType = state.value("@type").toString();
+    LOG("Call updated" << callId << stateType << "outgoing:" << m_isOutgoing << "video:" << m_isVideo);
+
+    if (m_callState != stateType) {
+        m_callState = stateType;
+        emit callStateChanged();
+    }
+
+    if (stateType == "callStateReady") {
+        ensureInstanceForReadyCall(state);
+    } else if (stateType == "callStateDiscarded" || stateType == "callStateError") {
+        stopInstance();
+        resetCall();
+    }
+}
+
+void VoipManager::handleCallSignalingDataReceived(qlonglong callId, const QByteArray &data)
+{
+    if (callId <= 0 || data.isEmpty()) {
+        return;
+    }
+    if (m_currentCallId != 0 && callId != m_currentCallId) {
+        return;
+    }
+    if (m_instance) {
+        m_instance->receiveSignalingData(toByteVector(data));
+    } else {
+        m_pendingSignalingData.append(data);
+    }
+}
+
+void VoipManager::ensureInstanceForReadyCall(const QVariantMap &callState)
+{
+    if (m_instance || m_currentCallId <= 0) {
+        return;
+    }
+
+    // SAS verification emojis for the UI.
+    const QVariantList emojiList = callState.value("emojis").toList();
+    m_emojis.clear();
+    for (QVariantList::const_iterator it = emojiList.cbegin(); it != emojiList.cend(); ++it) {
+        m_emojis.append(it->toString());
+    }
+    emit emojisChanged();
+
+    const QVariantMap protocol = callState.value("protocol").toMap();
+    const QVariantList remoteVersions = protocol.value("library_versions").toList();
+    std::vector<std::string> localVersions = tgcalls::Meta::Versions();
+    std::reverse(localVersions.begin(), localVersions.end());
+
+    QString selectedVersion;
+    for (QVariantList::const_iterator it = remoteVersions.cbegin(); it != remoteVersions.cend() && selectedVersion.isEmpty(); ++it) {
+        const QString remoteVersion = it->toString();
+        for (std::vector<std::string>::const_iterator lv = localVersions.cbegin(); lv != localVersions.cend(); ++lv) {
+            if (remoteVersion == QString::fromStdString(*lv)) {
+                selectedVersion = remoteVersion;
+                break;
+            }
+        }
+    }
+    if (selectedVersion.isEmpty() && !localVersions.empty()) {
+        selectedVersion = QString::fromStdString(localVersions.front());
+    }
+    if (selectedVersion.isEmpty()) {
+        WARN("No common call protocol version");
+        return;
+    }
+
+    const QByteArray keyData = decodeTdlibBytes(callState.value("encryption_key").toString());
+    if (keyData.isEmpty()) {
+        WARN("Missing call encryption key");
+        return;
+    }
+    std::shared_ptr<std::array<uint8_t, tgcalls::EncryptionKey::kSize>> encryptionKey =
+            std::make_shared<std::array<uint8_t, tgcalls::EncryptionKey::kSize>>();
+    encryptionKey->fill(0);
+    std::memcpy(encryptionKey->data(), keyData.constData(),
+                std::min<int>(keyData.size(), int(tgcalls::EncryptionKey::kSize)));
+
+    tgcalls::Descriptor descriptor{
+        selectedVersion.toStdString(),
+        tgcalls::Config(),
+        tgcalls::PersistentState(),
+        std::vector<tgcalls::Endpoint>(),
+        std::unique_ptr<tgcalls::Proxy>(),
+        std::vector<tgcalls::RtcServer>(),
+        tgcalls::NetworkType::WiFi,
+        tgcalls::EncryptionKey(encryptionKey, m_isOutgoing)
+    };
+    descriptor.config.initializationTimeout = 30.0;
+    descriptor.config.receiveTimeout = 20.0;
+    descriptor.config.enableP2P = callState.contains("allow_p2p") ? callState.value("allow_p2p").toBool() : true;
+    descriptor.config.allowTCP = true;
+    descriptor.config.enableStunMarking = true;
+    descriptor.config.enableAEC = true;
+    descriptor.config.enableNS = true;
+    descriptor.config.enableAGC = true;
+    descriptor.config.maxApiLayer = protocol.value("max_layer").toInt();
+    if (descriptor.config.maxApiLayer <= 0) {
+        descriptor.config.maxApiLayer = tgcalls::Meta::MaxLayer();
+    }
+
+    // Video calls: create the camera capture (SailfishInterface -> QtMultimedia ->
+    // I420 -> VP8/VP9 encoder) and hand it to tgcalls. Audio path is unchanged.
+    if (m_isVideo) {
+        m_frontCamera = true;
+        emit frontCameraChanged();
+        m_remoteVideoActive = false;
+        emit remoteVideoActiveChanged();
+        m_videoCapture = tgcalls::VideoCaptureInterface::Create(
+            tgcalls::StaticThreads::getThreads(), std::string(), false, nullptr);
+        descriptor.videoCapture = m_videoCapture;
+    }
+
+    // Remote media state -> the peer turned their camera on/off (QML shows the
+    // remote video or an avatar/placeholder accordingly).
+    descriptor.remoteMediaStateUpdated = [this](tgcalls::AudioState /*audioState*/, tgcalls::VideoState videoState) {
+        const bool activeVideo = (videoState == tgcalls::VideoState::Active);
+        QMetaObject::invokeMethod(this, "setRemoteVideoActive", Qt::QueuedConnection,
+                                  Q_ARG(bool, activeVideo));
+    };
+
+    // Relay/WebRTC servers live under "servers" (NOT "connections"). V2 instances
+    // ignore descriptor.endpoints, so a reflector must ALSO be exposed as an
+    // RtcServer with login="reflector" and password=hex(peerTag) (parsed back as
+    // hex by ReflectorPort) — without it, mobile-NAT calls fail to connect.
+    const QVariantList servers = callState.value("servers").toList();
+    for (QVariantList::const_iterator it = servers.cbegin(); it != servers.cend(); ++it) {
+        const QVariantMap server = it->toMap();
+        const QVariantMap type = server.value("type").toMap();
+        const QString typeName = type.value("@type").toString();
+        const QString host = !server.value("ip_address").toString().isEmpty()
+                ? server.value("ip_address").toString()
+                : server.value("ipv6_address").toString();
+        const uint16_t port = static_cast<uint16_t>(server.value("port").toUInt());
+
+        if (typeName == "callServerTypeTelegramReflector") {
+            const QByteArray peerTag = decodeTdlibBytes(type.value("peer_tag").toString());
+            const bool isTcp = type.value("is_tcp").toBool();
+
+            tgcalls::Endpoint endpoint;
+            endpoint.endpointId = server.value("id").toLongLong();
+            endpoint.host = tgcalls::EndpointHost{
+                server.value("ip_address").toString().toStdString(),
+                server.value("ipv6_address").toString().toStdString()
+            };
+            endpoint.port = port;
+            endpoint.type = isTcp ? tgcalls::EndpointType::TcpRelay : tgcalls::EndpointType::UdpRelay;
+            if (peerTag.size() >= 16) {
+                std::memcpy(endpoint.peerTag, peerTag.constData(), 16);
+            }
+            descriptor.endpoints.push_back(endpoint);
+
+            if (!isTcp && peerTag.size() >= 16) {
+                tgcalls::RtcServer reflector;
+                reflector.id = static_cast<uint8_t>((descriptor.rtcServers.size() % 250) + 1);
+                reflector.host = host.toStdString();
+                reflector.port = port;
+                reflector.login = "reflector";
+                reflector.password = QString::fromLatin1(peerTag.toHex()).toStdString();
+                reflector.isTurn = true;
+                reflector.isTcp = false;
+                descriptor.rtcServers.push_back(reflector);
+            }
+        } else if (typeName == "callServerTypeWebrtc") {
+            const int serverId = server.value("id").toInt();
+            const uint8_t rtcId = static_cast<uint8_t>(serverId < 0 ? 0 : (serverId > 255 ? 255 : serverId));
+            if (type.value("supports_stun").toBool()) {
+                tgcalls::RtcServer stun;
+                stun.id = rtcId;
+                stun.host = host.toStdString();
+                stun.port = port;
+                stun.isTurn = false;
+                descriptor.rtcServers.push_back(stun);
+            }
+            if (type.value("supports_turn").toBool()) {
+                tgcalls::RtcServer turn;
+                turn.id = rtcId;
+                turn.host = host.toStdString();
+                turn.port = port;
+                turn.login = type.value("username").toString().toStdString();
+                turn.password = type.value("password").toString().toStdString();
+                turn.isTurn = true;
+                turn.isTcp = type.value("is_tcp").toBool();
+                descriptor.rtcServers.push_back(turn);
+            }
+        }
+    }
+
+    descriptor.stateUpdated = [](tgcalls::State state) {
+        LOG("tgcalls state" << static_cast<int>(state));  // 0=WaitInit 2=Established 3=Failed
+    };
+    const qlonglong callId = m_currentCallId;
+    TDLibWrapper *wrapper = m_tdLibWrapper;
+    descriptor.signalingDataEmitted = [wrapper, callId](const std::vector<uint8_t> &data) {
+        if (!wrapper || data.empty()) {
+            return;
+        }
+        QByteArray bytes(reinterpret_cast<const char *>(data.data()), static_cast<int>(data.size()));
+        QMetaObject::invokeMethod(wrapper, "sendCallSignalingData", Qt::QueuedConnection,
+                                  Q_ARG(qlonglong, callId), Q_ARG(QByteArray, bytes));
+    };
+
+    LOG("Creating tgcalls instance, version" << selectedVersion
+        << "endpoints" << int(descriptor.endpoints.size())
+        << "rtcServers" << int(descriptor.rtcServers.size()));
+    m_instance = tgcalls::Meta::Create(selectedVersion.toStdString(), std::move(descriptor));
+    if (!m_instance) {
+        WARN("Failed to create tgcalls instance for version" << selectedVersion);
+        return;
+    }
+
+    // Wire the video streams: start the camera + local preview, and route the
+    // incoming (remote) video into the remote renderer.
+    if (m_videoCapture) {
+        m_videoCapture->setState(tgcalls::VideoState::Active);
+        // Local self-view uses the same frame rotation as the remote (world-upright);
+        // the rotating CallOverlay container makes both upright to the viewer.
+        m_videoCapture->setOutput(m_localVideoRenderer->sink());
+    }
+    if (m_isVideo) {
+        m_instance->setIncomingVideoOutput(m_remoteVideoRenderer->sink());
+    }
+
+    // Route the incoming-audio stream to the call sink and unmute it. The SFOS
+    // pulse policy rule (pulse/harbour-fernschreiber.conf) puts the WebRTC streams
+    // in the non-corking "call" group so the remote party is actually audible.
+    m_audioRouter->start();
+
+    while (!m_pendingSignalingData.isEmpty()) {
+        m_instance->receiveSignalingData(toByteVector(m_pendingSignalingData.takeFirst()));
+    }
+}
+
+void VoipManager::stopInstance()
+{
+    m_audioRouter->stop();
+    m_pendingSignalingData.clear();
+    if (m_videoCapture) {
+        m_videoCapture->setState(tgcalls::VideoState::Inactive);
+        m_videoCapture.reset();
+    }
+    m_remoteVideoRenderer->reset();
+    m_localVideoRenderer->reset();
+    if (!m_instance) {
+        return;
+    }
+    // Tear down the tgcalls instance OFF the GUI thread: stop() is async but the
+    // destructor joins the WebRTC threads and stops the PulseAudio device, which
+    // blocks for a moment (or deadlocks) if done on the GUI thread — that froze
+    // the UI on hang-up. Hand ownership to a detached thread so the UI stays live.
+    std::shared_ptr<tgcalls::Instance> instance(m_instance.release());
+    m_instance.reset();
+    std::thread([instance]() mutable {
+        instance->stop([](tgcalls::FinalState) {});
+        instance.reset();
+    }).detach();
+}
+
+void VoipManager::resetCall()
+{
+    m_currentCallId = 0;
+    m_peerUserId = 0;
+    m_isOutgoing = false;
+    m_isVideo = false;
+    m_frontCamera = true;
+    if (m_remoteVideoActive) {
+        m_remoteVideoActive = false;
+        emit remoteVideoActiveChanged();
+    }
+    m_callState.clear();
+    if (!m_emojis.isEmpty()) {
+        m_emojis.clear();
+        emit emojisChanged();
+    }
+    // callStateChanged drives `active` and `callState` bindings — without it the
+    // call overlay (bound to voipManager.active) never hides after hang-up.
+    emit callStateChanged();
+    emit callChanged();
+}
+
+std::vector<uint8_t> VoipManager::toByteVector(const QByteArray &data)
+{
+    return std::vector<uint8_t>(
+        reinterpret_cast<const uint8_t *>(data.constData()),
+        reinterpret_cast<const uint8_t *>(data.constData()) + data.size());
+}
+
+QByteArray VoipManager::decodeTdlibBytes(const QString &data)
+{
+    if (data.isEmpty()) {
+        return QByteArray();
+    }
+    const QByteArray decoded = QByteArray::fromBase64(data.toLatin1());
+    return decoded.isEmpty() ? data.toUtf8() : decoded;
+}

--- a/src/voip/voipmanager.h
+++ b/src/voip/voipmanager.h
@@ -1,0 +1,122 @@
+/*
+    Copyright (C) 2026 Fernschreiber contributors
+
+    This file is part of Fernschreiber and is licensed under the GNU General
+    Public License v3.0 (see LICENSE).
+
+    VoipManager bridges TDLib's call signalling (via TDLibWrapper) to the tgcalls
+    media engine: it builds the tgcalls Descriptor from callStateReady, owns the
+    call Instance lifecycle, shuttles signalling data both ways, and (for video
+    calls) owns the camera capture + the local/remote video renderers exposed to
+    QML. The call protocol (incl. tgcalls library versions) is built here, keeping
+    TDLibWrapper media-library agnostic.
+
+    The Descriptor construction and the video wiring follow the logic proven in
+    RooTelegram (GPL-3.0, github.com/RootGPT-YouTube/RooTelegram-SailfishOS) and
+    Yottagram, re-implemented here with a narrower responsibility.
+*/
+#ifndef FERNSCHREIBER_VOIPMANAGER_H
+#define FERNSCHREIBER_VOIPMANAGER_H
+
+#include <QObject>
+#include <QVariantMap>
+#include <QByteArray>
+#include <QStringList>
+#include <QList>
+#include <memory>
+#include <vector>
+#include <cstdint>
+
+namespace tgcalls {
+class Instance;
+class VideoCaptureInterface;
+}
+
+class TDLibWrapper;
+class CallAudioRouter;
+
+namespace fernschreiber {
+class VideoRenderer;
+}
+
+class VoipManager : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QString callState READ callState NOTIFY callStateChanged)
+    Q_PROPERTY(bool active READ active NOTIFY callStateChanged)
+    Q_PROPERTY(qlonglong peerUserId READ peerUserId NOTIFY callChanged)
+    Q_PROPERTY(bool isOutgoing READ isOutgoing NOTIFY callChanged)
+    Q_PROPERTY(bool isVideo READ isVideo NOTIFY callChanged)
+    Q_PROPERTY(QStringList emojis READ emojis NOTIFY emojisChanged)
+    // Video: renderers exposed to QML VideoOutput, camera + remote-video state.
+    Q_PROPERTY(QObject* remoteVideo READ remoteVideo CONSTANT)
+    Q_PROPERTY(QObject* localVideo READ localVideo CONSTANT)
+    Q_PROPERTY(bool frontCamera READ frontCamera NOTIFY frontCameraChanged)
+    Q_PROPERTY(bool remoteVideoActive READ remoteVideoActive NOTIFY remoteVideoActiveChanged)
+
+public:
+    explicit VoipManager(TDLibWrapper *tdLibWrapper, QObject *parent = nullptr);
+    ~VoipManager() override;
+
+    QString callState() const { return m_callState; }
+    bool active() const { return m_currentCallId != 0; }
+    qlonglong peerUserId() const { return m_peerUserId; }
+    bool isOutgoing() const { return m_isOutgoing; }
+    bool isVideo() const { return m_isVideo; }
+    QStringList emojis() const { return m_emojis; }
+    QObject *remoteVideo() const;
+    QObject *localVideo() const;
+    bool frontCamera() const { return m_frontCamera; }
+    bool remoteVideoActive() const { return m_remoteVideoActive; }
+
+    // Start an outgoing call to a user. isVideo requests a video call.
+    Q_INVOKABLE void startCall(qlonglong userId, bool isVideo);
+    // Accept the current incoming call.
+    Q_INVOKABLE void acceptCall();
+    // Hang up / decline the current call.
+    Q_INVOKABLE void hangUp();
+    // Mute/unmute the local microphone on the active tgcalls instance.
+    Q_INVOKABLE void setMicrophoneMuted(bool muted);
+    // Video: switch front/back camera; enable/disable outgoing video.
+    Q_INVOKABLE void switchCamera();
+    Q_INVOKABLE void setVideoEnabled(bool enabled);
+
+signals:
+    void callStateChanged();
+    void callChanged();
+    void emojisChanged();
+    void frontCameraChanged();
+    void remoteVideoActiveChanged();
+
+private slots:
+    void handleCallUpdated(const QVariantMap &call);
+    void handleCallSignalingDataReceived(qlonglong callId, const QByteArray &data);
+    void setRemoteVideoActive(bool active);
+
+private:
+    // callProtocol object (incl. tgcalls library_versions) for createCall/acceptCall.
+    QVariantMap buildProtocol() const;
+    void ensureInstanceForReadyCall(const QVariantMap &callState);
+    void stopInstance();
+    void resetCall();
+    static std::vector<uint8_t> toByteVector(const QByteArray &data);
+    static QByteArray decodeTdlibBytes(const QString &data);
+
+    TDLibWrapper *m_tdLibWrapper;
+    CallAudioRouter *m_audioRouter;
+    std::unique_ptr<tgcalls::Instance> m_instance;
+    std::shared_ptr<tgcalls::VideoCaptureInterface> m_videoCapture;
+    fernschreiber::VideoRenderer *m_remoteVideoRenderer;
+    fernschreiber::VideoRenderer *m_localVideoRenderer;
+    qlonglong m_currentCallId;
+    qlonglong m_peerUserId;
+    bool m_isOutgoing;
+    bool m_isVideo;
+    bool m_frontCamera;
+    bool m_remoteVideoActive;
+    QString m_callState;
+    QStringList m_emojis;
+    QList<QByteArray> m_pendingSignalingData;
+};
+
+#endif // FERNSCHREIBER_VOIPMANAGER_H

--- a/translations/harbour-fernschreiber-de.ts
+++ b/translations/harbour-fernschreiber-de.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation>Unbekannt</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation>Rufe an…</translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation>Eingehender Videoanruf</translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation>Eingehender Anruf</translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation>Schlüssel werden ausgetauscht…</translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation>Laufender Anruf</translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation>Wird beendet…</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation>Annehmen</translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation>Stummschaltung aufheben</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation>Stummschalten</translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation>Kamera wechseln</translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation>Ablehnen</translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation>Auflegen</translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -490,6 +545,14 @@
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
         <translation>Sind Sie sicher, dass Sie diesen Chat löschen wollen? Diese Handlung kann nicht zurückgenommen werden und Sie werden die gesamte Unterhaltung für immer verlieren!</translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation>Videoanruf</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Anruf</translation>
     </message>
 </context>
 <context>
@@ -905,6 +968,14 @@
     <message>
         <source>sent a video note</source>
         <translation>hat eine Videonachricht geschickt</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation>Videoanruf</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Anruf</translation>
     </message>
 </context>
 <context>
@@ -2356,6 +2427,14 @@
     <message>
         <source>sent a game</source>
         <translation>hat ein Spiel gesendet</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation>Videoanruf</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Anruf</translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-en.ts
+++ b/translations/harbour-fernschreiber-en.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation>Unknown</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation>Calling…</translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation>Incoming video call</translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation>Incoming call</translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation>Exchanging encryption keys…</translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation>Ongoing call</translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation>Hanging up…</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation>Accept</translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation>Unmute</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation>Mute</translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation>Flip</translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation>Decline</translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation>Hang up</translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -490,6 +545,14 @@
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation>Video Call</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Call</translation>
     </message>
 </context>
 <context>
@@ -907,6 +970,14 @@ messages</numerusform>
     <message>
         <source>sent a video note</source>
         <translation>sent a video note</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation>Video call</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Call</translation>
     </message>
 </context>
 <context>
@@ -2358,6 +2429,14 @@ messages</numerusform>
     <message>
         <source>sent a game</source>
         <translation>sent a game</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation>Video call</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Call</translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-es.ts
+++ b/translations/harbour-fernschreiber-es.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Desconocido</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -489,6 +544,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -905,6 +968,14 @@
     <message>
         <source>sent a video note</source>
         <translation>envió nota de video</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2356,6 +2427,14 @@
     <message>
         <source>sent a game</source>
         <translation>envió un juego</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-fi.ts
+++ b/translations/harbour-fernschreiber-fi.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Tuntematon</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -489,6 +544,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -906,6 +969,14 @@
     <message>
         <source>sent a video note</source>
         <translation>lähetti videoviestin</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2357,6 +2428,14 @@
     <message>
         <source>sent a game</source>
         <translation>lähetti pelin</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-fr.ts
+++ b/translations/harbour-fernschreiber-fr.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Inconnu</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -489,6 +544,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -905,6 +968,14 @@
     <message>
         <source>sent a video note</source>
         <translation>a envoyé une note vidéo</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2356,6 +2427,14 @@
     <message>
         <source>sent a game</source>
         <translation>a envoyé un jeu</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-hu.ts
+++ b/translations/harbour-fernschreiber-hu.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Ismeretlen</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -481,6 +536,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -893,6 +956,14 @@
     <message>
         <source>sent a video note</source>
         <translation>Videó üzenetet küldött</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2331,6 +2402,14 @@
     <message>
         <source>sent a game</source>
         <translation>játékot küldött</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-it.ts
+++ b/translations/harbour-fernschreiber-it.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Sconosciuto</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -489,6 +544,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -905,6 +968,14 @@
     <message>
         <source>sent a video note</source>
         <translation>ha inviato un videomessaggio</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2356,6 +2427,14 @@
     <message>
         <source>sent a game</source>
         <translation>ha inviato un gioco</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-pl.ts
+++ b/translations/harbour-fernschreiber-pl.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Nieznany</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message>
         <source>Unknown</source>
@@ -499,6 +554,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -919,6 +982,14 @@
     <message>
         <source>sent a video note</source>
         <translation>wysłał notatkę video</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2386,6 +2457,14 @@
     <message>
         <source>sent a game</source>
         <translation>wysłał grę</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-ru.ts
+++ b/translations/harbour-fernschreiber-ru.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -499,6 +554,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -922,6 +985,14 @@
     <message>
         <source>sent a video note</source>
         <translation>отправил(а) видео заметку</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2389,6 +2460,14 @@
     <message>
         <source>sent a game</source>
         <translation>отправил(а) игру</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-sk.ts
+++ b/translations/harbour-fernschreiber-sk.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Neznámy</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message>
         <source>Unknown</source>
@@ -499,6 +554,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -919,6 +982,14 @@
     <message>
         <source>sent a video note</source>
         <translation>poslal video-poznámku</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2386,6 +2457,14 @@
     <message>
         <source>sent a game</source>
         <translation>poslal hru</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-sv.ts
+++ b/translations/harbour-fernschreiber-sv.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">Okänd</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -489,6 +544,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -905,6 +968,14 @@
     <message>
         <source>sent a video note</source>
         <translation>skickade ett videomeddelande</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2356,6 +2427,14 @@
     <message>
         <source>sent a game</source>
         <translation>skickade ett spel</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber-zh_CN.ts
+++ b/translations/harbour-fernschreiber-zh_CN.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation type="unfinished">未知</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -479,6 +534,14 @@
     </message>
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -892,6 +955,14 @@
     <message>
         <source>sent a video note</source>
         <translation>发送视频消息</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2327,6 +2398,14 @@
     <message>
         <source>sent a game</source>
         <translation>发送游戏</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/harbour-fernschreiber.ts
+++ b/translations/harbour-fernschreiber.ts
@@ -96,6 +96,61 @@
     </message>
 </context>
 <context>
+    <name>CallOverlay</name>
+    <message>
+        <source>Unknown</source>
+        <translation>Unknown</translation>
+    </message>
+    <message>
+        <source>Calling…</source>
+        <translation>Calling…</translation>
+    </message>
+    <message>
+        <source>Incoming video call</source>
+        <translation>Incoming video call</translation>
+    </message>
+    <message>
+        <source>Incoming call</source>
+        <translation>Incoming call</translation>
+    </message>
+    <message>
+        <source>Exchanging encryption keys…</source>
+        <translation>Exchanging encryption keys…</translation>
+    </message>
+    <message>
+        <source>Ongoing call</source>
+        <translation>Ongoing call</translation>
+    </message>
+    <message>
+        <source>Hanging up…</source>
+        <translation>Hanging up…</translation>
+    </message>
+    <message>
+        <source>Accept</source>
+        <translation>Accept</translation>
+    </message>
+    <message>
+        <source>Unmute</source>
+        <translation>Unmute</translation>
+    </message>
+    <message>
+        <source>Mute</source>
+        <translation>Mute</translation>
+    </message>
+    <message>
+        <source>Flip</source>
+        <translation>Flip</translation>
+    </message>
+    <message>
+        <source>Decline</source>
+        <translation>Decline</translation>
+    </message>
+    <message>
+        <source>Hang up</source>
+        <translation>Hang up</translation>
+    </message>
+</context>
+<context>
     <name>ChatInformationPageContent</name>
     <message numerus="yes">
         <source>%1 subscribers</source>
@@ -490,6 +545,14 @@
     <message>
         <source>Are you sure that you want to delete this chat? This action can&apos;t be undone and you lose the entire conversation forever!</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video Call</source>
+        <translation>Video Call</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Call</translation>
     </message>
 </context>
 <context>
@@ -905,6 +968,14 @@
     <message>
         <source>sent a video note</source>
         <translation type="unfinished">sent a video note</translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation>Video call</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Call</translation>
     </message>
 </context>
 <context>
@@ -2356,6 +2427,14 @@
     <message>
         <source>sent a game</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Video call</source>
+        <translation>Video call</translation>
+    </message>
+    <message>
+        <source>Call</source>
+        <translation>Call</translation>
     </message>
 </context>
 </TS>

--- a/voip.pri
+++ b/voip.pri
@@ -1,0 +1,102 @@
+# Build glue for Telegram voice/video calls (tgcalls + tg_owt) on Sailfish OS.
+#
+# Opt-in: pass CONFIG+=voicecalls to qmake. Only meaningful on aarch64.
+# Requires a prebuilt tg_owt (libtg_owt.a) and the tgcalls sources. By default
+# these are expected in a sibling "tgcalls-build" directory; override with
+# TG_OWT_ROOT / TGCALLS_ROOT on the qmake command line. (A future step should
+# vendor tgcalls + tg_owt as git submodules for a reproducible upstream build.)
+
+isEmpty(TGCALLS_ROOT): TGCALLS_ROOT = $$PWD/../tgcalls-build/tgcalls
+isEmpty(TG_OWT_ROOT):  TG_OWT_ROOT  = $$PWD/../tgcalls-build/tg_owt_yg
+isEmpty(OPENH264_ROOT): OPENH264_ROOT = $$PWD/../tgcalls-build/openh264
+
+TGCALLS_SRC = $$TGCALLS_ROOT/tgcalls
+TG_OWT_SRC  = $$TG_OWT_ROOT/src
+
+# Fail early and say what is missing — otherwise a wrong/absent tg_owt only
+# surfaces as thousands of unresolved webrtc symbols at link time.
+!exists($$TG_OWT_SRC/api/peer_connection_interface.h) {
+    error("CONFIG+=voicecalls: no tg_owt sources at $${TG_OWT_ROOT}. Pass TG_OWT_ROOT=<path> to qmake (see doc/voicecalls.md).")
+}
+!exists($${TG_OWT_ROOT}/out/libtg_owt.a) {
+    error("CONFIG+=voicecalls: tg_owt is not built — $${TG_OWT_ROOT}/out/libtg_owt.a is missing (see doc/voicecalls.md).")
+}
+!exists($$TGCALLS_SRC/InstanceImpl.cpp) {
+    error("CONFIG+=voicecalls: no tgcalls sources at $${TGCALLS_ROOT}. Pass TGCALLS_ROOT=<path> to qmake (see doc/voicecalls.md).")
+}
+!exists($${OPENH264_ROOT}/libopenh264.so.8) {
+    error("CONFIG+=voicecalls: libopenh264.so.8 not found in $${OPENH264_ROOT}. Pass OPENH264_ROOT=<path> to qmake (see doc/voicecalls.md).")
+}
+!equals(TARGET_ARCHITECTURE, aarch64) {
+    warning("CONFIG+=voicecalls: only built and tested on aarch64; $${TARGET_ARCHITECTURE} is untested and needs a tg_owt built for it.")
+}
+
+# Compiling the vendored webrtc/tgcalls tree needs C++20.
+QMAKE_CXXFLAGS += -std=gnu++2a
+
+DEFINES += FERNSCHREIBER_VOIP
+
+# webrtc/tgcalls compile definitions (mirrors tg_owt cmake/libwebrtcbuild.cmake,
+# with X11/PipeWire off and dummy audio backend — the app provides audio I/O).
+DEFINES += \
+    NDEBUG WEBRTC_POSIX WEBRTC_LINUX \
+    WEBRTC_ENABLE_PROTOBUF=0 WEBRTC_APM_DEBUG_DUMP=0 WEBRTC_USE_BUILTIN_ISAC_FLOAT \
+    WEBRTC_INCLUDE_INTERNAL_AUDIO_DEVICE WEBRTC_USE_H264 WEBRTC_LIBRARY_IMPL \
+    WEBRTC_NON_STATIC_TRACE_EVENT_HANDLERS=1 WEBRTC_HAVE_DCSCTP WEBRTC_HAVE_SCTP \
+    NO_MAIN_THREAD_WRAPPING HAVE_WEBRTC_VIDEO RTC_ENABLE_H265 RTC_ENABLE_VP9 \
+    RTC_DISABLE_TRACE_EVENTS WEBRTC_ENABLE_LINUX_PULSE WEBRTC_ENABLE_LINUX_ALSA \
+    TGCALLS_USE_STD_OPTIONAL
+
+INCLUDEPATH += \
+    $$PWD/src \
+    $$TG_OWT_SRC \
+    $$TG_OWT_SRC/third_party/abseil-cpp \
+    $$TG_OWT_SRC/third_party/libyuv/include \
+    $$TGCALLS_ROOT \
+    $$TGCALLS_SRC
+
+# tgcalls sources for 1:1 private calls. We register InstanceImpl (core),
+# InstanceV2Impl and InstanceV2ReferenceImpl (v2/). The legacy/ and v2_4_0_0/
+# variants target an OLDER webrtc API than tg_owt @3215153 and don't compile
+# against it (cricket::Codec API changed); they are unused, so excluded.
+# Group-call sources are excluded too (1:1 only for now).
+SOURCES += \
+    $$files($$TGCALLS_SRC/*.cpp) \
+    $$files($$TGCALLS_SRC/v2/*.cpp) \
+    $$files($$TGCALLS_SRC/utils/*.cpp) \
+    $$files($$TGCALLS_SRC/third-party/*.cpp)
+
+# Our Sailfish tgcalls platform interface, the TDLib<->tgcalls bridge, and the
+# camera capture / video rendering pipeline (QtMultimedia <-> WebRTC).
+SOURCES += \
+    $$PWD/src/voip/sailfishinterface.cpp \
+    $$PWD/src/voip/voipmanager.cpp \
+    $$PWD/src/voip/callcameragrabber.cpp \
+    $$PWD/src/voip/videocapturer.cpp \
+    $$PWD/src/voip/videorenderer.cpp \
+    $$PWD/src/voip/callaudiorouter.cpp
+HEADERS += \
+    $$PWD/src/voip/sailfishinterface.h \
+    $$PWD/src/voip/voipmanager.h \
+    $$PWD/src/voip/callcameragrabber.h \
+    $$PWD/src/voip/videocapturer.h \
+    $$PWD/src/voip/videorenderer.h \
+    $$PWD/src/voip/videotracksource.h \
+    $$PWD/src/voip/callaudiorouter.h
+
+QT += multimedia sensors
+
+# Sailfish does not package openh264 (patent reasons) but tg_owt hard-requires it,
+# so it has to travel with the app — same treatment libtdjson already gets: dropped
+# into the binary's rpath dir and taken out of the RPM's requires via
+# __requires_exclude in rpm/harbour-fernschreiber.yaml. Without that the package
+# would declare a dependency no Sailfish repository can satisfy, i.e. it would not
+# install anywhere.
+openh264lib.files = $${OPENH264_ROOT}/libopenh264.so.8
+openh264lib.path = /usr/share/$${TARGET}/lib
+INSTALLS += openh264lib
+
+LIBS += -L$${TG_OWT_ROOT}/out -ltg_owt \
+    -lssl -lcrypto -lopus -lvpx \
+    -lavcodec -lavformat -lavutil -lswresample -lswscale \
+    -ljpeg -lopenh264 -lpulse -lasound -lpthread -ldl -lm -lz


### PR DESCRIPTION

**In one sentence:** this adds working 1:1 voice *and* video calls, entirely
behind a build flag — without `CONFIG+=voicecalls` the app you ship today is
unchanged.

I know this is a large PR landing unannounced, so the most important part first:
**how you can ignore most of it.** Everything that needs a WebRTC stack lives
behind `voicecalls {}` in the `.pro`, in a separate `voip.pri`, and in
`src/voip/`. A stock `mb2 build` never sees it. I have verified that explicitly
(see the build matrix below) rather than just asserting it.

## Why this needs a second library at all

TDLib does call **signalling only** — `createCall` / `acceptCall` /
`discardCall`, the DH exchange, protocol negotiation, the relay list. It never
produces or consumes a single media frame. The media has to come from
**tgcalls**, which sits on Telegram's WebRTC fork (**tg_owt**). That is why
Fernschreiber never had calls, and it is the only part of this that is genuinely
heavy.

The signalling side is kept deliberately **media-library agnostic**:
`TDLibWrapper` / `TDLibReceiver` gain the call methods and updates and know
nothing about tgcalls. If you ever wanted a different media backend, that layer
would stay as it is.

## Status

| | |
|---|---|
| Scope | 1:1 voice and video. **No group calls / voice chats.** |
| Tested on | Jolla phone, Sailfish OS 5.2.0.17; earlier on an Xperia 10 III, 5.1.0.11 |
| Interop | official Telegram Android and Desktop, both call directions, voice and video |
| Media architecture | aarch64 (see the armv7hl note below) |
| Encryption | the usual Telegram E2EE call path; SAS emojis are shown in the UI |

## Build matrix

Built from this branch's exact commit (`295d796`), on top of the current master,
all four measured today on the same machine:

| build | target | result |
|---|---|---|
| `mb2 build` (stock) | 4.6.0.13 aarch64 | OK, 172 s — 0 call symbols in the binary |
| `mb2 build` (stock) | 4.6.0.13 armv7hl | OK, 159 s — same |
| `mb2 build` (stock) | 5.0.0.62 aarch64 | OK, 177 s — same |
| `mb2 build -- --with voicecalls …` | 4.6.0.13 aarch64 | OK, 342 s — 30437 tgcalls symbols, the policy file and 16 multimedia libraries packaged |

Two SDK generations apart, so nothing here is tied to one release. Checked on the
RPM itself with `rpm -qlp` and `rpm -qRp` rather than on the build's exit code:
none of the bundled libraries appears in the package's requires, so nothing is
demanded that no repository can satisfy. Only one file of this PR reaches a stock
build — `qml/components/CallOverlay.qml`, which travels with the `qml` directory
and is never loaded there, because `voiceCallsAvailable` is false. The two
`libtdjson` entries a stock build does carry are upstream's own.

Enabling the calls in an RPM build is wired up as a plain rpmbuild conditional:

```sh
mb2 -t <target> build -- --with voicecalls \
    --define "tg_owt_root /path/to/tg_owt" \
    --define "tgcalls_root /path/to/tgcalls" \
    --define "openh264_root /path/to/openh264"
```

It is declared as `QMakeOptions` in `rpm/harbour-fernschreiber.yaml`, so it
survives spec regeneration, and the `%files` entry for the policy rule is guarded
by the same conditional.

One packaging detail worth knowing: **the multimedia libraries tg_owt needs
travel inside the package**, next to `libtdjson` in the binary's rpath
directory, with `__requires_exclude` keeping them out of the RPM's
dependencies. That is `libopenh264.so.8` — Sailfish packages openh264 nowhere,
for patent reasons, while tg_owt hard-requires it — and with it `libvpx`,
ffmpeg, opus, ogg, vorbis, theora, webp, openjpeg and speex. Their sonames
differ between Sailfish releases, so a package built against one release would
not resolve on another: 5.2 ships `libvpx.so.12` where the 4.6 SDK links
`.so.9`. Without this the calls RPM would declare dependencies no repository
can satisfy and simply refuse to install.

An earlier version of this PR bundled only openh264 and took `libvpx` from the
system by soname. That is what the commit "Bundle the multimedia stack so one
RPM works across Sailfish releases" replaces.

The point of rows 3 and 4: **the PR does not touch your existing build on either
architecture.** The calls only compile in when explicitly asked for.

## What is in here

| Path | Role |
|---|---|
| `src/tdlibwrapper.*`, `src/tdlibreceiver.*` | TDLib call signalling. Media-library agnostic. |
| `src/voip/voipmanager.*` | tgcalls instance lifetime, descriptor (relays, key, protocol), signalling relay, QML-facing API |
| `src/voip/sailfishinterface.*` | tgcalls `PlatformInterface` for Sailfish: codec factories, capturer creation |
| `src/voip/callcameragrabber.*`, `videocapturer.*`, `videotracksource.h` | camera: QtMultimedia → I420 → WebRTC, incl. device orientation |
| `src/voip/videorenderer.*` | frames → QML `VideoOutput` |
| `src/voip/callaudiorouter.*` | moves the WebRTC playout to the call sink and unmutes it, via in-process libpulse |
| `qml/components/CallOverlay.qml` | in-call UI: peer, state, SAS emojis, remote video + local PiP, mute / hang up / flip |
| `voip.pri`, `doc/voicecalls.md` | build glue and build instructions |
| `pulse/harbour-fernschreiber.conf` | audio policy rule, see below |
| `translations/` | new strings in the source `.ts`, `-en` and `-de` |

`.desktop` gains exactly one Sailjail permission: `Camera`.

## Incoming calls

An incoming call rings through **ngfd's `voip_ringtone` event**, not through
Fernschreiber's notification settings. That distinction matters in practice: a
call is not a message, so someone who has turned message tones off — a perfectly
normal setup — must still hear the phone ring. Going through ngfd also means
volume, vibration and silent mode follow the system profile, exactly like the
built-in dialer. The ringtone is tied to the call state rather than to the
overlay being visible, so it also rings while the app sits in the background.

The app **deliberately does not raise itself to the foreground** for an incoming
call — you open it yourself to answer. Grabbing the screen unasked seemed like
the kind of behaviour that should be your call rather than mine. If you would
rather have it behave like the dialer, say so and I will add it — either raising
the window, or a high-priority notification with answer/decline actions as the
gentler middle ground.

## Two things I would like your decision on

**1. The PulseAudio policy rule.** Without it the remote party is inaudible, so
it is not optional — but it installs to `/etc/pulse/xpolicy.conf.d/`, outside
the app tree, which a Harbour build would flag.

The reason it is needed: tgcalls names its streams `WEBRTC VoiceEngine`, the
Sailfish policy sorts unknown streams into the `othermedia` group, and that group
carries `cork_stream` — so the moment the call's microphone capture starts, the
policy corks the incoming-audio playback stream. The rule moves the WebRTC
streams into the telephony `call` group, which is what a real call uses. The
`INSTALLS` entry is inside the `voicecalls {}` block, so a stock build is
unaffected. If you would rather have a separate configuration sub-package, say
the word and I will restructure it.

**2. tg_owt and tgcalls are not vendored.** They are expected out-of-tree via
`TG_OWT_ROOT` / `TGCALLS_ROOT` (defaulting to a sibling directory). Vendoring
them as submodules would make the build reproducible for everyone, but that is a
packaging decision that felt like yours to make rather than mine to slip in.
`voip.pri` fails fast with an actionable message if the trees are missing or
unbuilt, instead of dumping thousands of unresolved WebRTC symbols at link time.

## About armv7hl

The **app** builds on armv7hl, verified above. The **media stack** was only ever
built for aarch64, so calls on armv7hl are untested: it would need a tg_owt built
for that target. `voip.pri` therefore emits a warning rather than pretending it
works, and the aarch64-specific bits (camera rotation values, resolution pinning)
are commented with the device they were measured on.

## Trying it out

`doc/voicecalls.md` has the exact revisions of the two forks, the cmake
invocation for tg_owt, and the `mb2` line. The forks are the ones RooTelegram and
Yottagram use; they carry the Sailfish/Halium fixes upstream tgcalls lacks. The
audio-routing approach is adapted from RooTelegram (GPL-3.0) and attributed in
the source.

## Not included

- group calls / voice chats (the tgcalls group sources are deliberately excluded)
- call history UI beyond the `messageCall` service-message text, which now
  names how the call ended (taken from #577, see the comment below)
- hardware video encoding — the encoder is software VP8/VP9. Decoding accepts
  everything the builtin factory offers, including H264/H265, so official
  clients (which prefer H264) are received reliably.

Happy to split this up, rework any part of it, or drop pieces you do not want.
